### PR TITLE
Cache snapshots synchronously

### DIFF
--- a/src/core/drive/view.ts
+++ b/src/core/drive/view.ts
@@ -4,7 +4,6 @@ import { Snapshot } from "./snapshot"
 import { SnapshotCache } from "./snapshot_cache"
 import { RenderCallback, RenderDelegate, SnapshotRenderer } from "./snapshot_renderer"
 import { Position } from "../types"
-import { nextMicrotask } from "../../util"
 
 export type RenderOptions = { snapshot: Snapshot, error: string, isPreview: boolean }
 
@@ -42,12 +41,11 @@ export class View {
     return this.getSnapshot().isCacheable()
   }
 
-  async cacheSnapshot() {
+  cacheSnapshot() {
     if (this.shouldCacheSnapshot()) {
       this.delegate.viewWillCacheSnapshot()
       const snapshot = this.getSnapshot()
       const location = this.lastRenderedLocation || Location.currentLocation
-      await nextMicrotask()
       this.snapshotCache.put(location, snapshot.clone())
     }
   }


### PR DESCRIPTION
This is a bit of a cheeky way to report a bug, but this change works for me, so I thought I'd propose it.

I have a `div` marked as `data-turbo-permanent`. The contents of this `div` are not changed at any time when testing, it's just marked as permanent. The `div` is not contained inside a `turbo-frame`.

    <div id="sidebar-content" data-turbo-permanent>
      ...
    </div>

On my M1 Mac, I've got a problem in Safari. When clicking a link to visit a new page, the `div` is correctly cached and restored at all times. However, when going back/forth in the browser, more often than not, some of the pages will lose the sidebar contents and have the placeholder `meta` tag instead. From that point on, such a page will never have the sidebar content again. Firefox doesn't show this problem.

From some logging, it appears that in some cases, the snapshot is cached right **after** moving the permanent elements out of the DOM. Hence, removing the `async` flag from `View.cacheSnapshot()` is one way to resolve this problem.

Now this `async` flag is new in Turbo---in Turbolinks, the analogous part wasn't marked as `async` and I can confirm that I had never previously encountered this problem. This might indicate that it is indeed the culprit?