### PR TITLE
Restrict Accept: turbo-stream to Form Submissions

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -2,6 +2,7 @@ import { FetchRequest, FetchMethod, fetchMethodFromString, FetchRequestHeaders }
 import { FetchResponse } from "../../http/fetch_response"
 import { expandURL } from "../url"
 import { dispatch } from "../../util"
+import { StreamMessage } from "../streams/stream_message"
 
 export interface FormSubmissionDelegate {
   formSubmissionStarted(formSubmission: FormSubmission): void
@@ -110,6 +111,7 @@ export class FormSubmission {
       if (token) {
         headers["X-CSRF-Token"] = token
       }
+      headers["Accept"] = StreamMessage.contentType
     }
     return headers
   }

--- a/src/core/streams/stream_message.ts
+++ b/src/core/streams/stream_message.ts
@@ -1,6 +1,7 @@
 import { StreamElement } from "../../elements/stream_element"
 
 export class StreamMessage {
+  static readonly contentType = "text/vnd.turbo-stream.html"
   readonly templateElement = document.createElement("template")
 
   static wrap(message: StreamMessage | string) {

--- a/src/observers/stream_observer.ts
+++ b/src/observers/stream_observer.ts
@@ -1,4 +1,3 @@
-import { FetchRequestOptions } from "../http/fetch_request"
 import { FetchResponse } from "../http/fetch_response"
 import { StreamMessage } from "../core/streams/stream_message"
 import { StreamSource } from "../core/types"
@@ -19,7 +18,6 @@ export class StreamObserver {
   start() {
     if (!this.started) {
       this.started = true
-      addEventListener("turbo:before-fetch-request", this.prepareFetchRequest, true)
       addEventListener("turbo:before-fetch-response", this.inspectFetchResponse, false)
     }
   }
@@ -27,7 +25,6 @@ export class StreamObserver {
   stop() {
     if (this.started) {
       this.started = false
-      removeEventListener("turbo:before-fetch-request", this.prepareFetchRequest, true)
       removeEventListener("turbo:before-fetch-response", this.inspectFetchResponse, false)
     }
   }
@@ -49,14 +46,6 @@ export class StreamObserver {
   streamSourceIsConnected(source: StreamSource) {
     return this.sources.has(source)
   }
-
-  prepareFetchRequest = <EventListener>((event: CustomEvent) => {
-    const fetchOptions: FetchRequestOptions = event.detail?.fetchOptions
-    if (fetchOptions) {
-      const { headers } = fetchOptions
-      headers.Accept = [ "text/vnd.turbo-stream.html", headers.Accept ].join(", ")
-    }
-  })
 
   inspectFetchResponse = <EventListener>((event: CustomEvent) => {
     const response = fetchResponseFromEvent(event)
@@ -93,5 +82,5 @@ function fetchResponseFromEvent(event: CustomEvent) {
 
 function fetchResponseIsStream(response: FetchResponse) {
   const contentType = response.contentType ?? ""
-  return /^text\/vnd\.turbo-stream\.html\b/.test(contentType)
+  return contentType.startsWith(StreamMessage.contentType)
 }


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/139

Since Turbo Stream responses over HTTP are in response to user
interactions, and the conventional way to trigger destructive user
interactions is through form submissions, this commit limits the
`StreamObserver` _only_ inject the [Accept][] header containing the
`text/html; turbo-stream` content type during form submissions.

Replace the [`turbo:before-fetch-request` event listener][turbo-event]
with a `turbo:submit-start` event listener.

From a Rails perspective, this enables an interesting pattern. Consider
the following controller:

```ruby
class MessagesController < ApplicationController
  def create
    @message = Message.new(params.require(:message).permit(:body))

    if @message.save
      redirect_to messages_url
    else
      render :new
    end
  end
end
```

By omitting a [respond_to][] block in the controller's action, the
controller offloads the rendering responsibility to the view layer,
enabling the presence or absence of a template to be the deciding factor
on the type of response:

```html+erb
<%# app/views/messages/new.html.erb %>
<%= turbo_frame_tag @message do %>
  <%= render partial: "form", locals: { message: @message } %>
<% end %>

<%# app/views/messages/new.turbo_stream.erb %>
<%= turbo_stream.replace dom_id(@message, :form) do %>
  <%= render partial: "form", locals: { message: @message }, formats: :html %>
<% end %>
```

Prior to this change, `GET` requests initiated by Turbo Drive
navigations were submitting requests with the content type, resulting in
requests to the `messages#new` being handled by the
`messages/new.turbo_stream.erb` template, instead of the fully-formed
HTML responses provided by the `messages/new.html.erb` template.

[Accept]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
[turbo-event]: https://turbo.hotwire.dev/reference/events
[respond_to]: https://edgeapi.rubyonrails.org/classes/ActionController/MimeResponds.html#method-i-respond_to