### PR TITLE
Read form method as attribute instead of property

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -44,7 +44,7 @@ export class FormSubmission {
   }
 
   get method(): FetchMethod {
-    const method = this.submitter?.getAttribute("formmethod") || this.formElement.method
+    const method = this.submitter?.getAttribute("formmethod") || this.formElement.getAttribute("method") || ""
     return fetchMethodFromString(method.toLowerCase()) || FetchMethod.get
   }
 

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -81,6 +81,11 @@
         <input type="hidden" name="content" value="Hello!">
         <input type="submit">
       </form>
+      <form action="/__turbo/messages/1" method="put" class="stream put">
+        <input type="hidden" name="type" value="stream">
+        <input type="hidden" name="content" value="Hello!">
+        <input type="submit">
+      </form>
       <div id="messages">
       </div>
     </turbo-frame>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -83,6 +83,16 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
   }
 
+  async "test frame form submission with HTTP verb other than GET or POST"() {
+    await this.clickSelector("#frame form.put.stream input[type=submit]")
+    await this.nextBeat
+
+    const message = await this.querySelector("#frame div.message")
+    this.assert.ok(await this.hasSelector("#frame form.redirect"))
+    this.assert.equal(await message.getVisibleText(), "1: Hello!")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+  }
+
   async "test form submission with Turbo disabled on the form"() {
     this.listenForFormSubmissions()
     await this.clickSelector('#disabled form[data-turbo="false"] input[type=submit]')

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -34,6 +34,22 @@ router.post("/messages", (request, response) => {
   }
 })
 
+router.put("/messages/:id", (request, response) => {
+  const { content, type } = request.body
+  const { id } = request.params
+  if (typeof content == "string") {
+    receiveMessage(content)
+    if (type == "stream") {
+      response.type("text/html; turbo-stream=*; charset=utf-8")
+      response.send(renderMessage(id + ": " + content))
+    } else {
+      response.sendStatus(200)
+    }
+  } else {
+    response.sendStatus(422)
+  }
+})
+
 router.get("/messages", (request, response) => {
   response.set({
     "Cache-Control": "no-cache",


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/69

Reverts part of [bf257f3][] to read a [`<form>` element's `method`
attribute][attribute] _directly_, instead of through the corresponding
[HTMLFormElement.method][property].

Add test coverage for a `PUT` request to ensure that methods that are
not `GET` or `POST` are supported during `FetchRequest` serialization.

[bf257f3]: https://github.com/hotwired/turbo/commit/bf257f3c40e9566955ad8a7329060a9e276fd429
[attribute]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-method
[property]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/method