### PR TITLE
Scroll to top after rejected form submission

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -97,6 +97,7 @@ export class Navigator {
     if (responseHTML) {
       const snapshot = PageSnapshot.fromHTMLString(responseHTML)
       await this.view.renderPage(snapshot)
+      window.scroll(0, 0)
       this.view.clearSnapshotCache()
     }
   }

--- a/src/tests/fixtures/422.html
+++ b/src/tests/fixtures/422.html
@@ -3,7 +3,7 @@
     <title>Unprocessable Entity</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
-  <body>
+  <body style="height: 200vh;">
     <h1>Unprocessable Entity</h1>
 
     <turbo-frame id="frame">

--- a/src/tests/fixtures/500.html
+++ b/src/tests/fixtures/500.html
@@ -3,7 +3,7 @@
     <title>Internal Server Error</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
-  <body>
+  <body style="height: 200vh;">
     <h1>Internal Server Error</h1>
 
     <turbo-frame id="frame">

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -12,7 +12,7 @@
       }
     </style>
   </head>
-  <body>
+  <body style="height: 200vh;">
     <div id="standard">
       <form action="/__turbo/redirect" method="post" class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -134,21 +134,29 @@ export class FormSubmissionTests extends TurboDriveTestCase {
   }
 
   async "test invalid form submission with unprocessable entity status"() {
+    await this.scrollToSelector("#reject")
     await this.clickSelector("#reject form.unprocessable_entity input[type=submit]")
     await this.nextBody
 
+    const { x: xAfterScrolling, y: yAfterScrolling } = await this.scrollPosition
     const title = await this.querySelector("h1")
     this.assert.equal(await title.getVisibleText(), "Unprocessable Entity", "renders the response HTML")
     this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
+    this.assert.equal(xAfterScrolling, 0)
+    this.assert.equal(yAfterScrolling, 0)
   }
 
   async "test invalid form submission with server error status"() {
+    await this.scrollToSelector("#reject")
     await this.clickSelector("#reject form.internal_server_error input[type=submit]")
     await this.nextBody
 
+    const { x: xAfterScrolling, y: yAfterScrolling } = await this.scrollPosition
     const title = await this.querySelector("h1")
     this.assert.equal(await title.getVisibleText(), "Internal Server Error", "renders the response HTML")
     this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
+    this.assert.equal(xAfterScrolling, 0)
+    this.assert.equal(yAfterScrolling, 0)
   }
 
   async "test submitter form submission reads button attributes"() {


### PR DESCRIPTION
After a form submission results in a 4xx-5xx response, scroll the window
to the top of the page, since that's what a browser does by default.