### PR TITLE
Ensure Turbo does not interfere with IFrames

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -122,8 +122,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   // Link click observer delegate
 
   willFollowLinkToLocation(link: Element, location: URL) {
-    return elementIsNavigable(link)
-      && this.locationIsVisitable(location)
+    return this.locationIsVisitable(location)
       && this.applicationAllowsFollowingLinkToLocation(link, location)
   }
 
@@ -155,7 +154,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   // Form submit observer delegate
 
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {
-    return elementIsNavigable(form) && elementIsNavigable(submitter)
+    return true
   }
 
   formSubmitted(form: HTMLFormElement, submitter?: HTMLElement) {

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -1,3 +1,5 @@
+import { elementIsNavigable } from "../core/session"
+
 export interface FormSubmitObserverDelegate {
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean
   formSubmitted(form: HTMLFormElement, submitter?: HTMLElement): void
@@ -35,7 +37,7 @@ export class FormSubmitObserver {
       const form = event.target instanceof HTMLFormElement ? event.target : undefined
       const submitter = event.submitter || undefined
 
-      if (form) {
+      if (form && elementIsNavigable(form) && elementIsNavigable(submitter)) {
         const method = submitter?.getAttribute("formmethod") || form.method
 
         if (method != "dialog" && this.delegate.willSubmitForm(form, submitter)) {

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -37,14 +37,27 @@ export class FormSubmitObserver {
       const form = event.target instanceof HTMLFormElement ? event.target : undefined
       const submitter = event.submitter || undefined
 
-      if (form && elementIsNavigable(form) && elementIsNavigable(submitter)) {
-        const method = submitter?.getAttribute("formmethod") || form.method
-
-        if (method != "dialog" && this.delegate.willSubmitForm(form, submitter)) {
-          event.preventDefault()
-          this.delegate.formSubmitted(form, submitter)
-        }
+      if (form
+          && elementIsNavigable(form)
+          && elementIsNavigable(submitter)
+          && !submissionControlsDialog(form, submitter)
+          && !submissionTargetsIframe(form, submitter)
+          && this.delegate.willSubmitForm(form, submitter)) {
+        event.preventDefault()
+        this.delegate.formSubmitted(form, submitter)
       }
     }
   })
+}
+
+function submissionControlsDialog(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+  const method = submitter?.getAttribute("formmethod") || form.method
+
+  return method == "dialog"
+}
+
+function submissionTargetsIframe(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+  const target = submitter?.getAttribute("formtarget") || form.target
+
+  return !!target && !!document.querySelector(`iframe[name="${target}"]`)
 }

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -1,4 +1,5 @@
 import { expandURL } from "../core/url"
+import { elementIsNavigable } from "../core/session"
 
 export interface LinkClickObserverDelegate {
   willFollowLinkToLocation(link: Element, location: URL): boolean
@@ -35,7 +36,7 @@ export class LinkClickObserver {
   clickBubbled = (event: MouseEvent) => {
     if (this.clickEventIsSignificant(event)) {
       const link = this.findLinkFromClickTarget(event.target)
-      if (link) {
+      if (link && elementIsNavigable(link)) {
         const location = this.getLocationForLink(link)
         if (this.delegate.willFollowLinkToLocation(link, location)) {
           event.preventDefault()

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -36,7 +36,7 @@ export class LinkClickObserver {
   clickBubbled = (event: MouseEvent) => {
     if (this.clickEventIsSignificant(event)) {
       const link = this.findLinkFromClickTarget(event.target)
-      if (link && elementIsNavigable(link)) {
+      if (link && elementIsNavigable(link) && !linkTargetsIframe(link)) {
         const location = this.getLocationForLink(link)
         if (this.delegate.willFollowLinkToLocation(link, location)) {
           event.preventDefault()
@@ -66,5 +66,13 @@ export class LinkClickObserver {
 
   getLocationForLink(link: Element): URL {
     return expandURL(link.getAttribute("href") || "")
+  }
+}
+
+function linkTargetsIframe(link: Element): boolean {
+  if (link instanceof HTMLAnchorElement) {
+    return !!document.querySelector(`iframe[name="${link.target}"]`)
+  } else {
+    return false
   }
 }

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -112,6 +112,14 @@
           <button formmethod="dialog">Close</button>
         </form>
       </dialog>
+
+      <form action="/src/tests/fixtures/one.html" method="get" target="iframe">
+        <button>Submit iframe target</button>
+      </form>
+
+      <form action="/src/tests/fixtures/one.html" method="get">
+        <button formtarget="iframe">Submit iframe formtarget</button>
+      </form>
     </div>
     <hr>
     <div id="targets-frame">
@@ -169,5 +177,6 @@
       <div id="messages">
       </div>
     </turbo-frame>
+    <iframe name="iframe"></iframe>
   </body>
 </html>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -26,8 +26,11 @@
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
       <p><a id="link-to-disabled-frame" href="/src/tests/fixtures/frames/hello.html" data-turbo-frame="hello">Disabled turbo-frame</a></p>
       <p><a id="autofocus-link" href="/src/tests/fixtures/autofocus.html">autofocus.html link</a></p>
+      <p><a id="targets-iframe" href="/src/tests/fixtures/one.html" target="iframe">Targets iframe</a></p>
     </section>
 
     <turbo-frame id="hello" disabled></turbo-frame>
+
+    <iframe name="iframe"></iframe>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -331,6 +331,22 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
   }
 
+  async "test form submission skipped with form[target]"() {
+    await this.clickSelector("#skipped form[target] button")
+    await this.nextBeat
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+    this.assert.notOk(await this.formSubmitted)
+  }
+
+  async "test form submission skipped with submitter button[formtarget]"() {
+    await this.clickSelector("#skipped [formtarget]")
+    await this.nextBeat
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+    this.assert.notOk(await this.formSubmitted)
+  }
+
   get formSubmitted(): Promise<boolean> {
     return this.hasSelector("html[data-form-submitted]")
   }

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -144,6 +144,13 @@ export class NavigationTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/hello.html")
   }
+
+  async "test ignores links that target an iframe"() {
+    await this.clickSelector("#targets-iframe")
+    await this.nextBeat
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
+  }
 }
 
 NavigationTests.registerSuite()


### PR DESCRIPTION
Move `[data-turbo="false"]` guard up to observers
===

Since the `FormSubmitObserver` and `LinkClickObserver` classes are
very interested in the page's HTML, extract the `elementIsNavigable`
checks from the `Session` into our utility module for re-use amongst the
observers.

This enables the `Session` to act with more confidence that any
interaction on the page is to be Turbo-enabled.

Ensure Turbo does not interfere with IFrames
===

Skip intercepting `<a>` element clicks or `<form>` element submissions
when they target an `<iframe>`. This occurs when an `<a>` declares a
[target][a-target], when a `<form>` declares a [target][form-target], or
a `<form>` element's submitting `<button>` element declares a
[formtarget][formtarget].

[a-target]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-target
[form-target]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-target
[formtarget]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formtarget
