### PR TITLE
GET form submissions to the current path

### DIFF
--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -137,8 +137,17 @@ export class FetchRequest {
 }
 
 function mergeFormDataEntries(url: URL, entries: [string, FormDataEntryValue][]): URL {
+  const currentSearchParams = new URLSearchParams(url.search)
+
   for (const [ name, value ] of entries) {
-    url.searchParams.append(name, value.toString())
+    if (value instanceof File) continue
+
+    if (currentSearchParams.has(name)) {
+      currentSearchParams.delete(name)
+      url.searchParams.set(name, value)
+    } else {
+      url.searchParams.append(name, value)
+    }
   }
 
   return url

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -43,6 +43,22 @@
         <input type="hidden" name="greeting" value="Hello from a form">
         <input type="submit">
       </form>
+      <form action="/src/tests/fixtures/form.html?query=1" method="get" class="conflicting-values">
+        <input type="hidden" name="query" value="2">
+        <input type="submit">
+      </form>
+    </div>
+    <hr>
+    <div id="no-action">
+      <form class="single">
+        <input type="hidden" name="query" value="1">
+        <input type="submit">
+      </form>
+      <form class="multiple">
+        <input type="hidden" name="query" value="1">
+        <input type="hidden" name="query" value="2">
+        <input type="submit">
+      </form>
     </div>
     <hr>
     <div id="reject">

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -94,6 +94,14 @@ export class FunctionalTestCase extends InternTestCase {
     return this.evaluate(() => location.search).then(search => new URLSearchParams(search))
   }
 
+  async getSearchParam(key: string): Promise<string> {
+    return (await this.searchParams).get(key) || ""
+  }
+
+  async getAllSearchParams(key: string): Promise<string[]> {
+    return (await this.searchParams).getAll(key) || []
+  }
+
   get hash(): Promise<string> {
     return this.evaluate(() => location.hash)
   }


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/107

The [HTML specification][] outlines the algorithm for handling form
submissions, and describes the steps involved in handling a `method=get`
request with `application/x-www-form-urlencoded` encoding.

However, it doesn't explicitly mention how to handle a `<form
method="get">` submission when the `action` attribute is omitted and the
current URL includes a query parameter that would be included within the
`<form>` element fields' values.

Determining the test cases to reproduce browser default behavior
involved was some trial and error troubleshooting in real browsers with
default (JavaScript-less) `<form>` submission handling.

The algorithm appears to be as follows:

* If there are no query parameters, append all field values as query
   parameters

* If there are existing query parameters whose keys exist as `<form>`
  fields, override them based on the form field's value

  * If there are existing query parameters whose keys exist as
    _multiple_ `<form>` fields, override the first occurrence, and then
    append subsequent values

[HTML specification]: https://html.spec.whatwg.org/#form-submission-algorithm