### PR TITLE
Turbo Stream: use a proper media type instead of an attribute

### DIFF
--- a/src/http/fetch_response.ts
+++ b/src/http/fetch_response.ts
@@ -32,7 +32,7 @@ export class FetchResponse {
   }
 
   get isHTML() {
-    return this.contentType && this.contentType.match(/^text\/html|^application\/xhtml\+xml/)
+    return this.contentType && this.contentType.match(/^text\/html|^application\/xhtml\+xml|^application\/vnd\.turbo\.stream\.html/)
   }
 
   get statusCode() {

--- a/src/observers/stream_observer.ts
+++ b/src/observers/stream_observer.ts
@@ -54,7 +54,7 @@ export class StreamObserver {
     const fetchOptions: FetchRequestOptions = event.detail?.fetchOptions
     if (fetchOptions) {
       const { headers } = fetchOptions
-      headers.Accept = [ "text/html; turbo-stream", headers.Accept ].join(", ")
+      headers.Accept = [ "application/vnd.turbo.stream.html", headers.Accept ].join(", ")
     }
   })
 
@@ -93,5 +93,5 @@ function fetchResponseFromEvent(event: CustomEvent) {
 
 function fetchResponseIsStream(response: FetchResponse) {
   const contentType = response.contentType ?? ""
-  return /text\/html;.*\bturbo-stream\b/.test(contentType)
+  return contentType.startsWith("application/vnd.turbo.stream.html")
 }

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -24,7 +24,7 @@ router.post("/messages", (request, response) => {
   if (typeof content == "string") {
     receiveMessage(content)
     if (type == "stream") {
-      response.type("text/html; turbo-stream=*; charset=utf-8")
+      response.type("application/vnd.turbo.stream.html; charset=utf-8") // the charset parameter should not be sent, but let's be liberal in what we accept
       response.send(renderMessage(content))
     } else {
       response.sendStatus(201)
@@ -40,7 +40,7 @@ router.put("/messages/:id", (request, response) => {
   if (typeof content == "string") {
     receiveMessage(content)
     if (type == "stream") {
-      response.type("text/html; turbo-stream=*; charset=utf-8")
+      response.type("application/vnd.turbo.stream.html")
       response.send(renderMessage(id + ": " + content))
     } else {
       response.sendStatus(200)


### PR DESCRIPTION
Fixes #24.