### PR TITLE
Add ability to turn off link and form behaviors

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -41,10 +41,10 @@ export function setProgressBarDelay(delay: number) {
   session.setProgressBarDelay(delay)
 }
 
-export function disableLinkBehavior() {
-  session.disableLinkBehavior()
+export function disableNavigation() {
+  session.disableNavigation()
 }
 
-export function disableFormBehavior() {
-  session.disableFormBehavior()
+export function disableFormSubmissions() {
+  session.disableFormSubmissions()
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -40,3 +40,11 @@ export function clearCache() {
 export function setProgressBarDelay(delay: number) {
   session.setProgressBarDelay(delay)
 }
+
+export function disableLinkBehavior() {
+  session.disableLinkBehavior()
+}
+
+export function disableFormBehavior() {
+  session.disableFormBehavior()
+}

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -94,6 +94,14 @@ export class Session implements NavigatorDelegate, PageObserverDelegate {
     this.progressBarDelay = delay
   }
 
+  disableLinkBehavior() {
+    this.linkClickObserver.stop()
+  }
+
+  disableFormBehavior() {
+    this.formSubmitObserver.stop()
+  }
+
   get location() {
     return this.history.location
   }

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -94,11 +94,11 @@ export class Session implements NavigatorDelegate, PageObserverDelegate {
     this.progressBarDelay = delay
   }
 
-  disableLinkBehavior() {
+  disableNavigation() {
     this.linkClickObserver.stop()
   }
 
-  disableFormBehavior() {
+  disableFormSubmissions() {
     this.formSubmitObserver.stop()
   }
 


### PR DESCRIPTION
:wave:

See https://github.com/hotwired/turbo/issues/77

In an effort to ease the upgrade (or adoption) path from Turbolinks to Turbodrive, support disabling the link and/or form behavior. This allows for people to:

- Upgrade from Turbolinks to TurboDrive but opt-out of new form behavior (this may be a non-trivial effort for legacy apps)
- Use TurboFrames and TurboStreams without going "all-in" on the Turbo stack

This isn't a large changeset and omits tests, but this might be a good place to continue the discussion while looking at some actual code.

The intended usage as a consumer would be:

```js
import Turbo from "@hotwired/turbo"
Turbo.disableNavigation()
Turbo.disableFormSubmissions()
```