### PR TITLE
Restore correct Accept header for form submissions

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -104,16 +104,14 @@ export class FormSubmission {
 
   // Fetch request delegate
 
-  additionalHeadersForRequest(request: FetchRequest, headers: { [header: string]: string }) {
-    const additionalHeaders: FetchRequestHeaders = {}
+  prepareHeadersForRequest(headers: FetchRequestHeaders, request: FetchRequest) {
     if (!request.isIdempotent) {
       const token = getCookieValue(getMetaContent("csrf-param")) || getMetaContent("csrf-token")
       if (token) {
-        additionalHeaders["X-CSRF-Token"] = token
+        headers["X-CSRF-Token"] = token
       }
-      additionalHeaders["Accept"] = [ StreamMessage.contentType, headers.Accept ].join(", ")
+      headers["Accept"] = [ StreamMessage.contentType, headers["Accept"] ].join(", ")
     }
-    return additionalHeaders
   }
 
   requestStarted(request: FetchRequest) {

--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -104,16 +104,16 @@ export class FormSubmission {
 
   // Fetch request delegate
 
-  additionalHeadersForRequest(request: FetchRequest) {
-    const headers: FetchRequestHeaders = {}
+  additionalHeadersForRequest(request: FetchRequest, headers: { [header: string]: string }) {
+    const additionalHeaders: FetchRequestHeaders = {}
     if (!request.isIdempotent) {
       const token = getCookieValue(getMetaContent("csrf-param")) || getMetaContent("csrf-token")
       if (token) {
-        headers["X-CSRF-Token"] = token
+        additionalHeaders["X-CSRF-Token"] = token
       }
-      headers["Accept"] = StreamMessage.contentType
+      additionalHeaders["Accept"] = [ StreamMessage.contentType, headers.Accept ].join(", ")
     }
-    return headers
+    return additionalHeaders
   }
 
   requestStarted(request: FetchRequest) {

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -1,5 +1,5 @@
 import { FrameElement, FrameElementDelegate, FrameLoadingStyle } from "../../elements/frame_element"
-import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
+import { FetchMethod, FetchRequest, FetchRequestDelegate, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/appearance_observer"
 import { parseHTMLDocument } from "../../util"
@@ -124,8 +124,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
 
   // Fetch request delegate
 
-  additionalHeadersForRequest(request: FetchRequest) {
-    return { "Turbo-Frame": this.id }
+  prepareHeadersForRequest(headers: FetchRequestHeaders, request: FetchRequest) {
+    headers["Turbo-Frame"] = this.id
   }
 
   requestStarted(request: FetchRequest) {

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -2,7 +2,7 @@ import { FetchResponse } from "./fetch_response"
 import { dispatch } from "../util"
 
 export interface FetchRequestDelegate {
-  additionalHeadersForRequest?(request: FetchRequest, headers: { [header: string]: string }): { [header: string]: string }
+  prepareHeadersForRequest?(headers: FetchRequestHeaders, request: FetchRequest): void
   requestStarted(request: FetchRequest): void
   requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse): void
   requestSucceededWithResponse(request: FetchRequest, response: FetchResponse): void
@@ -117,22 +117,21 @@ export class FetchRequest {
   }
 
   get headers() {
-    const defaultHeaders = { "Accept": "text/html, application/xhtml+xml" }
-    const additionalHeaders = this.additionalHeadersWithDefaults(defaultHeaders)
-
-    return { ...defaultHeaders, ...additionalHeaders }
-  }
-
-  additionalHeadersWithDefaults(defaults: { [header: string]: string }) {
-    if (typeof this.delegate.additionalHeadersForRequest == "function") {
-      return this.delegate.additionalHeadersForRequest(this, { ...defaults })
-    } else {
-      return {}
+    const headers = { ...this.defaultHeaders }
+    if (typeof this.delegate.prepareHeadersForRequest == "function") {
+      this.delegate.prepareHeadersForRequest(headers, this)
     }
+    return headers
   }
 
   get abortSignal() {
     return this.abortController.signal
+  }
+
+  get defaultHeaders() {
+    return {
+      "Accept": "text/html, application/xhtml+xml"
+    }
   }
 }
 

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -2,7 +2,7 @@ import { FetchResponse } from "./fetch_response"
 import { dispatch } from "../util"
 
 export interface FetchRequestDelegate {
-  additionalHeadersForRequest?(request: FetchRequest): { [header: string]: string }
+  additionalHeadersForRequest?(request: FetchRequest, headers: { [header: string]: string }): { [header: string]: string }
   requestStarted(request: FetchRequest): void
   requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse): void
   requestSucceededWithResponse(request: FetchRequest, response: FetchResponse): void
@@ -117,15 +117,15 @@ export class FetchRequest {
   }
 
   get headers() {
-    return {
-      "Accept": "text/html, application/xhtml+xml",
-      ...this.additionalHeaders
-    }
+    const defaultHeaders = { "Accept": "text/html, application/xhtml+xml" }
+    const additionalHeaders = this.additionalHeadersWithDefaults(defaultHeaders)
+
+    return { ...defaultHeaders, ...additionalHeaders }
   }
 
-  get additionalHeaders() {
+  additionalHeadersWithDefaults(defaults: { [header: string]: string }) {
     if (typeof this.delegate.additionalHeadersForRequest == "function") {
-      return this.delegate.additionalHeadersForRequest(this)
+      return this.delegate.additionalHeadersForRequest(this, { ...defaults })
     } else {
       return {}
     }

--- a/src/tests/fixtures/stream.html
+++ b/src/tests/fixtures/stream.html
@@ -7,6 +7,11 @@
     <script>Turbo.connectStreamSource(new EventSource("/__turbo/messages"))</script>
   </head>
   <body>
+    <form id="create" method="post" action="/__turbo/messages">
+      <input type="hidden" name="content" value="Hello world!">
+      <input type="hidden" name="type" value="stream">
+      <button type="submit">Create</button>
+    </form>
     <div id="messages">
       <div class="message">First</div>
     </div>

--- a/src/tests/functional/stream_tests.ts
+++ b/src/tests/functional/stream_tests.ts
@@ -12,21 +12,11 @@ export class StreamTests extends FunctionalTestCase {
     element = await this.querySelector(selector)
     this.assert.equal(await element.getVisibleText(), "First")
 
-    await this.createMessage("Hello world!")
+    await this.clickSelector("#create [type=submit]")
     await this.nextBeat
 
     element = await this.querySelector(selector)
     this.assert.equal(await element.getVisibleText(), "Hello world!")
-  }
-
-  async createMessage(content: string) {
-    return this.post("/__turbo/messages", { content })
-  }
-
-  async post(path: string, params: any = {}) {
-    await this.evaluate((path, method, params) => {
-      fetch(location.origin + path, { method, body: new URLSearchParams(params) })
-    }, path, "POST", params)
   }
 }
 


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/141.
Follows-up https://github.com/hotwired/turbo/pull/52.

---

When creating the headers for a `FetchRequest`, provide the default
headers to the delegate by adding an argument to the
`additionalHeadersForRequest` signature so that delegates can
incorporate the current values if they choose to. They're passed as a
copy to prevent delegates from destructively acting upon them, with the
intention that delegates merge values _into_ them.

Testing
---

Add a guard middleware to the test server to reject _all_ requests that
don't specify an [Accept][] header containing `"text/html,
application/xhtml+xml"`.

Next, guard Stream requests with a similar check for
`"text/vnd.turbo-stream.html"`. Since those endpoints are behind the
guard middleware, they'll also require `"text/html,
application/xhtml+xml"` as well.

Finally, replace the Stream functional test's explicit call to `fetch`
with a `<form>` element submitting with the same content.

[Accept]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept