### PR TITLE
Preserve input values in cache

### DIFF
--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -28,10 +28,18 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
   clone() {
     const clonedElement = this.element.cloneNode(true);
 
-    const selects = this.element.querySelectorAll<HTMLSelectElement>('select')
-    const clonedSelects = clonedElement.querySelectorAll<HTMLSelectElement>('select')
-    for (let i = 0; i < selects.length; i++) {
-      clonedSelects[i].value = selects[i].value
+    const singleSelects = this.element.querySelectorAll<HTMLSelectElement>('select:not([multiple])')
+    const clonedSingleSelects = clonedElement.querySelectorAll<HTMLSelectElement>('select:not([multiple])')
+    for (let i = 0; i < singleSelects.length; i++) {
+      clonedSingleSelects[i].value = singleSelects[i].value
+    }
+
+    const multipleSelects = this.element.querySelectorAll<HTMLSelectElement>('select[multiple]')
+    const clonedMultipleSelects = clonedElement.querySelectorAll<HTMLSelectElement>('select[multiple]')
+    for (let i = 0; i < multipleSelects.length; i++) {
+      for (let j = 0; j < multipleSelects[i].options.length; j++) {
+        clonedMultipleSelects[i].options[j].selected = multipleSelects[i].options[j].selected
+      }
     }
 
     return new PageSnapshot(clonedElement, this.headSnapshot, this.htmlElement)

--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -42,6 +42,10 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
       }
     }
 
+    clonedElement.querySelectorAll<HTMLInputElement>('input[type="password"]').forEach((clonedPasswordInput) => {
+      clonedPasswordInput.value = ''
+    })
+
     return new PageSnapshot(clonedElement, this.headSnapshot, this.htmlElement)
   }
 

--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -26,7 +26,15 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
   }
 
   clone() {
-    return new PageSnapshot(this.element.cloneNode(true), this.headSnapshot, this.htmlElement)
+    const clonedElement = this.element.cloneNode(true);
+
+    const selects = this.element.querySelectorAll<HTMLSelectElement>('select')
+    const clonedSelects = clonedElement.querySelectorAll<HTMLSelectElement>('select')
+    for (let i = 0; i < selects.length; i++) {
+      clonedSelects[i].value = selects[i].value
+    }
+
+    return new PageSnapshot(clonedElement, this.headSnapshot, this.htmlElement)
   }
 
   get headElement() {

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -49,6 +49,7 @@
         <input type="radio" id="radio-input" />
         <input type="checkbox" id="checkbox-input" />
         <textarea id="textarea"></textarea>
+        <select id="select"><option value="1">1</option><option value="2">2</option></select>
       </form>
     </section>
     <div id="permanent" data-turbo-permanent>Rendering</div>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -44,6 +44,12 @@
       <p><a id="permanent-in-frame-element-link" href="/src/tests/fixtures/permanent_element.html" data-turbo-frame="frame">Permanent element in frame</a></p>
       <p><a id="permanent-in-frame-without-layout-element-link" href="/src/tests/fixtures/frames/without_layout.html" data-turbo-frame="frame">Permanent element in frame without layout</a></p>
       <p><a id="delayed-link" href="/__turbo/delayed_response">Delayed link</a></p>
+      <form>
+        <input type="text" id="text-input" />
+        <input type="radio" id="radio-input" />
+        <input type="checkbox" id="checkbox-input" />
+        <textarea id="textarea"></textarea>
+      </form>
     </section>
     <div id="permanent" data-turbo-permanent>Rendering</div>
 

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -53,6 +53,8 @@
         <select id="select-multiple" multiple><option value="1">1</option><option value="2">2</option></select>
 
         <input type="password" id="password-input" />
+
+        <input type="reset" id="reset-input" />
       </form>
     </section>
     <div id="permanent" data-turbo-permanent>Rendering</div>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -51,6 +51,8 @@
         <textarea id="textarea"></textarea>
         <select id="select"><option value="1">1</option><option value="2">2</option></select>
         <select id="select-multiple" multiple><option value="1">1</option><option value="2">2</option></select>
+
+        <input type="password" id="password-input" />
       </form>
     </section>
     <div id="permanent" data-turbo-permanent>Rendering</div>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -50,6 +50,7 @@
         <input type="checkbox" id="checkbox-input" />
         <textarea id="textarea"></textarea>
         <select id="select"><option value="1">1</option><option value="2">2</option></select>
+        <select id="select-multiple" multiple><option value="1">1</option><option value="2">2</option></select>
       </form>
     </section>
     <div id="permanent" data-turbo-permanent>Rendering</div>

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -234,6 +234,7 @@ export class RenderingTests extends TurboDriveTestCase {
     await this.remote.findById("radio-input").click()
     await this.remote.findById("textarea").click().type("test")
     await this.remote.findById("select").findAllByCssSelector('option[value="2"]').click()
+    await this.remote.findById("select-multiple").findByCssSelector('option[value="2"]').click()
 
     this.clickSelector("#same-origin-link")
     await this.nextBody
@@ -245,6 +246,7 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert.equal(await this.remote.findById("radio-input").getProperty("checked"), true)
     this.assert.equal(await this.remote.findById("textarea").getProperty("value"), "test")
     this.assert.equal(await this.remote.findById("select").getProperty("value"), "2")
+    this.assert.equal(await this.remote.findById("select-multiple").getProperty("value"), "2")
   }
 
   async "test before-cache event"() {

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -260,6 +260,29 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert.equal(await this.remote.findById("password-input").getProperty("value"), "")
   }
 
+  async "test <input type='reset'> clears values when restored from cache"() {
+    await this.remote.findById("text-input").click().type("test")
+    await this.remote.findById("checkbox-input").click()
+    await this.remote.findById("radio-input").click()
+    await this.remote.findById("textarea").click().type("test")
+    await this.remote.findById("select").findAllByCssSelector('option[value="2"]').click()
+    await this.remote.findById("select-multiple").findByCssSelector('option[value="2"]').click()
+
+    this.clickSelector("#same-origin-link")
+    await this.nextBody
+    await this.goBack()
+    await this.nextBody
+
+    await this.remote.findById("reset-input").click()
+
+    this.assert.equal(await this.remote.findById("text-input").getProperty("value"), "")
+    this.assert.equal(await this.remote.findById("checkbox-input").getProperty("checked"), false)
+    this.assert.equal(await this.remote.findById("radio-input").getProperty("checked"), false)
+    this.assert.equal(await this.remote.findById("textarea").getProperty("value"), "")
+    this.assert.equal(await this.remote.findById("select").getProperty("value"), "1")
+    this.assert.equal(await this.remote.findById("select-multiple").getProperty("value"), "")
+  }
+
   async "test before-cache event"() {
     this.beforeCache((body) => (body.innerHTML = "Modified"))
     this.clickSelector("#same-origin-link")

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -228,6 +228,23 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert.equal(timeAfterRender, timeBeforeRender, "element state is preserved")
   }
 
+  async "test preserves input values"() {
+    await this.remote.findById("text-input").click().type("test")
+    await this.remote.findById("checkbox-input").click()
+    await this.remote.findById("radio-input").click()
+    await this.remote.findById("textarea").click().type("test")
+
+    this.clickSelector("#same-origin-link")
+    await this.nextBody
+    await this.goBack()
+    await this.nextBody
+
+    this.assert.equal(await this.remote.findById("text-input").getProperty("value"), "test")
+    this.assert.equal(await this.remote.findById("checkbox-input").getProperty("checked"), true)
+    this.assert.equal(await this.remote.findById("radio-input").getProperty("checked"), true)
+    this.assert.equal(await this.remote.findById("textarea").getProperty("value"), "test")
+  }
+
   async "test before-cache event"() {
     this.beforeCache((body) => (body.innerHTML = "Modified"))
     this.clickSelector("#same-origin-link")

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -249,6 +249,17 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert.equal(await this.remote.findById("select-multiple").getProperty("value"), "2")
   }
 
+  async "test does not preserve password values"() {
+    await this.remote.findById("password-input").click().type("test")
+
+    this.clickSelector("#same-origin-link")
+    await this.nextBody
+    await this.goBack()
+    await this.nextBody
+
+    this.assert.equal(await this.remote.findById("password-input").getProperty("value"), "")
+  }
+
   async "test before-cache event"() {
     this.beforeCache((body) => (body.innerHTML = "Modified"))
     this.clickSelector("#same-origin-link")

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -233,6 +233,7 @@ export class RenderingTests extends TurboDriveTestCase {
     await this.remote.findById("checkbox-input").click()
     await this.remote.findById("radio-input").click()
     await this.remote.findById("textarea").click().type("test")
+    await this.remote.findById("select").findAllByCssSelector('option[value="2"]').click()
 
     this.clickSelector("#same-origin-link")
     await this.nextBody
@@ -243,6 +244,7 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert.equal(await this.remote.findById("checkbox-input").getProperty("checked"), true)
     this.assert.equal(await this.remote.findById("radio-input").getProperty("checked"), true)
     this.assert.equal(await this.remote.findById("textarea").getProperty("value"), "test")
+    this.assert.equal(await this.remote.findById("select").getProperty("value"), "2")
   }
 
   async "test before-cache event"() {


### PR DESCRIPTION
This change will save the values of `<input>`s, `<textarea>`s, and `<select>`s when creating a snapshot so that when you navigate back or forward in history, form fields will not be reset.

This behavior was already present prior to <https://github.com/hotwired/turbo/commit/5dfc79ee2feba441ea9c9b486009d08336e78d76> for `<input>`s and `<textarea>`s but not `<select>`s (see <https://github.com/turbolinks/turbolinks/issues/238>).