### PR TITLE
Read turbo-frame target from Submitter

### DIFF
--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -39,19 +39,19 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
   }
 
   formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement) {
-    const frame = this.findFrameElement(element)
+    const frame = this.findFrameElement(element, submitter)
     if (frame) {
       frame.delegate.formSubmissionIntercepted(element, submitter)
     }
   }
 
   private shouldRedirect(element: Element, submitter?: HTMLElement) {
-    const frame = this.findFrameElement(element)
+    const frame = this.findFrameElement(element, submitter)
     return frame ? frame != element.closest("turbo-frame") : false
   }
 
-  private findFrameElement(element: Element) {
-    const id = element.getAttribute("data-turbo-frame")
+  private findFrameElement(element: Element, submitter?: HTMLElement) {
+    const id = submitter?.getAttribute("data-turbo-frame") || element.getAttribute("data-turbo-frame")
     if (id && id != "_top") {
       const frame = this.element.querySelector(`#${id}:not([disabled])`)
       if (frame instanceof FrameElement) {

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -13,6 +13,8 @@
     </style>
   </head>
   <body>
+    <h1 id="forms">Forms</h1>
+
     <div id="standard">
       <form action="/__turbo/redirect" method="post" class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
@@ -84,6 +86,15 @@
       <form action="/__turbo/redirect" method="post">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
         <input type="submit" formenctype="multipart/form-data">
+      </form>
+
+      <form action="/src/tests/fixtures/frames/form.html" method="get">
+        <button type="submit" data-turbo-frame="frame">GET to Frame</button>
+      </form>
+
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html">
+        <button type="submit" data-turbo-frame="frame">POST to Frame</button>
       </form>
     </div>
     <hr>
@@ -166,8 +177,24 @@
         <input type="hidden" name="content" value="Hello!">
         <input type="submit">
       </form>
+      <form action="/src/tests/fixtures/one.html" method="get">
+        <button type="submit" data-turbo-frame="_top">Break-out of Frame with GET</button>
+      </form>
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <button type="submit" data-turbo-frame="_top">Break-out of Frame with POST</button>
+      </form>
+      <form action="/src/tests/fixtures/frames/hello.html" method="get">
+        <button type="submit" data-turbo-frame="hello">Navigate other Frame with GET</button>
+      </form>
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/hello.html">
+        <button type="submit" data-turbo-frame="hello">Navigate other Frame with POST</button>
+      </form>
       <div id="messages">
       </div>
     </turbo-frame>
+    <hr>
+    <turbo-frame id="hello"></turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/frames/hello.html
+++ b/src/tests/fixtures/frames/hello.html
@@ -2,12 +2,11 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Frame</title>
+    <title>Frames: Hello</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
-    <h1>Form</h1>
     <turbo-frame id="hello">
       <h2>Hello from a frame</h2>
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -168,6 +168,64 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(enctype?.startsWith("multipart/form-data"), "submits a multipart/form-data request")
   }
 
+  async "test submitter GET submission from submitter with data-turbo-frame"() {
+    await this.clickSelector("#submitter form[method=get] [type=submit][data-turbo-frame]")
+    await this.nextBeat
+
+    const message = await this.querySelector("#frame div.message")
+    const title = await this.querySelector("#forms")
+    this.assert.equal(await title.getVisibleText(), "Forms")
+    this.assert.equal(await message.getVisibleText(), "Frame redirected")
+  }
+
+  async "test submitter POST submission from submitter with data-turbo-frame"() {
+    await this.clickSelector("#submitter form[method=post] [type=submit][data-turbo-frame]")
+    await this.nextBeat
+
+    const message = await this.querySelector("#frame div.message")
+    const title = await this.querySelector("#forms")
+    this.assert.equal(await title.getVisibleText(), "Forms")
+    this.assert.equal(await message.getVisibleText(), "Frame redirected")
+  }
+
+  async "test frame form GET submission from submitter with data-turbo-frame=_top"() {
+    await this.clickSelector("#frame form[method=get] [type=submit][data-turbo-frame=_top]")
+    await this.nextBody
+
+    const title = await this.querySelector("h1")
+    this.assert.notOk(await this.hasSelector("#forms"))
+    this.assert.equal(await title.getVisibleText(), "One")
+  }
+
+  async "test frame form POST submission from submitter with data-turbo-frame=_top"() {
+    await this.clickSelector("#frame form[method=post] [type=submit][data-turbo-frame=_top]")
+    await this.nextBody
+
+    const title = await this.querySelector("h1")
+    this.assert.notOk(await this.hasSelector("#forms"))
+    this.assert.equal(await title.getVisibleText(), "One")
+  }
+
+  async "test frame form GET submission from submitter referencing another frame"() {
+    await this.clickSelector("#frame form[method=get] [type=submit][data-turbo-frame=hello]")
+    await this.nextBeat
+
+    const title = await this.querySelector("#forms")
+    const frameTitle = await this.querySelector("#hello h2")
+    this.assert.equal(await frameTitle.getVisibleText(), "Hello from a frame")
+    this.assert.equal(await title.getVisibleText(), "Forms")
+  }
+
+  async "test frame form POST submission from submitter referencing another frame"() {
+    await this.clickSelector("#frame form[method=post] [type=submit][data-turbo-frame=hello]")
+    await this.nextBeat
+
+    const title = await this.querySelector("#forms")
+    const frameTitle = await this.querySelector("#hello h2")
+    this.assert.equal(await frameTitle.getVisibleText(), "Hello from a frame")
+    this.assert.equal(await title.getVisibleText(), "Forms")
+  }
+
   async "test frame form submission with redirect response"() {
     const path = await this.attributeForSelector("#frame form.redirect input[name=path]", "value") || ""
     const url = new URL(path, "http://localhost:9000")
@@ -178,6 +236,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.nextBeat
 
     const message = await this.querySelector("#frame div.message")
+    this.assert.ok(await this.hasSelector("#forms"))
     this.assert.notOk(await this.hasSelector("#frame form.redirect"))
     this.assert.equal(await message.getVisibleText(), "Frame redirected")
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html", "does not redirect _top")
@@ -254,6 +313,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.nextBeat
 
     const message = await this.querySelector("#frame div.message")
+    this.assert.ok(await this.hasSelector("#forms"))
     this.assert.ok(await this.hasSelector("#frame form.redirect"))
     this.assert.equal(await message.getVisibleText(), "Hello!")
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")


### PR DESCRIPTION
If `<turbo-frame>` elements are analogous to `<iframe>` elements, and
`<form data-turbo-frame="...">` attributes are analogous to `<form
target="...">` attributes, this commit adds support for reading the
value of `data-turbo-frame` from a `submitter` (transmitted as part of
the `SubmitEvent.submitter` property) as if it were the `<button
formtarget="...">` attribute.

[mdn-form-target]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/target
[mdn-button-formtarget]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement
