### PR TITLE
Add charset so response from Rails matches

### DIFF
--- a/src/stream_message.ts
+++ b/src/stream_message.ts
@@ -1,7 +1,7 @@
 import { StreamElement } from "./elements/stream_element"
 
 export class StreamMessage {
-  static readonly contentType = "text/html; turbo-stream"
+  static readonly contentType = "text/html; turbo-stream; charset=utf-8"
 
   readonly templateElement = document.createElement("template")
 


### PR DESCRIPTION
Better solution would be to cut off the charset in the comparison, though. But couldn't immediately make that work. So at least this is a marker that it needs to be done. Without this things are currently broken.