### PR TITLE
Proposal: <turbo-frame> elements progressively enhance target attribute

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -118,7 +118,7 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
   }
 
   private findFrameElement(element: Element) {
-    const id = element.getAttribute("data-turbo-frame")
+    const id = element.getAttribute("target")
     return getFrameElementById(id) ?? this.element
   }
 
@@ -184,7 +184,7 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
   }
 
   private shouldInterceptNavigation(element: Element) {
-    const id = element.getAttribute("data-turbo-frame") || this.element.getAttribute("target")
+    const id = element.getAttribute("target") || this.element.getAttribute("target")
 
     if (!this.enabled || id == "_top") {
       return false

--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -51,7 +51,7 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
   }
 
   private findFrameElement(element: Element) {
-    const id = element.getAttribute("data-turbo-frame")
+    const id = element.getAttribute("target")
     if (id && id != "_top") {
       const frame = this.element.querySelector(`#${id}:not([disabled])`)
       if (frame instanceof FrameElement) {


### PR DESCRIPTION
Since `<turbo-frame>` elements are a spiritual success to `<iframe>`
elements, there is an opportunity to build atop a concept with existing
history and understanding.

Replace the `data-turbo-frame` attribute with the `target` attribute,
progressively enhancing both [`<form target="...">`][form-target] and
[`<a target="...">`][a-target].

Instead of introducing a new `data-turbo-frame` attribute, layer on
additional behavior to a well understood attribute that determines which
`<iframe>` element on the page to submit the `<form>` element or
navigate the `<a>` element within.

In both cases, the `_top` value is a special case value:

> the topmost browsing context (the "highest" context that’s an ancestor
> of the current one). If no ancestors, behaves as _self.

This commit also modifies the check for `[data-turbo-frame="top"]` to
instead be a check for `[target="_top"]`.

To set the `target` attribute on [an `<a>` constructed with
`link_to`][link_to], pass it directly as `target:`.

To set the `target` attribute on [a `<form>` constructed with
`form_with`][form_with], pass it as part of the `html: { target: ... }`
option.

To set the `target` attribute on [a `<form>` constructed with
`button_to`][button_to], pass it as part of the `form: { target: ... }`
option.

[form-target]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-target
[a-target]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target
[link_to]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-link_to
[form_with]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/FormHelper.html#method-i-form_with
[button_to]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-button_to