### PR TITLE
Read frame target from turbo-frame[target]

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -212,7 +212,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   private findFrameElement(element: Element) {
-    const id = element.getAttribute("data-turbo-frame")
+    const id = element.getAttribute("data-turbo-frame") || this.element.getAttribute("target")
     return getFrameElementById(id) ?? this.element
   }
 

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -12,8 +12,23 @@
       <h2>Frames: #frame</h2>
     </turbo-frame>
 
-    <turbo-frame id="hello">
+    <turbo-frame id="hello" target="frame">
       <h2>Frames: #hello</h2>
+
+      <a href="/src/tests/fixtures/frames/frame.html">Load #frame</a>
+    </turbo-frame>
+
+    <turbo-frame id="nested-root" target="frame">
+      <h2>Frames: #nested-root</h2>
+      <turbo-frame id="nested-child">
+        <h2>Frames: #nested-child</h2>
+        <a href="/src/tests/fixtures/frames/frame.html">Load #nested-child</a>
+        <a href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
+      </turbo-frame>
+    </turbo-frame>
+
+    <turbo-frame id="navigate-top" target="_top">
+      <a href="/src/tests/fixtures/one.html">Visit one.html</a>
     </turbo-frame>
 
     <turbo-frame id="missing">

--- a/src/tests/fixtures/frames/frame.html
+++ b/src/tests/fixtures/frames/frame.html
@@ -9,5 +9,9 @@
     <turbo-frame id="frame">
       <h2>Frame: Loaded</h2>
     </turbo-frame>
+
+    <turbo-frame id="nested-child">
+      <h2>Frame: Loaded</h2>
+    </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -10,6 +10,42 @@ export class FrameTests extends FunctionalTestCase {
     await this.nextBeat
     this.assert.notOk(await this.innerHTMLForSelector("#missing"))
   }
+
+  async "test following a link within a frame with a target set navigates the target frame"() {
+    await this.clickSelector("#hello a")
+    await this.nextBeat
+
+    const frameText = await this.querySelector("#frame h2")
+    this.assert.equal(await frameText.getVisibleText(), "Frame: Loaded")
+  }
+
+  async "test following a link within a descendant frame whose ancestor declares a target set navigates the descendant frame"() {
+    await this.clickSelector("#nested-root[target=frame] #nested-child a:not([data-turbo-frame])")
+    await this.nextBeat
+
+    const frame = await this.querySelector("#frame h2")
+    const nestedRoot = await this.querySelector("#nested-root h2")
+    const nestedChild = await this.querySelector("#nested-child")
+    this.assert.equal(await frame.getVisibleText(), "Frames: #frame")
+    this.assert.equal(await nestedRoot.getVisibleText(), "Frames: #nested-root")
+    this.assert.equal(await nestedChild.getVisibleText(), "Frame: Loaded")
+  }
+
+  async "test following a link that declares data-turbo-frame within a frame whose ancestor respects the override"() {
+    await this.clickSelector("#nested-root[target=frame] #nested-child a[data-turbo-frame]")
+    await this.nextBeat
+
+    const frameText = await this.querySelector("body > h1")
+    this.assert.equal(await frameText.getVisibleText(), "One")
+  }
+
+  async "test following a link within a frame with target=_top navigates the page"() {
+    await this.clickSelector("#navigate-top a")
+    await this.nextBeat
+
+    const frameText = await this.querySelector("body > h1")
+    this.assert.equal(await frameText.getVisibleText(), "One")
+  }
 }
 
 FrameTests.registerSuite()


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/115

When navigating via an `<a>` click within a `<turbo-frame>`, determine
the target of the navigation by checking for `[data-turbo-frame]`
overrides on the `<a>` element itself, and then check for frames
rreferenced by `turbo-frame[target]`, then fall back to the frame
itself.
