### PR TITLE
Prevent reloading pages when tapping same-page anchors

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -2,7 +2,7 @@ import { Adapter } from "../native/adapter"
 import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { History } from "./history"
-import { getAnchor } from "../url"
+import { getAnchor, getRequestURL } from "../url"
 import { PageSnapshot } from "./page_snapshot"
 import { Action } from "../types"
 import { uuid } from "../../util"
@@ -70,6 +70,7 @@ export class Visit implements FetchRequestDelegate {
   frame?: number
   historyChanged = false
   location: URL
+  isSamePage: boolean
   redirectedToLocation?: URL
   request?: FetchRequest
   response?: VisitResponse
@@ -81,6 +82,11 @@ export class Visit implements FetchRequestDelegate {
   constructor(delegate: VisitDelegate, location: URL, restorationIdentifier: string | undefined, options: Partial<VisitOptions> = {}) {
     this.delegate = delegate
     this.location = location
+    this.isSamePage = (
+      getAnchor(location) != null &&
+      getRequestURL(location) === getRequestURL(new URL(window.location.href))
+    )
+
     this.restorationIdentifier = restorationIdentifier || uuid()
 
     const { action, historyChanged, referrer, snapshotHTML, response } = { ...defaultOptions, ...options }
@@ -234,10 +240,14 @@ export class Visit implements FetchRequestDelegate {
       const isPreview = this.shouldIssueRequest()
       this.render(async () => {
         this.cacheSnapshot()
-        await this.view.renderPage(snapshot)
-        this.adapter.visitRendered(this)
-        if (!isPreview) {
-          this.complete()
+        if (this.isSamePage) {
+          this.adapter.visitRendered(this)
+        } else {
+          await this.view.renderPage(snapshot)
+          this.adapter.visitRendered(this)
+          if (!isPreview) {
+            this.complete()
+          }
         }
       })
     }
@@ -248,6 +258,15 @@ export class Visit implements FetchRequestDelegate {
       this.location = this.redirectedToLocation
       this.history.replace(this.redirectedToLocation, this.restorationIdentifier)
       this.followedRedirect = true
+    }
+  }
+
+  goToSamePageAnchor() {
+    if (this.isSamePage) {
+      this.render(async () => {
+        this.cacheSnapshot()
+        this.adapter.visitRendered(this)
+      })
     }
   }
 
@@ -346,9 +365,13 @@ export class Visit implements FetchRequestDelegate {
   }
 
   shouldIssueRequest() {
-    return this.action == "restore"
-      ? !this.hasCachedSnapshot()
-      : true
+    if (this.action == "restore") {
+      return !this.hasCachedSnapshot()
+    } else if (this.isSamePage) {
+      return false
+    } else {
+      return true
+    }
   }
 
   cacheSnapshot() {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -310,8 +310,9 @@ export class Visit implements FetchRequestDelegate {
   }
 
   scrollToAnchor() {
-    if (getAnchor(this.location) != null) {
-      this.view.scrollToAnchor(getAnchor(this.location))
+    const anchor = getAnchor(this.location)
+    if (anchor != null) {
+      this.view.scrollToAnchor(anchor)
       return true
     }
   }

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -22,6 +22,7 @@ export class BrowserAdapter implements Adapter {
   visitStarted(visit: Visit) {
     visit.issueRequest()
     visit.changeHistory()
+    visit.goToSamePageAnchor()
     visit.loadCachedSnapshot()
   }
 

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -9,11 +9,11 @@ export class Snapshot<E extends Element = Element> {
     return [ ...this.element.children ]
   }
 
-  hasAnchor(anchor: string) {
+  hasAnchor(anchor: string | undefined) {
     return this.getElementForAnchor(anchor) != null
   }
 
-  getElementForAnchor(anchor: string) {
+  getElementForAnchor(anchor: string | undefined) {
     try {
       return this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`)
     } catch {

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -12,8 +12,6 @@ export function getAnchor(url: URL) {
     return url.hash.slice(1)
   } else if (anchorMatch = url.href.match(/#(.*)$/)) {
     return anchorMatch[1]
-  } else {
-    return ""
   }
 }
 

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -28,13 +28,15 @@ export function isPrefixedBy(baseURL: URL, url: URL) {
   return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
 }
 
+export function getRequestURL(url: URL) {
+  const anchor = getAnchor(url)
+  return anchor != null
+    ? url.href.slice(0, -(anchor.length + 1))
+    : url.href
+}
+
 export function toCacheKey(url: URL) {
-  const anchorLength = url.hash.length
-  if (anchorLength < 2) {
-    return url.href
-  } else {
-    return url.href.slice(0, -anchorLength)
-  }
+  return getRequestURL(url)
 }
 
 function getPathComponents(url: URL) {

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -25,6 +25,7 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
     const element = this.snapshot.getElementForAnchor(anchor)
     if (element) {
       this.scrollToElement(element)
+      this.focusElement(element)
     } else {
       this.scrollToPosition({ x: 0, y: 0 })
     }
@@ -40,6 +41,13 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
 
   get scrollRoot(): { scrollTo(x: number, y: number): void } {
     return window
+  }
+
+  focusElement(element: Element | HTMLElement) {
+    const tabindex = element.getAttribute('tabindex')
+    element.setAttribute('tabindex', '-1')
+    if ('focus' in element) element.focus()
+    tabindex ? element.setAttribute('tabindex', tabindex) : element.removeAttribute('tabindex')
   }
 
   // Rendering

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -118,10 +118,13 @@ export class NavigationTests extends TurboDriveTestCase {
   }
 
   async "test skip link with hash-only path"() {
+    const bodyElementId = (await this.body).elementId
     await this.clickSelector('a[href="#main"]')
 
+    await this.nextBeat
     this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
     this.assert.equal(await this.hash, "#main")
+    this.assert.equal((await this.body).elementId, bodyElementId, "does not reload page")
     this.assert.ok(await this.isScrolledToSelector("#main"))
 
     await this.pressTab()


### PR DESCRIPTION
This is a port of https://github.com/turbolinks/turbolinks/pull/285 to resolve https://github.com/turbolinks/turbolinks/issues/75, https://github.com/turbolinks/turbolinks/issues/214, and https://github.com/turbolinks/turbolinks/issues/192

## The Problem

Clicking on a link which references an anchor on the current page issues an unnecessary request. This can cause problems when linking to content which is lazily loaded (see https://agile-reef-88023.herokuapp.com/posts/1), as well as with [analytics](https://github.com/turbolinks/turbolinks/issues/75#issuecomment-255867311) and [skip links](https://github.com/hotwired/turbo/issues/42). Disabling Turbo completely on those links prevents the request, but because the view is not cached, this approach breaks the Back button.

## The Solution

This PR detects whether the visit is to an anchor on the same page, and if so, prevents the request. It takes a snapshot and performs the scroll, bypassing any rendering and `turbo:load` triggering. A similar flow handles restorations to same-page anchors. Correct focusing is achieved by temporarily adding `tabindex=-1` and calling `focus` on the target.

The focus test still seems to fail. I'm beginning to think that simulating pressing tab doesn't do anything? 

A final note: the [Turbolinks version](https://github.com/turbolinks/turbolinks/pull/285) of this PR performed [the same-page check in the session](https://github.com/turbolinks/turbolinks/pull/285/files#diff-da4d3d3a97b9ed26e47b50d9a5d2f5795434467e001f8a6deba72c361a23baa7R330-R333) (née controller). This allowed the [native adapters to check for same-page anchors](https://github.com/turbolinks/turbolinks-ios/pull/126/files#diff-db83eae543943038c85ab2f7a4c437adda02ed30411e803d0091f5a7fc32d0acR57) and handle accordingly. The session is not so accessible from the Visit, so I'd welcome some tips on how to solve this (or whether it's even necessary now?).