### PR TITLE
Pausable rendering

### DIFF
--- a/src/core/drive/error_renderer.ts
+++ b/src/core/drive/error_renderer.ts
@@ -6,7 +6,7 @@ export class ErrorRenderer extends Renderer {
   readonly newHead: HTMLHeadElement
   readonly newBody: HTMLBodyElement
 
-  static render(delegate: RenderDelegate, callback: RenderCallback, html: string) {
+  static render(delegate: RenderDelegate, callback: RenderCallback, html: string):Promise<void> {
     return new this(delegate, html).render(callback)
   }
 
@@ -22,8 +22,8 @@ export class ErrorRenderer extends Renderer {
     this.newBody = this.htmlElement.querySelector("body") || document.createElement("body")
   }
 
-  render(callback: RenderCallback) {
-    this.renderView(() => {
+  render(callback: RenderCallback):Promise<void> {
+    return this.renderView(() => {
       this.replaceHeadAndBody()
       this.activateBodyScriptElements()
       callback()

--- a/src/core/drive/renderer.ts
+++ b/src/core/drive/renderer.ts
@@ -1,7 +1,7 @@
 export type RenderCallback = () => void
 
 export interface RenderDelegate {
-  viewWillRender(newBody: HTMLBodyElement): void
+  applicationAllowsImmediateRendering(newBody: HTMLBodyElement, render:() => void): boolean
   viewRendered(newBody: HTMLBodyElement): void
   viewInvalidated(): void
 }
@@ -10,10 +10,15 @@ export abstract class Renderer {
   abstract delegate: RenderDelegate
   abstract newBody: HTMLBodyElement
 
-  renderView(callback: RenderCallback) {
-    this.delegate.viewWillRender(this.newBody)
-    callback()
-    this.delegate.viewRendered(this.newBody)
+  renderView(callback: RenderCallback):Promise<void> {
+    return new Promise<void>((resolve) => {
+      if (this.delegate.applicationAllowsImmediateRendering(this.newBody, resolve)) {
+        resolve()
+      }
+    }).then(() => {
+      callback()
+      this.delegate.viewRendered(this.newBody)
+    })
   }
 
   invalidateView() {

--- a/src/core/drive/snapshot_renderer.ts
+++ b/src/core/drive/snapshot_renderer.ts
@@ -17,7 +17,7 @@ export class SnapshotRenderer extends Renderer {
   readonly newBody: HTMLBodyElement
   readonly isPreview: boolean
 
-  static render(delegate: RenderDelegate, callback: RenderCallback, currentSnapshot: Snapshot, newSnapshot: Snapshot, isPreview: boolean) {
+  static render(delegate: RenderDelegate, callback: RenderCallback, currentSnapshot: Snapshot, newSnapshot: Snapshot, isPreview: boolean):Promise<void> {
     return new this(delegate, currentSnapshot, newSnapshot, isPreview).render(callback)
   }
 
@@ -32,10 +32,10 @@ export class SnapshotRenderer extends Renderer {
     this.isPreview = isPreview
   }
 
-  render(callback: RenderCallback) {
+  render(callback: RenderCallback):Promise<void> {
     if (this.shouldRender()) {
       this.mergeHead()
-      this.renderView(() => {
+      return this.renderView(() => {
         this.replaceBody()
         if (!this.isPreview) {
           this.focusFirstAutofocusableElement()
@@ -44,6 +44,7 @@ export class SnapshotRenderer extends Renderer {
       })
     } else {
       this.invalidateView()
+      return Promise.resolve()
     }
   }
 

--- a/src/core/drive/view.ts
+++ b/src/core/drive/view.ts
@@ -56,12 +56,12 @@ export class View {
     return this.snapshotCache.get(location)
   }
 
-  render({ snapshot, error, isPreview }: Partial<RenderOptions>, callback: RenderCallback) {
+  render({ snapshot, error, isPreview }: Partial<RenderOptions>, callback: RenderCallback):Promise<void> {
     this.markAsPreview(isPreview)
     if (snapshot) {
-      this.renderSnapshot(snapshot, isPreview, callback)
+      return this.renderSnapshot(snapshot, isPreview, callback)
     } else {
-      this.renderError(error, callback)
+      return this.renderError(error, callback)
     }
   }
 
@@ -95,10 +95,10 @@ export class View {
   }
 
   renderSnapshot(snapshot: Snapshot, isPreview: boolean | undefined, callback: RenderCallback) {
-    SnapshotRenderer.render(this.delegate, callback, this.getSnapshot(), snapshot, isPreview || false)
+    return SnapshotRenderer.render(this.delegate, callback, this.getSnapshot(), snapshot, isPreview || false)
   }
 
   renderError(error: string | undefined, callback: RenderCallback) {
-    ErrorRenderer.render(this.delegate, callback, error || "")
+    return ErrorRenderer.render(this.delegate, callback, error || "")
   }
 }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -194,14 +194,14 @@ export class Visit implements FetchRequestDelegate {
   loadResponse() {
     if (this.response) {
       const { statusCode, responseHTML } = this.response
-      this.render(() => {
+      this.render(async () => {
         this.cacheSnapshot()
         if (isSuccessful(statusCode) && responseHTML != null) {
-          this.view.render({ snapshot: Snapshot.fromHTMLString(responseHTML) }, this.performScroll)
+          await this.view.render({ snapshot: Snapshot.fromHTMLString(responseHTML) }, this.performScroll)
           this.adapter.visitRendered(this)
           this.complete()
         } else {
-          this.view.render({ error: responseHTML }, this.performScroll)
+          await this.view.render({ error: responseHTML }, this.performScroll)
           this.adapter.visitRendered(this)
           this.fail()
         }
@@ -233,9 +233,9 @@ export class Visit implements FetchRequestDelegate {
     const snapshot = this.getCachedSnapshot()
     if (snapshot) {
       const isPreview = this.shouldIssueRequest()
-      this.render(() => {
+      this.render(async () => {
         this.cacheSnapshot()
-        this.view.render({ snapshot, isPreview }, this.performScroll)
+        await this.view.render({ snapshot, isPreview }, this.performScroll)
         this.adapter.visitRendered(this)
         if (!isPreview) {
           this.complete()


### PR DESCRIPTION
Just like `turbo:before-visit`, this pull request makes the `turbo:before-render` event cancellable with `preventDefault`. Additionally it adds a `render` method to the event to let the render process resolve (using Promises). This effectively makes rendering pausable; useful for waiting for exit animations, and _could_ open the door to custom renderers e.g. DOM diffing. A basic example might look like:

```js
addEventListener('turbo:before-render', async function (event) {
  event.preventDefault()
  await animateOut()
  event.detail.render()
})
```

Here's a demo of some basic animation possibilities: https://laser-crawling-chanter.glitch.me/ ([View source](https://glitch.com/edit/#!/laser-crawling-chanter?path=turn.js%3A1%3A0))

This pull request also adds the Visit's `action` to the event detail, making it possible to change the behaviour depending on whether it's an `advance` or `restore`.

If there's interest, I could do similar features for streams/frames + add documentation.

There are a few old Turbolinks issues that make reference to something like this:
- turbolinks/turbolinks#68
- turbolinks/turbolinks#70
- turbolinks/turbolinks#153
- turbolinks/turbolinks#184
- turbolinks/turbolinks#293
- turbolinks/turbolinks#408