### PR TITLE
Add Functional tests for Submitter attributes

### DIFF
--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -12,6 +12,12 @@
         <input type="submit">
       </form>
     </div>
+    <div id="submitter">
+      <form action="/src/tests/fixtures/one.html" method="get">
+        <button type="submit" formmethod="post" formaction="/__turbo/redirect"
+            name="path" value="/src/tests/fixtures/two.html">Submit</button>
+      </form>
+    </div>
     <hr>
     <turbo-frame id="frame">
       <form action="/__turbo/redirect" method="post" class="redirect">

--- a/src/tests/fixtures/two.html
+++ b/src/tests/fixtures/two.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Two</title>
+    <script src="/src/tests/fixtures/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="test" content="foo">
+  </head>
+  <body>
+    <h1>Two</h1>
+
+    <!--styles ensure that the element will be scrolled to top when navigated to via an anchored link -->
+    <a name="named-anchor"></a>
+    <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
+  </body>
+</html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -14,6 +14,15 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await this.visitAction, "advance")
   }
 
+  async "test submitter form submission reads button attributes"() {
+    const button = await this.querySelector("#submitter form button[type=submit]")
+    await button.click()
+    await this.nextBody
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/two.html")
+    this.assert.equal(await this.visitAction, "advance")
+  }
+
   async "test frame form submission with redirect response"() {
     const button = await this.querySelector("#frame form.redirect input[type=submit]")
     await button.click()


### PR DESCRIPTION
Now that we're capable of testing Form Submissions through
browser-driven environments, add tests to cover the behavior.

Declare a test to exercise a form with a submitter that overrides the
`<form>` element's method _and_ action via `formmethod` and
`formaction`. The submitter `<button>` element also declares its own
`name`/`value` pairing. When combined, the attributes transform what
would be a `GET` navigation straight to `/src/tests/fixtures/one.html`
into a `POST` submission that results in a redirect to a new
`/src/tests/fixtures/two.html` fixture page.