### PR TITLE
Switch Turbo Streams to `text/vnd.turbo-stream.html`

### DIFF
--- a/src/http/fetch_response.ts
+++ b/src/http/fetch_response.ts
@@ -32,7 +32,7 @@ export class FetchResponse {
   }
 
   get isHTML() {
-    return this.contentType && this.contentType.match(/^text\/html|^application\/xhtml\+xml/)
+    return this.contentType && this.contentType.match(/^(?:text\/([^\s;,]+\b)?html|application\/xhtml\+xml)\b/)
   }
 
   get statusCode() {

--- a/src/observers/stream_observer.ts
+++ b/src/observers/stream_observer.ts
@@ -54,7 +54,7 @@ export class StreamObserver {
     const fetchOptions: FetchRequestOptions = event.detail?.fetchOptions
     if (fetchOptions) {
       const { headers } = fetchOptions
-      headers.Accept = [ "text/html; turbo-stream", headers.Accept ].join(", ")
+      headers.Accept = [ "text/vnd.turbo-stream.html", headers.Accept ].join(", ")
     }
   })
 
@@ -93,5 +93,5 @@ function fetchResponseFromEvent(event: CustomEvent) {
 
 function fetchResponseIsStream(response: FetchResponse) {
   const contentType = response.contentType ?? ""
-  return /text\/html;.*\bturbo-stream\b/.test(contentType)
+  return /^text\/vnd\.turbo-stream\.html\b/.test(contentType)
 }

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -24,7 +24,7 @@ router.post("/messages", (request, response) => {
   if (typeof content == "string") {
     receiveMessage(content)
     if (type == "stream") {
-      response.type("text/html; turbo-stream=*; charset=utf-8")
+      response.type("text/vnd.turbo-stream.html; charset=utf-8")
       response.send(renderMessage(content))
     } else {
       response.sendStatus(201)
@@ -40,7 +40,7 @@ router.put("/messages/:id", (request, response) => {
   if (typeof content == "string") {
     receiveMessage(content)
     if (type == "stream") {
-      response.type("text/html; turbo-stream=*; charset=utf-8")
+      response.type("text/vnd.turbo-stream.html; charset=utf-8")
       response.send(renderMessage(id + ": " + content))
     } else {
       response.sendStatus(200)


### PR DESCRIPTION
Using the `text/` prefix allows browsers' web inspectors to display the payload as text instead of displaying a message saying it's unpresentable.

Closes #24, #91

/cc @dhh 
