### PR TITLE
Add a `streamElement` property to the `turbo:before-stream-render` event

### DIFF
--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -75,13 +75,7 @@ export class StreamElement extends HTMLElement {
   }
 
   private get beforeRenderEvent() {
-    let properties: CustomEventInit = { bubbles: true, cancelable: true }
-
-    if (this.action !== 'remove') {
-      properties.detail = { newTemplate: this.templateContent }
-    }
-
-    return new CustomEvent("turbo:before-stream-render", properties)
+    return new CustomEvent("turbo:before-stream-render", { bubbles: true, cancelable: true, detail: { streamElement: this }})
   }
 }
 

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -75,7 +75,13 @@ export class StreamElement extends HTMLElement {
   }
 
   private get beforeRenderEvent() {
-    return new CustomEvent("turbo:before-stream-render", { bubbles: true, cancelable: true })
+    let properties: CustomEventInit = { bubbles: true, cancelable: true }
+
+    if (this.action !== 'remove') {
+      properties.detail = { newTemplate: this.templateContent }
+    }
+
+    return new CustomEvent("turbo:before-stream-render", properties)
   }
 }
 


### PR DESCRIPTION
This adds a `streamElement` property to the detail of the `turbo:before-stream-render`. Feel free to do with it as you wish!

Personally I'm using this for intercepting the event to smoothly transition between the frames, e.g.:

```
document.addEventListener('turbo:before-stream-render', function(event) {
  event.preventDefault()

  /* Transition the old frame away ... */

  event.detail.streamElement.performAction()
})
```

Thank you for all your work! 🙏