### PR TITLE
Form Encoding

### DIFF
--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -26,7 +26,18 @@
         <input type="hidden" name="status" value="204">
         <input type="submit" style="">
       </form>
+      <form action="/__turbo/redirect" method="post" class="no-enctype">
+        <input type="submit">
+      </form>
+      <form action="/__turbo/redirect" method="post" enctype="multipart/form-data">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
+        <input type="submit">
+      </form>
+      <form action="/__turbo/redirect" method="get" enctype="multipart/form-data">
+        <input type="submit">
+      </form>
     </div>
+    <hr>
     <div id="reject">
       <form class="unprocessable_entity" action="/__turbo/reject" method="post">
         <input type="hidden" name="status" value="422">
@@ -42,6 +53,10 @@
       <form action="/src/tests/fixtures/one.html" method="get">
         <button type="submit" formmethod="post" formaction="/__turbo/redirect"
             name="path" value="/src/tests/fixtures/two.html">Submit</button>
+      </form>
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
+        <input type="submit" formenctype="multipart/form-data">
       </form>
     </div>
     <hr>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -36,6 +36,30 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(htmlAfter, htmlBefore)
   }
 
+  async "test standard POST form submission with multipart/form-data enctype"() {
+    await this.clickSelector("#standard form[method=post][enctype] input[type=submit]")
+    await this.nextBeat
+
+    const enctype = (await this.searchParams).get("enctype")
+    this.assert.ok(enctype?.startsWith("multipart/form-data"), "submits a multipart/form-data request")
+  }
+
+  async "test standard GET form submission ignores enctype"() {
+    await this.clickSelector("#standard form[method=get][enctype] input[type=submit]")
+    await this.nextBeat
+
+    const enctype = (await this.searchParams).get("enctype")
+    this.assert.notOk(enctype, "GET form submissions ignore enctype")
+  }
+
+  async "test standard POST form submission without an enctype"() {
+    await this.clickSelector("#standard form[method=post].no-enctype input[type=submit]")
+    await this.nextBeat
+
+    const enctype = (await this.searchParams).get("enctype")
+    this.assert.ok(enctype?.startsWith("application/x-www-form-urlencoded"), "submits a application/x-www-form-urlencoded request")
+  }
+
   async "test invalid form submission with unprocessable entity status"() {
     await this.clickSelector("#reject form.unprocessable_entity input[type=submit]")
     await this.nextBody
@@ -61,6 +85,14 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/two.html")
     this.assert.equal(await this.visitAction, "advance")
+  }
+
+  async "test submitter POST form submission with multipart/form-data formenctype"() {
+    await this.clickSelector("#submitter form[method=post]:not([enctype]) input[formenctype]")
+    await this.nextBeat
+
+    const enctype = (await this.searchParams).get("enctype")
+    this.assert.ok(enctype?.startsWith("multipart/form-data"), "submits a multipart/form-data request")
   }
 
   async "test frame form submission with redirect response"() {

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -90,6 +90,10 @@ export class FunctionalTestCase extends InternTestCase {
     return this.evaluate(() => location.pathname)
   }
 
+  get searchParams(): Promise<URLSearchParams> {
+    return this.evaluate(() => location.search).then(search => new URLSearchParams(search))
+  }
+
   get hash(): Promise<string> {
     return this.evaluate(() => location.hash)
   }

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1,6 +1,7 @@
 import { Response, Router } from "express"
 import multer from "multer"
 import path from "path"
+import url from "url"
 
 const router = Router()
 const streamResponses: Set<Response> = new Set
@@ -8,8 +9,17 @@ const streamResponses: Set<Response> = new Set
 router.use(multer().none())
 
 router.post("/redirect", (request, response) => {
-  const path = request.body.path ?? "/src/tests/fixtures/one.html"
-  response.redirect(303, path)
+  const pathname = request.body.path ?? "/src/tests/fixtures/one.html"
+  const enctype = request.get("Content-Type")
+  const query = enctype ? { enctype } : {}
+  response.redirect(303, url.format({ pathname, query }))
+})
+
+router.get("/redirect", (request, response) => {
+  const pathname = (request.query as any).path ?? "/src/tests/fixtures/one.html"
+  const enctype = request.get("Content-Type")
+  const query = enctype ? { enctype } : {}
+  response.redirect(301, url.format({ pathname, query }))
 })
 
 router.post("/reject", (request, response) => {


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/76

According to the HTML Specification for [Form Submission Encoding][],
there are three possible values:

* [application/x-www-form-urlencoded][] (the default value)
* [multipart/form-data][]
* [text/plain][]

[Encoding declarations on `<form method="get">` elements are
ignored][get-ignored].

This commit re-structures the `FetchRequest` constructor, and moves the
FormData to URL parameter encoding process _out_ to the `FormSubmission`
itself, since the `HTMLFormElement` knows about its [enctype][] and the
submitter its [formenctype][].

[Form Submission Encoding]: https://www.w3.org/TR/html52/sec-forms.html#selecting-a-form-submission-encoding
[application/x-www-form-urlencoded]: https://www.w3.org/TR/html52/sec-forms.html#selecting-a-form-submission-encoding
[multipart/form-data]: https://www.w3.org/TR/html52/sec-forms.html#multipart-form-data
[text/plain]: https://www.w3.org/TR/html52/sec-forms.html#plain-text-form-data
[enctype]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/enctype
[formenctype]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formenctype
[get-ignored]: https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest#submitting_forms_and_uploading_files
