### PR TITLE
Trigger event after stream render

### DIFF
--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -21,6 +21,7 @@ export class StreamElement extends HTMLElement {
       if (this.dispatchEvent(this.beforeRenderEvent)) {
         await nextAnimationFrame()
         this.performAction()
+        this.dispatchEvent(this.afterRenderEvent)
       }
     })()
   }
@@ -76,6 +77,10 @@ export class StreamElement extends HTMLElement {
 
   private get beforeRenderEvent() {
     return new CustomEvent("turbo:before-stream-render", { bubbles: true, cancelable: true })
+  }
+
+  private get afterRenderEvent() {
+    return new CustomEvent("turbo:after-stream-render", { bubbles: true, cancelable: true })
   }
 }
 


### PR DESCRIPTION
I've been using HTMX for a while to achieve something similar to Hotwire but with a lot more workarounds. I love what you've done here, and I think I'm going to be able to replace a lot of custom code with this.

However, I often find myself in a situation where I want to do some cleanup after an element changes. A specific example: I have an index page that shows records grouped by date, with the date on top of the group. As a user deletes the records, I can easily remove them with turbo-streams, but when a group is empty, I have a dangling date I want to remove. I usually solve this in my current stack by listening to an event (HTMX has an 'afterLoad' event that works well for this).

I'm proposing triggering an event after turbo-stream renders, and I'm also curious if you have other ideas on how to deal with this cleanup.