### PR TITLE
Fix default refresh behaviour

### DIFF
--- a/src/core/drive/history.ts
+++ b/src/core/drive/history.ts
@@ -27,8 +27,6 @@ export class History {
 
   start() {
     if (!this.started) {
-      this.previousScrollRestoration = history.scrollRestoration
-      history.scrollRestoration = "manual"
       addEventListener("popstate", this.onPopState, false)
       addEventListener("load", this.onPageLoad, false)
       this.started = true
@@ -89,6 +87,8 @@ export class History {
 
   onPageLoad = async (event: Event) => {
     await nextMicrotask()
+    this.previousScrollRestoration = history.scrollRestoration
+    history.scrollRestoration = "manual"
     this.pageLoaded = true
   }
 

--- a/src/core/session_storage.ts
+++ b/src/core/session_storage.ts
@@ -1,0 +1,13 @@
+export class SessionStorage {
+  set(key:string, value:any) {
+    sessionStorage.setItem(key, JSON.stringify(value))
+  }
+
+  get(key:string) {
+    return JSON.parse(sessionStorage.getItem(key) || 'null')
+  }
+
+  remove(key:string) {
+    sessionStorage.removeItem(key)
+  }
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -5,6 +5,7 @@ export function isAction(action: any): action is Action {
 }
 
 export type Position = { x: number, y: number }
+export type PersistedPosition = { location: string, x: number, y: number }
 
 export type StreamSource = {
   addEventListener(type: "message", listener: (event: MessageEvent) => void, options?: boolean | AddEventListenerOptions): void

--- a/src/observers/page_observer.ts
+++ b/src/observers/page_observer.ts
@@ -2,6 +2,7 @@ export interface PageObserverDelegate {
   pageBecameInteractive(): void
   pageLoaded(): void
   pageInvalidated(): void
+  beforePageUnloaded(): void
 }
 
 export enum PageStage {
@@ -27,6 +28,7 @@ export class PageObserver {
         this.stage = PageStage.loading
       }
       document.addEventListener("readystatechange", this.interpretReadyState, false)
+      addEventListener("beforeunload", this.beforePageUnloaded, false)
       this.started = true
     }
   }
@@ -34,6 +36,7 @@ export class PageObserver {
   stop() {
     if (this.started) {
       document.removeEventListener("readystatechange", this.interpretReadyState, false)
+      removeEventListener("beforeunload", this.beforePageUnloaded, false)
       this.started = false
     }
   }
@@ -67,6 +70,10 @@ export class PageObserver {
       this.stage = PageStage.complete
       this.delegate.pageLoaded()
     }
+  }
+
+  beforePageUnloaded = () => {
+    this.delegate.beforePageUnloaded()
   }
 
   get readyState() {

--- a/src/observers/scroll_observer.ts
+++ b/src/observers/scroll_observer.ts
@@ -12,6 +12,10 @@ export class ScrollObserver {
     this.delegate = delegate
   }
 
+  get position(): Position {
+    return { x: window.pageXOffset, y: window.pageYOffset }
+  }
+
   start() {
     if (!this.started) {
       addEventListener("scroll", this.onScroll, false)
@@ -28,7 +32,7 @@ export class ScrollObserver {
   }
 
   onScroll = () => {
-    this.updatePosition({ x: window.pageXOffset, y: window.pageYOffset })
+    this.updatePosition(this.position)
   }
 
   // Private

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -21,6 +21,11 @@
       <p><a id="same-origin-download-link" href="/src/tests/fixtures/one.html" download="one.html">Same-origin download link</a></p>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
+
+      <!-- style is for testing scroll position when page is reloaded -->
+      <div style="margin: 200vh 0;">
+        <a id="page-invalidated-link" href="/src/tests/fixtures/tracked_asset_change.html">Page invalidated link</a>
+      </div>
     </section>
   </body>
 </html>

--- a/src/tests/fixtures/tracked_asset_change.html
+++ b/src/tests/fixtures/tracked_asset_change.html
@@ -7,6 +7,7 @@
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
-    <h1>Tracked asset change</h1>
+    <!-- style is for testing scroll position when reloaded -->
+    <h1 style="height: 200vh">Tracked asset change</h1>
   </body>
 </html>

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -116,6 +116,30 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
     this.assert.equal(await this.visitAction, "restore")
   }
+
+  async "test cold loading an anchored URL"() {
+    // Go back from setup() navigation to ensure a cold load
+    await this.goBack()
+    await this.goToLocation("/src/tests/fixtures/navigation.html#page-invalidated-link")
+    this.assert.notDeepEqual(await this.scrollPosition, { x: 0, y: 0 })
+    this.assert(await this.isScrolledToSelector("#page-invalidated-link"))
+  }
+
+  async "test following a link to a page which reloads"() {
+    await this.scrollToSelector("#page-invalidated-link")
+    this.clickSelector("#page-invalidated-link")
+    await this.nextBody
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/tracked_asset_change.html")
+    this.assert.equal(await this.visitAction, "load")
+    this.assert.deepEqual(await this.scrollPosition, { x: 0, y: 0 })
+  }
+
+  async "test refreshing a scrolled page"() {
+    await this.scrollToSelector("#page-invalidated-link")
+    const positionBeforeRefresh = await this.scrollPosition
+    await this.refresh()
+    this.assert.deepEqual(await this.scrollPosition, positionBeforeRefresh)
+  }
 }
 
 NavigationTests.registerSuite()

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -19,6 +19,10 @@ export class FunctionalTestCase extends InternTestCase {
     return this.remote.goForward()
   }
 
+  async refresh(): Promise<void> {
+    return this.remote.refresh()
+  }
+
   async hasSelector(selector: string) {
     return (await this.remote.findAllByCssSelector(selector)).length > 0
   }
@@ -31,6 +35,10 @@ export class FunctionalTestCase extends InternTestCase {
     return this.remote.findByCssSelector(selector).click()
   }
 
+  async scrollToSelector(selector: string): Promise<void> {
+    return this.remote.moveMouseTo(await this.remote.findByCssSelector(selector))
+  }
+
   get scrollPosition(): Promise<{ x: number, y: number }> {
     return this.evaluate(() => ({ x: window.scrollX, y: window.scrollY }))
   }
@@ -39,7 +47,7 @@ export class FunctionalTestCase extends InternTestCase {
     const { y: pageY } = await this.scrollPosition
     const { y: elementY } = await this.remote.findByCssSelector(selector).getPosition()
     const offset = pageY - elementY
-    return offset > -1 && offset < 1
+    return offset > -2 && offset < 2
   }
 
   get nextBeat(): Promise<void> {


### PR DESCRIPTION
[Setting `history.scrollRestoration = "manual"`](https://github.com/hotwired/turbo/blob/18b755f6210a270ad6d9eedaf1195a474e82d9cb/src/core/drive/history.ts#L31) fixes the scrolling issues mentioned in https://github.com/turbolinks/turbolinks/issues/181 and https://github.com/turbolinks/turbolinks/issues/241, however it alters the browser's refresh behaviour. When reloading a page, the scroll position is usually maintained, returning the user to their previous place (this behaviour caused the issue in https://github.com/turbolinks/turbolinks/issues/181). With `history.scrollRestoration = "manual"`, a refresh _always_ resets the scroll position to the top.

This pull request aims to fix that. It captures the scroll position just before the page is reloaded (using `onbeforeunload`), and persists it in session storage along with the current location. After a refresh, the scroll position is restored. When a view is invalidated, either by tracked asset change or a `visit-control` directive, a flag is stored in session storage. This ensures the scroll position is _not_ restored, and the user is navigated to the top as expected.

The downside of this change is that a Hard Reload, or Empty Cache + Hard Reload, won't scroll the user to the top (as is typical), rather, they'll be returned to their previous position. Hard reloads do not clear session storage, and since I don't think we can detect them, I'm not sure we can overcome this.