### PR TITLE
Avoid redefining things when using the asset pipeline in Safari

### DIFF
--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -7,5 +7,5 @@ FrameElement.delegateConstructor = FrameController
 export * from "./frame_element"
 export * from "./stream_element"
 
-customElements.define("turbo-frame", FrameElement)
-customElements.define("turbo-stream", StreamElement)
+customElements.get("turbo-frame") || customElements.define("turbo-frame", FrameElement)
+customElements.get("turbo-stream") || customElements.define("turbo-stream", StreamElement)

--- a/src/polyfills/submit-event.ts
+++ b/src/polyfills/submit-event.ts
@@ -18,6 +18,7 @@ function clickCaptured(event: Event) {
 
 (function() {
   if ("SubmitEvent" in window) return
+  if ("submitter" in Event.prototype) return
 
   addEventListener("click", clickCaptured, true)
 


### PR DESCRIPTION
While using Safari with Turbo and Stimulus(through the hotwire gem) and a Stimulus controller
that also utilizes Turbo I am seeing these errors.

When Stimulus tries to import the controller, it seems as if it is
trying to import Turbo twice causing these "already defined" errors.

While using Turbo and Stimulus through the asset pipeline
- Only define customeElements when they are not already
- Only define 'submitter' property if it isnt already defined on Event

You can recreate this error by setting up hotwire through the asset pipeline then add `import { Turbo } from "turbo"` to a stimulus controller. 