### PR TITLE
Support Lazy-loading `<turbo-frame>` contents

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -64,6 +64,21 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
     }
   }
 
+  async visit(url: Locatable) {
+    const location = Location.wrap(url)
+    const request = new FetchRequest(this, FetchMethod.get, location)
+
+    return new Promise<void>(resolve => {
+      this.resolveVisitPromise = () => {
+        this.resolveVisitPromise = () => {}
+        resolve()
+      }
+      request.perform()
+    })
+  }
+
+  // Link interceptor delegate
+
   shouldInterceptLinkClick(element: Element, url: string) {
     return this.shouldInterceptNavigation(element)
   }
@@ -71,6 +86,8 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
   linkClickIntercepted(element: Element, url: string) {
     this.navigateFrame(element, url)
   }
+
+  // Form interceptor delegate
 
   shouldInterceptFormSubmission(element: HTMLFormElement) {
     return this.shouldInterceptNavigation(element)
@@ -89,18 +106,7 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
     }
   }
 
-  async visit(url: Locatable) {
-    const location = Location.wrap(url)
-    const request = new FetchRequest(this, FetchMethod.get, location)
-
-    return new Promise<void>(resolve => {
-      this.resolveVisitPromise = () => {
-        this.resolveVisitPromise = () => {}
-        resolve()
-      }
-      request.perform()
-    })
-  }
+  // Fetch request delegate
 
   additionalHeadersForRequest(request: FetchRequest) {
     return { "Turbo-Frame": this.id }
@@ -133,6 +139,8 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
     this.element.removeAttribute("busy")
   }
 
+  // Form submission delegate
+
   formSubmissionStarted(formSubmission: FormSubmission) {
 
   }
@@ -153,6 +161,8 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
   formSubmissionFinished(formSubmission: FormSubmission) {
 
   }
+
+  // Private
 
   private navigateFrame(element: Element, url: string) {
     const frame = this.findFrameElement(element)
@@ -249,6 +259,8 @@ export class FrameController implements FetchRequestDelegate, FormInterceptorDel
   unobserveIntersections() {
     this.intersectionObserver.unobserve(this.element)
   }
+
+  // Computed properties
 
   get firstAutofocusableElement(): HTMLElement | null {
     const element = this.element.querySelector("[autofocus]")

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -84,6 +84,10 @@ export class FrameElement extends HTMLElement {
     }
   }
 
+  get complete() {
+    return !this.controller.isLoading
+  }
+
   get isActive() {
     return this.ownerDocument === document && !this.isPreview
   }

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -25,12 +25,10 @@ export class FrameElement extends HTMLElement {
   }
 
   attributeChangedCallback(name: string) {
-    if (this.loading == FrameLoadingStyle.eager && this.src && this.isActive) {
-      this.loaded = this.controller.visit(this.src)
-    }
-
     if (name == "loading") {
-      this.loading == FrameLoadingStyle.eager ? this.controller.unobserveIntersections() : this.controller.observeIntersections()
+      this.controller.loadingStyleChanged()
+    } else if (name == "src") {
+      this.controller.sourceURLChanged()
     }
   }
 

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -4,6 +4,7 @@ import { FrameController } from "../core/frames/frame_controller"
 export enum FrameLoadingStyle { eager = "eager", lazy = "lazy" }
 
 export class FrameElement extends HTMLElement {
+  loaded: Promise<FetchResponse | void> = Promise.resolve()
   readonly controller: FrameController
 
   static get observedAttributes() {
@@ -59,15 +60,6 @@ export class FrameElement extends HTMLElement {
     } else {
       this.removeAttribute("loading")
     }
-  }
-
-  get loaded(): Promise<FetchResponse | void> {
-    return Promise.resolve(undefined)
-  }
-
-  set loaded(value: Promise<FetchResponse | void>) {
-    Object.defineProperty(this, "loaded", { value, configurable: true })
-    value.then(() => this.removeAttribute("loading"))
   }
 
   get disabled() {

--- a/src/observers/appearance_observer.ts
+++ b/src/observers/appearance_observer.ts
@@ -1,0 +1,37 @@
+export interface AppearanceObserverDelegate {
+  elementAppearedInViewport(element: Element): void
+}
+
+export class AppearanceObserver {
+  readonly delegate: AppearanceObserverDelegate
+  readonly element: Element
+  readonly intersectionObserver: IntersectionObserver
+  started = false
+
+  constructor(delegate: AppearanceObserverDelegate, element: Element) {
+    this.delegate = delegate
+    this.element = element
+    this.intersectionObserver = new IntersectionObserver(this.intersect)
+  }
+
+  start() {
+    if (!this.started) {
+      this.started = true
+      this.intersectionObserver.observe(this.element)
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.started = false
+      this.intersectionObserver.unobserve(this.element)
+    }
+  }
+
+  intersect: IntersectionObserverCallback = entries => {
+    const lastEntry = entries.slice(-1)[0]
+    if (lastEntry?.isIntersecting) {
+      this.delegate.elementAppearedInViewport(this.element)
+    }
+  }
+}

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -64,6 +64,7 @@
     </div>
     <hr>
     <turbo-frame id="frame">
+      <h2>Frame: Form</h2>
       <form action="/__turbo/redirect" method="post" class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html">
         <input type="submit">

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frame</title>
+    <script src="/src/tests/fixtures/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <h1>Frames</h1>
+
+    <turbo-frame id="frame">
+      <h2>Frames: #frame</h2>
+    </turbo-frame>
+
+    <turbo-frame id="hello">
+      <h2>Frames: #hello</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/frames/frame.html
+++ b/src/tests/fixtures/frames/frame.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frame</title>
+    <script src="/src/tests/fixtures/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <turbo-frame id="frame">
+      <h2>Frame: Loaded</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/loading.html
+++ b/src/tests/fixtures/loading.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <script src="/src/tests/fixtures/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <details id="loading-lazy">
+      <summary>Lazy-loaded</summary>
+
+      <turbo-frame id="hello" src="/src/tests/fixtures/frames/hello.html" loading="lazy"></turbo-frame>
+    </details>
+
+    <details id="loading-eager">
+      <summary>Eager-loaded</summary>
+
+      <turbo-frame id="frame" src="/src/tests/fixtures/frames/frame.html" loading="eager"></turbo-frame>
+    </details>
+  </body>
+</html>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -18,7 +18,7 @@
       <p><a id="same-origin-anchored-link-named" href="/src/tests/fixtures/one.html#named-anchor">Same-origin link to named anchor</a></p>
       <p><a id="cross-origin-unannotated-link" href="about:blank">Cross-origin unannotated link</a></p>
       <p><a id="same-origin-targeted-link" href="/src/tests/fixtures/one.html" target="_blank">Same-origin targeted link</a></p>
-      <p><a id="same-origin-download-link" href="/src/tests/fixtures/one.html" download="one.html">Same-origin download link</a></p>
+      <p><a id="same-origin-download-link" href="/intentionally_missing_fake_download.html" download="x.html">Same-origin download link</a></p>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
     </section>

--- a/src/tests/functional/index.ts
+++ b/src/tests/functional/index.ts
@@ -1,5 +1,6 @@
 export * from "./async_script_tests"
 export * from "./form_submission_tests"
+export * from "./loading_tests"
 export * from "./navigation_tests"
 export * from "./rendering_tests"
 export * from "./stream_tests"

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -21,7 +21,6 @@ export class LoadingTests extends TurboDriveTestCase {
 
     const contents = await this.querySelector(frameContents)
     this.assert.equal(await contents.getVisibleText(), "Hello from a frame")
-    this.assert.notOk(await this.hasSelector("#loading-lazy[loading=lazy]"), "removes attributes once loaded")
   }
 
   async "test changing loading attribute from lazy to eager loads frame"() {
@@ -50,7 +49,6 @@ export class LoadingTests extends TurboDriveTestCase {
 
     const contents = await this.querySelector(frameContents)
     this.assert.equal(await contents.getVisibleText(), "Frames: #hello")
-    this.assert.notOk(await this.hasSelector("#loading-lazy[loading=lazy]"), "removes attributes once loaded")
   }
 
   async "test changing src attribute on a frame with loading=eager navigates"() {

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -1,0 +1,67 @@
+import { TurboDriveTestCase } from "../helpers/turbo_drive_test_case"
+
+export class LoadingTests extends TurboDriveTestCase {
+  async setup() {
+    await this.goToLocation("/src/tests/fixtures/loading.html")
+  }
+
+  async "test eager loading within a details element"() {
+    await this.nextBeat
+    this.assert.ok(await this.hasSelector("#loading-eager turbo-frame#frame h2"))
+  }
+
+  async "test lazy loading within a details element"() {
+    await this.nextBeat
+
+    const frameContents = "#loading-lazy turbo-frame h2"
+    this.assert.notOk(await this.hasSelector(frameContents))
+
+    await this.clickSelector("#loading-lazy summary")
+    await this.nextBeat
+
+    const contents = await this.querySelector(frameContents)
+    this.assert.equal(await contents.getVisibleText(), "Hello from a frame")
+    this.assert.notOk(await this.hasSelector("#loading-lazy[loading=lazy]"), "removes attributes once loaded")
+  }
+
+  async "test changing loading attribute from lazy to eager loads frame"() {
+    const frameContents = "#loading-lazy turbo-frame h2"
+    await this.nextBeat
+
+    this.assert.notOk(await this.hasSelector(frameContents))
+
+    await this.remote.execute(() => document.querySelector("#loading-lazy turbo-frame")?.setAttribute("loading", "eager"))
+    await this.nextBeat
+
+    const contents = await this.querySelector(frameContents)
+    await this.clickSelector("#loading-lazy summary")
+    this.assert.equal(await contents.getVisibleText(), "Hello from a frame")
+  }
+
+  async "test changing src attribute on a frame with loading=lazy defers navigation"() {
+    const frameContents = "#loading-lazy turbo-frame h2"
+    await this.nextBeat
+
+    await this.remote.execute(() => document.querySelector("#loading-lazy turbo-frame")?.setAttribute("src", "/src/tests/fixtures/frames.html"))
+    this.assert.notOk(await this.hasSelector(frameContents))
+
+    await this.clickSelector("#loading-lazy summary")
+    await this.nextBeat
+
+    const contents = await this.querySelector(frameContents)
+    this.assert.equal(await contents.getVisibleText(), "Frames: #hello")
+    this.assert.notOk(await this.hasSelector("#loading-lazy[loading=lazy]"), "removes attributes once loaded")
+  }
+
+  async "test changing src attribute on a frame with loading=eager navigates"() {
+    const frameContents = "#loading-eager turbo-frame h2"
+    await this.remote.execute(() => document.querySelector("#loading-eager turbo-frame")?.setAttribute("src", "/src/tests/fixtures/frames.html"))
+    await this.nextBeat
+    await this.clickSelector("#loading-eager summary")
+
+    const contents = await this.querySelector(frameContents)
+    this.assert.equal(await contents.getVisibleText(), "Frames: #frame")
+  }
+}
+
+LoadingTests.registerSuite()


### PR DESCRIPTION
Add support for declaring `[loading="lazy"]` (in the style of
[`iframe[loading="lazy"]`][iframe-loading] and
[`img[loading="lazy"]`][img-loading]). When both `src` and
`loading="lazy"` are declared on the frame, navigation will be deferred
until the element is visible in the document.

As an example, consider a `<details>`/`<summary>` pairing:

```html
<details>
  <summary>Lazy load</summary>

  <turbo-frame id="frame" src="/lazy-loaded.html" loading="lazy"></turbo-frame>
</details>
```

On initial load, the frame's contents will be empty. When the
`<summary>` element is clicked and the contents are visible, the
`<turbo-frame>` element will navigate to the URL specified in the `src`
element.

By default, `<turbo-frame>` elements that omit the `loading` attribute
will be treated as if they've declared `loading="eager"`.

The attribute (and corresponding `TurboFrameElement.loading` property
accessors) provide a means of controlling the loading strategy
declaratively without additional application-side JavaScript, while
still providing a means for application-side JavaScript to intervene if
necessary.

If visibility-based intersection is insufficient for an application's
need, there are various ways to control the loading strategy.

For example, consider an optimization to pre-load the frame when the
`<details>` element's disclosure `<summary>` button is hovered or
focused. First, consider HTML annotated with Stimulus attributes:

```html
<details data-controller="lazy-loader">
  <summary data-action="hover->lazy-loader#prefetch focus->lazy-loader#prefetch">Lazy load</summary>

  <turbo-frame id="frame" src="/lazy-loaded.html" loading="lazy" data-lazy-loader-target="frame"></turbo-frame>
</details>
```

Next, consider the corresponding `lazy-loader` Stimulus controller:

```js
import { Controller } from "stimulus"

export default class extends Controller {
  static targets = [ "frame" ]

  prefetch() {
    this.frameTarget.loading = "eager"
  }
}
```

[img-loading]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Img#attr-loading
[iframe-loading]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/iframe#attr-loading

