### PR TITLE
add jsdoc to exported components

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,34 +9,88 @@ const session = new Session
 const { navigator } = session
 export { navigator }
 
+/**
+ * Starts the main session.
+ * This initialises any necessary observers such as those to monitor
+ * link interactions.
+ */
 export function start() {
   session.start()
 }
 
+/**
+ * Registers an adapter for the main session.
+ *
+ * @param adapter Adapter to register
+ */
 export function registerAdapter(adapter: Adapter) {
   session.registerAdapter(adapter)
 }
 
+/**
+ * Performs an application visit to the given location.
+ *
+ * @param location Location to visit (a URL or path)
+ * @param options Options to apply
+ * @param options.action Type of history navigation to apply ("restore",
+ * "replace" or "advance")
+ * @param options.historyChanged Specifies whether the browser history has
+ * already been changed for this visit or not
+ * @param options.referrer Specifies the referrer of this visit such that
+ * navigations to the same page will not result in a new history entry.
+ * @param options.snapshotHTML Cached snapshot to render
+ * @param options.response Response of the specified location
+ */
 export function visit(location: Locatable, options?: Partial<VisitOptions>) {
   session.visit(location, options)
 }
 
+/**
+ * Connects a stream source to the main session.
+ *
+ * @param source Stream source to connect
+ */
 export function connectStreamSource(source: StreamSource) {
   session.connectStreamSource(source)
 }
 
+/**
+ * Disconnects a stream source from the main session.
+ *
+ * @param source Stream source to disconnect
+ */
 export function disconnectStreamSource(source: StreamSource) {
   session.disconnectStreamSource(source)
 }
 
+/**
+ * Renders a stream message to the main session by appending it to the
+ * current document.
+ *
+ * @param message Message to render
+ */
 export function renderStreamMessage(message: StreamMessage | string) {
   session.renderStreamMessage(message)
 }
 
+/**
+ * Removes all entries from the Turbo Drive page cache.
+ * Call this when state has changed on the server that may affect cached pages.
+ */
 export function clearCache() {
   session.clearCache()
 }
 
+/**
+ * Sets the delay after which the progress bar will appear during navigation.
+ *
+ * The progress bar appears after 500ms by default.
+ *
+ * Note that this method has no effect when used with the iOS or Android
+ * adapters.
+ *
+ * @param delay Time to delay in milliseconds
+ */
 export function setProgressBarDelay(delay: number) {
   session.setProgressBarDelay(delay)
 }

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -13,6 +13,22 @@ export interface FrameElementDelegate {
   isLoading: boolean
 }
 
+/**
+ * Contains a fragment of HTML which is updated based on navigation within
+ * it (e.g. via links or form submissions).
+ *
+ * @customElement turbo-frame
+ * @example
+ *   <turbo-frame id="messages">
+ *     <a href="/messages/expanded">
+ *       Show all expanded messages in this frame.
+ *     </a>
+ *
+ *     <form action="/messages">
+ *       Show response from this form within this frame.
+ *     </form>
+ *   </turbo-frame>
+ */
 export class FrameElement extends HTMLElement {
   static delegateConstructor: new (element: FrameElement) => FrameElementDelegate
 
@@ -46,10 +62,16 @@ export class FrameElement extends HTMLElement {
     }
   }
 
+  /**
+   * Gets the URL to lazily load source HTML from
+   */
   get src() {
     return this.getAttribute("src")
   }
 
+  /**
+   * Sets the URL to lazily load source HTML from
+   */
   set src(value: string | null) {
     if (value) {
       this.setAttribute("src", value)
@@ -58,10 +80,16 @@ export class FrameElement extends HTMLElement {
     }
   }
 
+  /**
+   * Determines if the element is loading
+   */
   get loading(): FrameLoadingStyle {
     return frameLoadingStyleFromString(this.getAttribute("loading") || "")
   }
 
+  /**
+   * Sets the value of if the element is loading
+   */
   set loading(value: FrameLoadingStyle) {
     if (value) {
       this.setAttribute("loading", value)
@@ -70,10 +98,20 @@ export class FrameElement extends HTMLElement {
     }
   }
 
+  /**
+   * Gets the disabled state of the frame.
+   *
+   * If disabled, no requests will be intercepted by the frame.
+   */
   get disabled() {
     return this.hasAttribute("disabled")
   }
 
+  /**
+   * Sets the disabled state of the frame.
+   *
+   * If disabled, no requests will be intercepted by the frame.
+   */
   set disabled(value: boolean) {
     if (value) {
       this.setAttribute("disabled", "")
@@ -82,10 +120,20 @@ export class FrameElement extends HTMLElement {
     }
   }
 
+  /**
+   * Gets the autoscroll state of the frame.
+   *
+   * If true, the frame will be scrolled into view automatically on update.
+   */
   get autoscroll() {
     return this.hasAttribute("autoscroll")
   }
 
+  /**
+   * Sets the autoscroll state of the frame.
+   *
+   * If true, the frame will be scrolled into view automatically on update.
+   */
   set autoscroll(value: boolean) {
     if (value) {
       this.setAttribute("autoscroll", "")
@@ -94,14 +142,27 @@ export class FrameElement extends HTMLElement {
     }
   }
 
+  /**
+   * Determines if the element has finished loading
+   */
   get complete() {
     return !this.delegate.isLoading
   }
 
+  /**
+   * Gets the active state of the frame.
+   *
+   * If inactive, source changes will not be observed.
+   */
   get isActive() {
     return this.ownerDocument === document && !this.isPreview
   }
 
+  /**
+   * Sets the active state of the frame.
+   *
+   * If inactive, source changes will not be observed.
+   */
   get isPreview() {
     return this.ownerDocument?.documentElement?.hasAttribute("data-turbo-preview")
   }

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -3,6 +3,24 @@ import { nextAnimationFrame } from "../util"
 
 // <turbo-stream action=replace target=id><template>...
 
+/**
+ * Renders updates to the page from a stream of messages.
+ *
+ * Using the `action` attribute, this can be configured one of four ways:
+ *
+ * - `append` - appends the result to the container
+ * - `prepend` - prepends the result to the container
+ * - `replace` - replaces the contents of the container
+ * - `remove` - removes the container
+ *
+ * @customElement turbo-stream
+ * @example
+ *   <turbo-stream action="append" target="dom_id">
+ *     <template>
+ *       Content to append to container designated with the dom_id.
+ *     </template>
+ *   </turbo-stream>
+ */
 export class StreamElement extends HTMLElement {
   async connectedCallback() {
     try {
@@ -29,10 +47,16 @@ export class StreamElement extends HTMLElement {
     try { this.remove() } catch {}
   }
  
+  /**
+   * Removes duplicate children (by ID)
+   */
   removeDuplicateTargetChildren() {
     this.duplicateChildren.forEach(c => c.remove())
   }
   
+  /**
+   * Gets the list of duplicate children (i.e. those with the same ID)
+   */
   get duplicateChildren() {
     const existingChildren = this.targetElements.flatMap(e => [...e.children]).filter(c => !!c.id)
     const newChildrenIds   = [...this.templateContent?.children].filter(c => !!c.id).map(c => c.id)
@@ -40,6 +64,10 @@ export class StreamElement extends HTMLElement {
     return existingChildren.filter(c => newChildrenIds.includes(c.id))
   }
   
+
+  /**
+   * Gets the action function to be performed.
+   */
   get performAction() {
     if (this.action) {
       const actionFunction = StreamActions[this.action]
@@ -51,6 +79,9 @@ export class StreamElement extends HTMLElement {
     this.raise("action attribute is missing")
   }
 
+  /**
+   * Gets the target elements which the template will be rendered to.
+   */
   get targetElements() {
     if (this.target) { 
       return this.targetElementsById
@@ -61,10 +92,16 @@ export class StreamElement extends HTMLElement {
     }
   }
 
+  /**
+   * Gets the contents of the main `<template>`.
+   */
   get templateContent() {
     return this.templateElement.content.cloneNode(true)
   }
 
+  /**
+   * Gets the main `<template>` used for rendering
+   */
   get templateElement() {
     if (this.firstElementChild instanceof HTMLTemplateElement) {
       return this.firstElementChild
@@ -72,14 +109,24 @@ export class StreamElement extends HTMLElement {
     this.raise("first child element must be a <template> element")
   }
 
+  /**
+   * Gets the current action.
+   */
   get action() {
     return this.getAttribute("action")
   }
 
+  /**
+   * Gets the current target (an element ID) to which the result will
+   * be rendered.
+   */
   get target() {
     return this.getAttribute("target")
   }
 
+  /**
+   * Gets the current "targets" selector (a CSS selector)
+   */
   get targets() {
     return this.getAttribute("targets")
   }


### PR DESCRIPTION
again, was trying to get an understanding of this code base so had been documenting my understanding.

here's some jsdoc if its of any use. if its something you'd like to merge just let me know any rewording you want etc.

i know this project doesn't aim to be consumed by JS much, but the element jsdoc especially is useful for tooling which hints at the available properties/attrs of custom elements.

on that note, you may want to change the stream element to have identical 'mirrored' properties to its attributes just like the frame element does. so it can be configured by attributes _and_ by properties (and can then be documented).