### PR TITLE
Forms don't have to redirect

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -35,7 +35,7 @@ export class Navigator {
 
   submitForm(form: HTMLFormElement, submitter?: HTMLElement) {
     this.stop()
-    this.formSubmission = new FormSubmission(this, form, submitter, true)
+    this.formSubmission = new FormSubmission(this, form, submitter)
     this.formSubmission.start()
   }
 
@@ -81,8 +81,9 @@ export class Navigator {
 
         const { statusCode } = fetchResponse
         const visitOptions = { response: { statusCode, responseHTML } }
-        console.log("Visiting", fetchResponse.location, visitOptions)
-        this.proposeVisit(fetchResponse.location, visitOptions)
+        const newLocation = fetchResponse.redirected ? fetchResponse.location : this.location
+        console.log("Visiting", newLocation, visitOptions)
+        this.proposeVisit(newLocation, visitOptions)
       }
     }
   }


### PR DESCRIPTION
Hey all. I was playing around with hotwire and it's awesome. I was trying to see if it can replace my current setup. Basically it's using this gem - https://github.com/jorgemanrubia/turbolinks_render, which is really awesome. When you submit a form it just replaces the whole content with new content. Form validations are non issue this way, redirects are working too etc. 

Hotwire almost replaces this gem, however there is a slight problem. Forms must redirect or use turbo frames. I don't really understand why forms must redirect, but I am sure there is a reason for it so I would be interested to hear it. 

Since I don't understand why they have to redirect I think it's unnecessary, so this is a POC of how I think it should work. You submit a form without any frames - it replaces the whole content. Behind the scenes it does simulated turbo visit with either redirected location or the current location.

This way, even when you use something like devise for authentication, you can make the devise form to be ajax based very easily - no need to edit the views & controllers to add turbo frames to it. The same goes for any form really. No need to add turbo frames, by default it just replaces the whole body. However you can still return something like 
```
  <%= turbo_stream.replace "form" do %>
    hi world
  <% end %>
```
and it still works, only the `#form` is replaced. 

---
Please let me know if you would be interested to continue with this - I will then look into tests. If not, feel free to just close it. ✌️ 
