### PR TITLE
turbo-frame: Navigate frame when intercepting GET

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -35,8 +35,7 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
   }
 
   linkClickIntercepted(element: Element, url: string) {
-    const frame = this.findFrameElement(element)
-    frame.src = url
+    this.navigateFrame(element, url)
   }
 
   shouldInterceptFormSubmission(element: HTMLFormElement) {
@@ -49,7 +48,11 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
     }
 
     this.formSubmission = new FormSubmission(this, element)
-    this.formSubmission.start()
+    if (this.formSubmission.fetchRequest.isIdempotent) {
+      this.navigateFrame(element, this.formSubmission.fetchRequest.url)
+    } else {
+      this.formSubmission.start()
+    }
   }
 
   async visit(url: Locatable) {
@@ -115,6 +118,11 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
 
   formSubmissionFinished(formSubmission: FormSubmission) {
 
+  }
+
+  private navigateFrame(element: Element, url: string) {
+    const frame = this.findFrameElement(element)
+    frame.src = url
   }
 
   private findFrameElement(element: Element) {


### PR DESCRIPTION
When a `<form method="get" data-turbolinks-frame="...">` references a
`<turbo-frame>`, intercept the submission and set `<turbo-frame
src="...">`, which kicks off the `<turbo-frame>` internal submission
lifecycle, including setting `[busy]` and submitting the request with
the `X-Turbolinks-Frame:` header.