### PR TITLE
Enable opting-out of form submissions

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -121,7 +121,7 @@ export class Session implements NavigatorDelegate {
   // Link click observer delegate
 
   willFollowLinkToLocation(link: Element, location: Location) {
-    return this.linkIsVisitable(link)
+    return this.elementIsNavigable(link)
       && this.locationIsVisitable(location)
       && this.applicationAllowsFollowingLinkToLocation(link, location)
   }
@@ -151,8 +151,8 @@ export class Session implements NavigatorDelegate {
 
   // Form submit observer delegate
 
-  willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement) {
-    return true
+  willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+    return this.elementIsNavigable(form) && this.elementIsNavigable(submitter)
   }
 
   formSubmitted(form: HTMLFormElement, submitter?: HTMLElement) {
@@ -246,8 +246,8 @@ export class Session implements NavigatorDelegate {
     return isAction(action) ? action : "advance"
   }
 
-  linkIsVisitable(link: Element) {
-    const container = link.closest("[data-turbo]")
+  elementIsNavigable(element?: Element) {
+    const container = element?.closest("[data-turbo]")
     if (container) {
       return container.getAttribute("data-turbo") != "false"
     } else {

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -34,8 +34,11 @@ export class FormSubmitObserver {
     if (!event.defaultPrevented) {
       const form = event.target instanceof HTMLFormElement ? event.target : undefined
       const submitter = event.submitter || undefined
+
       if (form) {
-        if (this.delegate.willSubmitForm(form, submitter)) {
+        const method = submitter?.getAttribute("formmethod") || form.method
+
+        if (method != "dialog" && this.delegate.willSubmitForm(form, submitter)) {
           event.preventDefault()
           this.delegate.formSubmitted(form, submitter)
         }

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -5,6 +5,21 @@
     <title>Form</title>
     <script src="/src/tests/fixtures/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
+    <script type="module">
+      import dialogPolyfill from "https://cdn.skypack.dev/dialog-polyfill"
+
+     addEventListener("click", ({ target }) => {
+        if (target instanceof HTMLElement) {
+          const id = target?.getAttribute("data-open")
+          const dialog = document.querySelector(`dialog#${id}`)
+
+          if (dialog && dialog.tagName == "DIALOG") {
+            dialogPolyfill.registerDialog(dialog)
+            dialog.showModal()
+          }
+        }
+      })
+    </script>
   </head>
   <body>
     <div id="standard">
@@ -22,11 +37,41 @@
         <input type="submit">
       </form>
     </div>
+    <hr>
     <div id="submitter">
       <form action="/src/tests/fixtures/one.html" method="get">
         <button type="submit" formmethod="post" formaction="/__turbo/redirect"
             name="path" value="/src/tests/fixtures/two.html">Submit</button>
       </form>
+    </div>
+    <hr>
+    <div id="disabled">
+      <form action="/__turbo/redirect" method="post" data-turbo="false">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="submit">
+      </form>
+
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="submit" data-turbo="false">
+      </form>
+    </div>
+    <hr>
+    <div id="skipped">
+      <dialog id="dialog-method">
+        <form method="dialog">
+          <button type="submit">Close</button>
+        </form>
+      </dialog>
+      <button type="button" data-open="dialog-method">Open</button>
+
+      <dialog id="dialog-formmethod">
+        <form action="/__turbo/redirect" method="post">
+          <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+          <button formmethod="dialog">Close</button>
+        </form>
+      </dialog>
+      <button type="button" data-open="dialog-formmethod">Open</button>
     </div>
     <hr>
     <turbo-frame id="frame">

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -5,21 +5,12 @@
     <title>Form</title>
     <script src="/src/tests/fixtures/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
-    <script type="module">
-      import dialogPolyfill from "https://cdn.skypack.dev/dialog-polyfill"
-
-     addEventListener("click", ({ target }) => {
-        if (target instanceof HTMLElement) {
-          const id = target?.getAttribute("data-open")
-          const dialog = document.querySelector(`dialog#${id}`)
-
-          if (dialog && dialog.tagName == "DIALOG") {
-            dialogPolyfill.registerDialog(dialog)
-            dialog.showModal()
-          }
-        }
-      })
-    </script>
+    <style>
+      dialog {
+        display: block;
+        position: static;
+      }
+    </style>
   </head>
   <body>
     <div id="standard">
@@ -58,20 +49,18 @@
     </div>
     <hr>
     <div id="skipped">
-      <dialog id="dialog-method">
+      <dialog id="dialog-method" open>
         <form method="dialog">
           <button type="submit">Close</button>
         </form>
       </dialog>
-      <button type="button" data-open="dialog-method">Open</button>
 
-      <dialog id="dialog-formmethod">
+      <dialog id="dialog-formmethod" open>
         <form action="/__turbo/redirect" method="post">
           <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
           <button formmethod="dialog">Close</button>
         </form>
       </dialog>
-      <button type="button" data-open="dialog-formmethod">Open</button>
     </div>
     <hr>
     <turbo-frame id="frame">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -103,22 +103,18 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
   async "test form submission skipped within method=dialog"() {
     this.listenForFormSubmissions()
-    await this.clickSelector('button[data-open="dialog-method"]')
     await this.clickSelector('#dialog-method [type="submit"]')
     await this.nextBeat
 
     this.assert.notOk(await this.turboFormSubmitted)
-    this.assert.notOk(await this.hasSelector("#dialog-method[open]"))
   }
 
   async "test form submission skipped with submitter formmethod=dialog"() {
     this.listenForFormSubmissions()
-    await this.clickSelector('button[data-open="dialog-formmethod"]')
     await this.clickSelector('#dialog-formmethod [formmethod="dialog"]')
     await this.nextBeat
 
     this.assert.notOk(await this.turboFormSubmitted)
-    this.assert.notOk(await this.hasSelector("#dialog-formmethod[open]"))
   }
 
   listenForFormSubmissions() {

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -6,10 +6,12 @@ export class FormSubmissionTests extends TurboDriveTestCase {
   }
 
   async "test standard form submission with redirect response"() {
+    this.listenForFormSubmissions()
     const button = await this.querySelector("#standard form input[type=submit]")
     await button.click()
     await this.nextBody
 
+    this.assert.ok(this.turboFormSubmitted)
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
     this.assert.equal(await this.visitAction, "advance")
   }
@@ -79,6 +81,55 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(await this.hasSelector("#frame form.redirect"))
     this.assert.equal(await message.getVisibleText(), "Hello!")
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+  }
+
+  async "test form submission with Turbo disabled on the form"() {
+    this.listenForFormSubmissions()
+    await this.clickSelector('#disabled form[data-turbo="false"] input[type=submit]')
+    await this.nextBody
+    await this.querySelector("#element-id")
+
+    this.assert.notOk(await this.turboFormSubmitted)
+  }
+
+  async "test form submission with Turbo disabled on the submitter"() {
+    this.listenForFormSubmissions()
+    await this.clickSelector('#disabled form:not([data-turbo]) input[data-turbo="false"]')
+    await this.nextBody
+    await this.querySelector("#element-id")
+
+    this.assert.notOk(await this.turboFormSubmitted)
+  }
+
+  async "test form submission skipped within method=dialog"() {
+    this.listenForFormSubmissions()
+    await this.clickSelector('button[data-open="dialog-method"]')
+    await this.clickSelector('#dialog-method [type="submit"]')
+    await this.nextBeat
+
+    this.assert.notOk(await this.turboFormSubmitted)
+    this.assert.notOk(await this.hasSelector("#dialog-method[open]"))
+  }
+
+  async "test form submission skipped with submitter formmethod=dialog"() {
+    this.listenForFormSubmissions()
+    await this.clickSelector('button[data-open="dialog-formmethod"]')
+    await this.clickSelector('#dialog-formmethod [formmethod="dialog"]')
+    await this.nextBeat
+
+    this.assert.notOk(await this.turboFormSubmitted)
+    this.assert.notOk(await this.hasSelector("#dialog-formmethod[open]"))
+  }
+
+  listenForFormSubmissions() {
+    this.remote.execute(() => addEventListener("turbo:submit-start", function eventListener(event) {
+      removeEventListener("turbo:submit-start", eventListener, false)
+      document.head.insertAdjacentHTML("beforeend", `<meta name="turbo-form-submitted">`)
+    }, false))
+  }
+
+  get turboFormSubmitted(): Promise<boolean> {
+    return this.hasSelector("meta[name=turbo-form-submitted]")
   }
 }
 


### PR DESCRIPTION
Similar to [Disabling Turbo Drive on Specific Links][turbo-drive-false],
guard intercepting form subissions with a similar check for
`[data-turbo-drive="false"]` on the submitter, `<form>` element, or an
ancestor.

Similarly, *do not intercept* when the submitter or form element
specifies a method that isn't an HTTP verb (via
[formmethod="dialog"][formmethod] attribute or [method="dialog"][method]
attribute, respectively).

In practice, HTTP submitting `<form>` elements will only ever declare
`method="get"` or `method="post"`. The one [exceptional case is
`method="dialog"`][method-dialog], which we check for as a special case.

Testing
---

Since we're covering behavior for the `<dialog>` element _and_ running
the suite in both Chrome and Firefox, the test suite needs to polyfill
support for the `<dialog>` element.

[turbo-drive-false]: https://turbo.hotwire.dev/handbook/drive#disabling-turbo-drive-on-specific-links
[formmethod]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formmethod
[method]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method
[method-dialog]: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-2
