### PR TITLE
Transform GET submissions into Visits

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -37,7 +37,12 @@ export class Navigator {
   submitForm(form: HTMLFormElement, submitter?: HTMLElement) {
     this.stop()
     this.formSubmission = new FormSubmission(this, form, submitter, true)
-    this.formSubmission.start()
+
+    if (this.formSubmission.fetchRequest.isIdempotent) {
+      this.proposeVisit(this.formSubmission.fetchRequest.url)
+    } else {
+      this.formSubmission.start()
+    }
   }
 
   stop() {

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -15,6 +15,8 @@
   <body>
     <div id="standard">
       <form action="/__turbo/redirect" method="post" class="redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
+        <input type="hidden" name="greeting" value="Hello from a redirect">
         <input type="submit">
       </form>
       <form action="/__turbo/messages" method="post" class="created">
@@ -34,6 +36,11 @@
         <input type="submit">
       </form>
       <form action="/__turbo/redirect" method="get" enctype="multipart/form-data">
+        <input type="submit">
+      </form>
+      <form action="/__turbo/redirect" method="get" class="greeting">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="hidden" name="greeting" value="Hello from a form">
         <input type="submit">
       </form>
     </div>

--- a/src/tests/fixtures/greetings.ejs
+++ b/src/tests/fixtures/greetings.ejs
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Greeting</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <h1><%= greeting %></h1>
+  </body>
+</html>

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -9,16 +9,22 @@ const streamResponses: Set<Response> = new Set
 router.use(multer().none())
 
 router.post("/redirect", (request, response) => {
-  const pathname = request.body.path ?? "/src/tests/fixtures/one.html"
+  const { path, ...query } = request.body
+  const pathname = path ?? "/src/tests/fixtures/one.html"
   const enctype = request.get("Content-Type")
-  const query = enctype ? { enctype } : {}
+  if (enctype) {
+    query.enctype = enctype
+  }
   response.redirect(303, url.format({ pathname, query }))
 })
 
 router.get("/redirect", (request, response) => {
-  const pathname = (request.query as any).path ?? "/src/tests/fixtures/one.html"
+  const { path, ...query } = request.query as any
+  const pathname = path ?? "/src/tests/fixtures/one.html"
   const enctype = request.get("Content-Type")
-  const query = enctype ? { enctype } : {}
+  if (enctype) {
+    query.enctype = enctype
+  }
   response.redirect(301, url.format({ pathname, query }))
 })
 


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/126

When submitting a `<form method="get">`, skip the Form Submission
lifecycle and instead initiate a Visit.

Testing
---

Resolve an issue that caused false positives in our test suite when
monitoring whether or not an action triggered a form submission.
