### PR TITLE
Move `[data-turbo="false"]` guard up to observers

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -121,8 +121,7 @@ export class Session implements NavigatorDelegate {
   // Link click observer delegate
 
   willFollowLinkToLocation(link: Element, location: Location) {
-    return this.elementIsNavigable(link)
-      && this.locationIsVisitable(location)
+    return this.locationIsVisitable(location)
       && this.applicationAllowsFollowingLinkToLocation(link, location)
   }
 
@@ -152,7 +151,7 @@ export class Session implements NavigatorDelegate {
   // Form submit observer delegate
 
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {
-    return this.elementIsNavigable(form) && this.elementIsNavigable(submitter)
+    return true
   }
 
   formSubmitted(form: HTMLFormElement, submitter?: HTMLElement) {
@@ -244,15 +243,6 @@ export class Session implements NavigatorDelegate {
   getActionForLink(link: Element): Action {
     const action = link.getAttribute("data-turbo-action")
     return isAction(action) ? action : "advance"
-  }
-
-  elementIsNavigable(element?: Element) {
-    const container = element?.closest("[data-turbo]")
-    if (container) {
-      return container.getAttribute("data-turbo") != "false"
-    } else {
-      return true
-    }
   }
 
   locationIsVisitable(location: Location) {

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -1,3 +1,5 @@
+import { elementIsNavigable } from "../util"
+
 export interface FormSubmitObserverDelegate {
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean
   formSubmitted(form: HTMLFormElement, submitter?: HTMLElement): void
@@ -35,7 +37,7 @@ export class FormSubmitObserver {
       const form = event.target instanceof HTMLFormElement ? event.target : undefined
       const submitter = event.submitter || undefined
 
-      if (form) {
+      if (form && elementIsNavigable(form) && elementIsNavigable(submitter)) {
         const method = submitter?.getAttribute("formmethod") || form.method
 
         if (method != "dialog" && this.delegate.willSubmitForm(form, submitter)) {

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -1,3 +1,4 @@
+import { elementIsNavigable } from "../util"
 import { Location } from "../core/location"
 
 export interface LinkClickObserverDelegate {
@@ -35,7 +36,7 @@ export class LinkClickObserver {
   clickBubbled = (event: MouseEvent) => {
     if (this.clickEventIsSignificant(event)) {
       const link = this.findLinkFromClickTarget(event.target)
-      if (link) {
+      if (link && elementIsNavigable(link)) {
         const location = this.getLocationForLink(link)
         if (this.delegate.willFollowLinkToLocation(link, location)) {
           event.preventDefault()

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,3 +41,12 @@ export function uuid() {
     }
   }).join("")
 }
+
+export function elementIsNavigable(element?: Element): boolean {
+  const container = element?.closest("[data-turbo]")
+  if (container) {
+    return container.getAttribute("data-turbo") != "false"
+  } else {
+    return true
+  }
+}


### PR DESCRIPTION
Since the `FormSubmitObserver` and `LinkClickObserver` classes are
very interested in the page's HTML, extract the `elementIsNavigable`
checks from the `Session` into our utility module for re-use amongst the
observers.

This enables the `Session` to act with more confidence that any
interaction on the page is to be Turbo-enabled.