### PR TITLE
Expand rendering capabilities of `<turbo-frame>`

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -1,7 +1,7 @@
 import { FetchRequest, FetchMethod, fetchMethodFromString, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { expandURL } from "../url"
-import { dispatch } from "../../util"
+import { clearBusyState, dispatch, markAsBusy } from "../../util"
 import { StreamMessage } from "../streams/stream_message"
 
 export interface FormSubmissionDelegate {
@@ -146,6 +146,7 @@ export class FormSubmission {
 
   requestStarted(request: FetchRequest) {
     this.state = FormSubmissionState.waiting
+    markAsBusy(this.formElement)
     this.submitter?.setAttribute("disabled", "")
     dispatch("turbo:submit-start", { target: this.formElement, detail: { formSubmission: this } })
     this.delegate.formSubmissionStarted(this)
@@ -181,6 +182,7 @@ export class FormSubmission {
   requestFinished(request: FetchRequest) {
     this.state = FormSubmissionState.stopped
     this.submitter?.removeAttribute("disabled")
+    clearBusyState(this.formElement)
     dispatch("turbo:submit-end", { target: this.formElement, detail: { formSubmission: this, ...this.result }})
     this.delegate.formSubmissionFinished(this)
   }

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -1,10 +1,9 @@
-import { Action, isAction } from "../types"
+import { Action } from "../types"
 import { FetchMethod } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { FormSubmission } from "./form_submission"
 import { expandURL, getAnchor, getRequestURL, Locatable, locationIsVisitable } from "../url"
-import { getAttribute } from "../../util"
-import { Visit, VisitDelegate, VisitOptions } from "./visit"
+import { Visit, VisitDelegate, VisitOptions, getVisitAction } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
@@ -157,9 +156,7 @@ export class Navigator {
     return this.history.restorationIdentifier
   }
 
-  getActionForFormSubmission(formSubmission: FormSubmission): Action {
-    const { formElement, submitter } = formSubmission
-    const action = getAttribute("data-turbo-action", submitter, formElement)
-    return isAction(action) ? action : "advance"
+  getActionForFormSubmission({ formElement, submitter }: FormSubmission): Action {
+    return getVisitAction(submitter, formElement) || "advance"
   }
 }

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -2,6 +2,13 @@ import { Renderer } from "../renderer"
 import { PageSnapshot } from "./page_snapshot"
 
 export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
+  private readonly willRender: boolean
+
+  constructor(currentSnapshot: PageSnapshot, newSnapshot: PageSnapshot, isPreview: boolean, willRender = true) {
+    super(currentSnapshot, newSnapshot, isPreview)
+    this.willRender = willRender
+  }
+
   get shouldRender() {
     return this.newSnapshot.isVisitable && this.trackedElementsAreIdentical
   }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -5,8 +5,8 @@ import { History } from "./history"
 import { getAnchor } from "../url"
 import { Snapshot } from "../snapshot"
 import { PageSnapshot } from "./page_snapshot"
-import { Action } from "../types"
-import { uuid } from "../../util"
+import { Action, isAction } from "../types"
+import { getAttribute, uuid } from "../../util"
 import { PageView } from "./page_view"
 
 export interface VisitDelegate {
@@ -417,6 +417,12 @@ export class Visit implements FetchRequestDelegate {
       delete this.frame
     }
   }
+}
+
+export function getVisitAction(...elements: (Element|undefined)[]): Action | null {
+  const action = getAttribute("data-turbo-action", ...elements)
+
+  return isAction(action) ? action : null
 }
 
 function isSuccessful(statusCode: number) {

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -108,7 +108,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
       if (html) {
         const { body } = parseHTMLDocument(html)
         const snapshot = new Snapshot(await this.extractForeignFrameElement(body))
-        const renderer = new FrameRenderer(this.view.snapshot, snapshot, false, false)
+        const renderer = new FrameRenderer(this.view.snapshot, snapshot, false)
         if (this.view.renderPromise) await this.view.renderPromise
         await this.view.render(renderer)
         session.frameRendered(fetchResponse, this.element)

--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -2,6 +2,7 @@ import { FormInterceptor, FormInterceptorDelegate } from "./form_interceptor"
 import { FrameElement } from "../../elements/frame_element"
 import { LinkInterceptor, LinkInterceptorDelegate } from "./link_interceptor"
 import { expandURL, getAction, locationIsVisitable } from "../url"
+import { FrameVisit } from "./frame_visit"
 
 export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptorDelegate {
   readonly element: Element
@@ -31,7 +32,8 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
   linkClickIntercepted(element: Element, url: string) {
     const frame = this.findFrameElement(element)
     if (frame) {
-      frame.delegate.linkClickIntercepted(element, url)
+      frame.setAttribute("reloadable", "")
+      frame.delegate.visit(FrameVisit.optionsForClick(element, url))
     }
   }
 
@@ -43,7 +45,7 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
     const frame = this.findFrameElement(element, submitter)
     if (frame) {
       frame.removeAttribute("reloadable")
-      frame.delegate.formSubmissionIntercepted(element, submitter)
+      frame.delegate.submit(FrameVisit.optionsForSubmit(element, submitter))
     }
   }
 

--- a/src/core/frames/frame_visit.ts
+++ b/src/core/frames/frame_visit.ts
@@ -1,0 +1,144 @@
+import { expandURL } from "../url"
+import { Action } from "../types"
+import { getVisitAction } from "../drive/visit"
+import { FrameElement } from "../../elements/frame_element"
+import { FetchRequest, FetchRequestHeaders, FetchRequestDelegate, FetchMethod } from "../../http/fetch_request"
+import { FetchResponse } from "../../http/fetch_response"
+import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
+
+export interface FrameVisitOptions {
+  action: Action | null,
+  submit: { form: HTMLFormElement, submitter?: HTMLElement },
+  url: string,
+}
+
+export interface FrameVisitDelegate {
+  shouldVisit(frameVisit: FrameVisit): boolean
+  visitStarted(frameVisit: FrameVisit): void
+  visitSucceeded(frameVisit: FrameVisit, response: FetchResponse): void
+  visitFailed(frameVisit: FrameVisit, response: FetchResponse): void
+  visitErrored(frameVisit: FrameVisit, error: Error): void
+  visitCompleted(frameVisit: FrameVisit): void
+}
+
+export class FrameVisit implements FetchRequestDelegate, FormSubmissionDelegate {
+  readonly delegate: FrameVisitDelegate
+  readonly element: FrameElement
+  readonly action: Action | null
+  readonly previousURL: string | null
+  readonly options: Partial<FrameVisitOptions>
+  readonly isFormSubmission: boolean = false
+
+  private readonly fetchRequest?: FetchRequest
+  private readonly formSubmission?: FormSubmission
+  private resolveVisitPromise = () => {}
+
+  static optionsForClick(element: Element, url: string): Partial<FrameVisitOptions> {
+    const action = getVisitAction(element)
+
+    return { action, url }
+  }
+
+  static optionsForSubmit(form: HTMLFormElement, submitter?: HTMLElement): Partial<FrameVisitOptions> {
+    const action = getVisitAction(form, submitter)
+
+    return { action, submit: { form, submitter } }
+  }
+
+  constructor(delegate: FrameVisitDelegate, element: FrameElement, options: Partial<FrameVisitOptions> = {}) {
+    this.delegate = delegate
+    this.element = element
+    this.previousURL = this.element.src
+    const { action, url, submit } = this.options = options
+
+    this.action = action || getVisitAction(this.element)
+    if (url) {
+      this.fetchRequest = new FetchRequest(this, FetchMethod.get, expandURL(url), new URLSearchParams, this.element)
+    } else if (submit) {
+      const { fetchRequest } = this.formSubmission = new FormSubmission(this, submit.form, submit.submitter)
+      this.prepareHeadersForRequest(fetchRequest.headers)
+      this.isFormSubmission = true
+    }
+  }
+
+  async start() {
+    if (this.delegate.shouldVisit(this)) {
+      if (this.formSubmission) {
+        await this.formSubmission.start()
+      } else {
+        await this.performRequest()
+      }
+    }
+  }
+
+  stop() {
+    this.fetchRequest?.cancel()
+    this.formSubmission?.stop()
+  }
+
+  // Fetch request delegate
+
+  prepareHeadersForRequest(headers: FetchRequestHeaders) {
+    headers["Turbo-Frame"] = this.element.id
+  }
+
+  requestStarted(request: FetchRequest) {
+    this.delegate.visitStarted(this)
+  }
+
+  requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse) {
+    this.resolveVisitPromise()
+  }
+
+  requestFinished(request: FetchRequest) {
+    this.delegate.visitCompleted(this)
+  }
+
+  async requestSucceededWithResponse(fetchRequest: FetchRequest, fetchResponse: FetchResponse) {
+    await this.delegate.visitSucceeded(this, fetchResponse)
+    this.resolveVisitPromise()
+  }
+
+  async requestFailedWithResponse(request: FetchRequest, fetchResponse: FetchResponse) {
+    console.error(fetchResponse)
+    await this.delegate.visitFailed(this, fetchResponse)
+    this.resolveVisitPromise()
+  }
+
+  requestErrored(request: FetchRequest, error: Error) {
+    this.delegate.visitErrored(this, error)
+    this.resolveVisitPromise()
+  }
+
+  // Form submission delegate
+
+  formSubmissionStarted({ fetchRequest }: FormSubmission) {
+    this.requestStarted(fetchRequest)
+  }
+
+  async formSubmissionSucceededWithResponse({ fetchRequest }: FormSubmission, response: FetchResponse) {
+    await this.requestSucceededWithResponse(fetchRequest, response)
+  }
+
+  async formSubmissionFailedWithResponse({ fetchRequest }: FormSubmission, fetchResponse: FetchResponse) {
+    await this.requestFailedWithResponse(fetchRequest, fetchResponse)
+  }
+
+  formSubmissionErrored({ fetchRequest }: FormSubmission, error: Error) {
+    this.requestErrored(fetchRequest, error)
+  }
+
+  formSubmissionFinished({ fetchRequest }: FormSubmission) {
+    this.requestFinished(fetchRequest)
+  }
+
+  private performRequest() {
+    this.element.loaded = new Promise<void>(resolve => {
+      this.resolveVisitPromise = () => {
+        this.resolveVisitPromise = () => {}
+        resolve()
+      }
+      this.fetchRequest?.perform()
+    })
+  }
+}

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -10,15 +10,13 @@ export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapsh
   readonly currentSnapshot: S
   readonly newSnapshot: S
   readonly isPreview: boolean
-  readonly willRender: boolean
   readonly promise: Promise<void>
   private resolvingFunctions?: ResolvingFunctions<void>
 
-  constructor(currentSnapshot: S, newSnapshot: S, isPreview: boolean, willRender = true) {
+  constructor(currentSnapshot: S, newSnapshot: S, isPreview: boolean) {
     this.currentSnapshot = currentSnapshot
     this.newSnapshot = newSnapshot
     this.isPreview = isPreview
-    this.willRender = willRender
     this.promise = new Promise((resolve, reject) => this.resolvingFunctions = { resolve, reject })
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -11,10 +11,10 @@ import { PageObserver, PageObserverDelegate } from "../observers/page_observer"
 import { ScrollObserver } from "../observers/scroll_observer"
 import { StreamMessage } from "./streams/stream_message"
 import { StreamObserver } from "../observers/stream_observer"
-import { Action, Position, StreamSource, isAction } from "./types"
+import { Action, Position, StreamSource } from "./types"
 import { clearBusyState, dispatch, markAsBusy } from "../util"
 import { PageView, PageViewDelegate } from "./drive/page_view"
-import { Visit, VisitOptions } from "./drive/visit"
+import { Visit, VisitOptions, getVisitAction } from "./drive/visit"
 import { PageSnapshot } from "./drive/page_snapshot"
 import { FrameElement } from "../elements/frame_element"
 import { FetchResponse } from "../http/fetch_response"
@@ -344,8 +344,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   // Private
 
   getActionForLink(link: Element): Action {
-    const action = link.getAttribute("data-turbo-action")
-    return isAction(action) ? action : "advance"
+    return getVisitAction(link) || "advance"
   }
 
   getTargetFrameForLink(link: Element) {

--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -1,12 +1,41 @@
-import { StreamElement } from "../../elements/stream_element"
+export type StreamRenderable = {
+  targetElements: Element[],
+  templateContent: DocumentFragment,
+  removeDuplicates: boolean,
+}
 
-export const StreamActions: { [action: string]: (this: StreamElement) => void } = {
+export enum StreamAction {
+  after = "after",
+  append = "append",
+  before = "before",
+  prepend = "prepend",
+  remove = "remove",
+  replace = "replace",
+  update = "update",
+  default = update,
+}
+
+export function streamActionFromString(action: string | null): StreamAction | null {
+  switch (action?.toLowerCase()) {
+    case "after":   return StreamAction.after
+    case "append":  return StreamAction.append
+    case "before":  return StreamAction.before
+    case "prepend": return StreamAction.prepend
+    case "remove":  return StreamAction.remove
+    case "replace": return StreamAction.replace
+    default:        return null
+  }
+}
+
+export const StreamActions: { [action: string]: (this: StreamRenderable) => void } = {
   after() {
     this.targetElements.forEach(e => e.parentElement?.insertBefore(this.templateContent, e.nextSibling))
   },
 
   append() {
-    this.removeDuplicateTargetChildren()
+    if (this.removeDuplicates) {
+      removeDuplicateTargetChildren(this)
+    }
     this.targetElements.forEach(e => e.append(this.templateContent))
   },
 
@@ -15,7 +44,9 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
   },
 
   prepend() {
-    this.removeDuplicateTargetChildren()
+    if (this.removeDuplicates) {
+      removeDuplicateTargetChildren(this)
+    }
     this.targetElements.forEach(e => e.prepend(this.templateContent))
   },
 
@@ -28,9 +59,26 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
   },
 
   update() {
-    this.targetElements.forEach(e => { 
+    this.targetElements.forEach(e => {
       e.innerHTML = ""
       e.append(this.templateContent)
     })
   }
+}
+
+/**
+  * Removes duplicate children (by ID)
+  */
+const removeDuplicateTargetChildren = (streamRenderable: StreamRenderable) => {
+  duplicateChildren(streamRenderable).forEach(c => c.remove())
+}
+
+/**
+  * Gets the list of duplicate children (i.e. those with the same ID)
+  */
+const duplicateChildren = ({ targetElements, templateContent }: StreamRenderable) => {
+  const existingChildren = targetElements.flatMap(e => [...e.children]).filter(c => !!c.id)
+  const newChildrenIds   = [...templateContent?.children].filter(c => !!c.id).map(c => c.id)
+
+  return existingChildren.filter(c => newChildrenIds.includes(c.id))
 }

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -1,3 +1,4 @@
+import { StreamAction, streamActionFromString } from "../core/streams/stream_actions"
 import { FetchResponse } from "../http/fetch_response"
 import { FrameVisitOptions } from "../core/frames/frame_visit"
 
@@ -66,6 +67,26 @@ export class FrameElement extends HTMLElement {
       this.delegate.sourceURLChanged()
     } else {
       this.delegate.disabledChanged()
+    }
+  }
+
+  /**
+   * Gets the action the frame will render its changes with from the `rendering`
+   * HTML attribute. Defaults to "update" when the attribute is missing.
+   */
+  get rendering(): StreamAction {
+    return streamActionFromString(this.getAttribute("rendering")) || StreamAction.default
+  }
+
+  /**
+   * Sets the action the frame will render its changes with. Defaults to
+   * "update" when the value is null.
+   */
+  set rendering(value: StreamAction) {
+    if (value) {
+      this.setAttribute("rendering", value)
+    } else {
+      this.removeAttribute("rendering")
     }
   }
 

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -1,4 +1,5 @@
 import { FetchResponse } from "../http/fetch_response"
+import { FrameVisitOptions } from "../core/frames/frame_visit"
 
 export enum FrameLoadingStyle { eager = "eager", lazy = "lazy" }
 
@@ -8,10 +9,8 @@ export interface FrameElementDelegate {
   loadingStyleChanged(): void
   sourceURLChanged(): void
   disabledChanged(): void
-  formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement): void
-  linkClickIntercepted(element: Element, url: string): void
-  loadResponse(response: FetchResponse): void
-  fetchResponseLoaded: (fetchResponse: FetchResponse) => void
+  visit(options: Partial<FrameVisitOptions>): void
+  submit(options: Partial<FrameVisitOptions>): void
   isLoading: boolean
 }
 

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -1,4 +1,4 @@
-import { StreamActions } from "../core/streams/stream_actions"
+import { StreamActions, StreamRenderable } from "../core/streams/stream_actions"
 import { nextAnimationFrame } from "../util"
 
 // <turbo-stream action=replace target=id><template>...
@@ -23,7 +23,7 @@ import { nextAnimationFrame } from "../util"
  *     </template>
  *   </turbo-stream>
  */
-export class StreamElement extends HTMLElement {
+export class StreamElement extends HTMLElement implements StreamRenderable {
   async connectedCallback() {
     try {
       await this.render()
@@ -48,24 +48,6 @@ export class StreamElement extends HTMLElement {
   disconnect() {
     try { this.remove() } catch {}
   }
- 
-  /**
-   * Removes duplicate children (by ID)
-   */
-  removeDuplicateTargetChildren() {
-    this.duplicateChildren.forEach(c => c.remove())
-  }
-  
-  /**
-   * Gets the list of duplicate children (i.e. those with the same ID)
-   */
-  get duplicateChildren() {
-    const existingChildren = this.targetElements.flatMap(e => [...e.children]).filter(c => !!c.id)
-    const newChildrenIds   = [...this.templateContent?.children].filter(c => !!c.id).map(c => c.id)
-  
-    return existingChildren.filter(c => newChildrenIds.includes(c.id))
-  }
-  
 
   /**
    * Gets the action function to be performed.
@@ -131,6 +113,10 @@ export class StreamElement extends HTMLElement {
    */
   get targets() {
     return this.getAttribute("targets")
+  }
+
+  get removeDuplicates() {
+    return true
   }
 
   private raise(message: string): never {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -31,8 +31,11 @@
       <a id="link-frame" href="/src/tests/fixtures/frames/frame.html">Navigate #frame from within</a>
       <a id="link-frame-with-search-params" href="/src/tests/fixtures/frames/frame.html?key=value">Navigate #frame with ?key=value</a>
       <a id="link-nested-frame-action-advance" href="/src/tests/fixtures/frames/frame.html" data-turbo-action="advance">Navigate #frame from within with a[data-turbo-action="advance"]</a>
+      <a id="inside-frame-500" href="/__turbo/internal_server_error">inside #frame: 500</a>
     </turbo-frame>
     <a id="outside-frame-form" href="/src/tests/fixtures/frames/form.html" data-turbo-frame="frame">Navigate #frame to /frames/form.html</a>
+    <a id="outside-frame-500" href="/__turbo/internal_server_error" data-turbo-frame="frame">outside #frame: 500</a>
+
 
     <a id="link-outside-frame-action-advance" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-action="advance">Navigate #frame from outside with a[data-turbo-action="advance"]</a>
     <form id="form-get-frame-action-advance" action="/__turbo/redirect" data-turbo-frame="frame" data-turbo-action="advance">

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -43,9 +43,31 @@
     </section>
     <div id="permanent" data-turbo-permanent>Rendering</div>
 
-    <turbo-frame id="frame">
-      <div id="permanent-in-frame" data-turbo-permanent>Rendering</div>
-    </turbo-frame>
+    <div id="frame-rendering">
+      <turbo-frame id="frame">
+        <div id="permanent-in-frame" data-turbo-permanent>Rendering</div>
+      </turbo-frame>
+
+      <a id="outside-frame" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame">Load #frame</a>
+      <a id="frame-after" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-rendering="after">Load #frame with data-turbo-rendering="after"</a>
+      <a id="frame-append" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-rendering="append">Load #frame with data-turbo-rendering="append"</a>
+      <a id="frame-before" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-rendering="before">Load #frame with data-turbo-rendering="before"</a>
+      <a id="frame-prepend" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-rendering="prepend">Load #frame with data-turbo-rendering="prepend"</a>
+      <a id="frame-remove" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-rendering="remove">Load #frame with data-turbo-rendering="remove"</a>
+      <a id="frame-replace" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-rendering="replace">Load #frame with data-turbo-rendering="replace"</a>
+      <a id="frame-update" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-rendering="update">Load #frame with data-turbo-rendering="update"</a>
+
+      <form action="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame" data-turbo-rendering="prepend">
+        <button id="frame-form-get-prepend">Load #frame with button from form[method="get"][data-turbo-rendering="prepend"]</button>
+        <button id="frame-form-get-append" data-turbo-rendering="append">Load #frame with button[data-turbo-rendering="append"] from form[method="get"][data-turbo-rendering="prepend"]</button>
+      </form>
+
+      <form method="post" action="/__turbo/redirect" data-turbo-frame="frame" data-turbo-rendering="prepend">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+        <button id="frame-form-post-prepend">Load #frame with button from form[method="post"][data-turbo-rendering="prepend"]</button>
+        <button id="frame-form-post-append" data-turbo-rendering="append">Load #frame with button[data-turbo-rendering="append"] from form[method="post"][data-turbo-rendering="prepend"]</button>
+      </form>
+    </div>
 
     <video id="permanent-video" data-turbo-permanent>
       <source src="/src/tests/fixtures/video.webm" type="video/webm">

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -53,6 +53,22 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.equal(otherEvents.length, 0, "no more events")
   }
 
+  async "test following a link within a frame renders an error response"() {
+    await this.clickSelector("#inside-frame-500")
+    await this.nextBeat
+
+    const title = await this.querySelector("#frame h2")
+    this.assert.equal(await title.getVisibleText(), "Frame: Internal Server Error")
+  }
+
+  async "test following a link targetting a frame renders an error response"() {
+    await this.clickSelector("#outside-frame-500")
+    await this.nextBeat
+
+    const title = await this.querySelector("#frame h2")
+    this.assert.equal(await title.getVisibleText(), "Frame: Internal Server Error")
+  }
+
   async "test following a link driving a frame toggles the [aria-busy=true] attribute"() {
     await this.clickSelector("#hello a")
 

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -208,6 +208,166 @@ export class RenderingTests extends TurboDriveTestCase {
     await this.goBack()
   }
 
+  async "test frame with rendering=after inserts the contents after the frame"() {
+    await this.remote.execute(() => document.getElementById("frame")?.setAttribute("rendering", "after"))
+    await this.clickSelector("#outside-frame")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame"), "Rendering", "preserves frame contents")
+    this.assert.equal(await this.getVisibleText("#frame ~ h2"), "Frame: Loaded", "inserts contents after frame")
+  }
+
+  async "test frame with rendering=append appends the contents"() {
+    await this.remote.execute(() => document.getElementById("frame")?.setAttribute("rendering", "append"))
+    await this.clickSelector("#outside-frame")
+    await this.nextBeat
+
+    this.assert.ok(await this.hasSelector("#frame"), "preserves existing frame")
+    this.assert.equal(await this.getVisibleText("#frame :first-child"), "Rendering")
+    this.assert.equal(await this.getVisibleText("#frame :last-child"), "Frame: Loaded")
+  }
+
+  async "test frame with rendering=before inserts the contents before the frame"() {
+    await this.remote.execute(() => document.getElementById("frame")?.setAttribute("rendering", "before"))
+    await this.clickSelector("#outside-frame")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame-rendering :first-child"), "Frame: Loaded", "inserts contents before frame")
+    this.assert.equal(await this.getVisibleText("#frame"), "Rendering", "preserves frame contents")
+  }
+
+  async "test frame with rendering=prepend prepends the contents"() {
+    await this.remote.execute(() => document.getElementById("frame")?.setAttribute("rendering", "prepend"))
+    await this.clickSelector("#outside-frame")
+    await this.nextBeat
+
+    this.assert.ok(await this.hasSelector("#frame"), "preserves existing frame")
+    this.assert.equal(await this.getVisibleText("#frame :first-child"), "Frame: Loaded")
+    this.assert.equal(await this.getVisibleText("#frame :last-child"), "Rendering")
+  }
+
+  async "test frame with rendering=remove removes the element"() {
+    await this.remote.execute(() => document.getElementById("frame")?.setAttribute("rendering", "remove"))
+    await this.clickSelector("#outside-frame")
+    await this.nextBeat
+
+    this.assert.notOk(await this.hasSelector("#frame"), "removes existing frame")
+    this.assert.ok(await this.hasSelector("#outside-frame"), "does not navigate page")
+  }
+
+  async "test frame with rendering=replace sets outerHTML"() {
+    await this.remote.execute(() => document.getElementById("frame")?.setAttribute("rendering", "replace"))
+    await this.clickSelector("#outside-frame")
+    await this.nextBeat
+
+    this.assert.notOk(await this.hasSelector("#frame"), "removes existing frame")
+    this.assert.equal(await this.getVisibleText("#frame-rendering :first-child"), "Frame: Loaded")
+  }
+
+  async "test frame without action defaults to rendering=update"() {
+    await this.remote.execute(() => document.getElementById("frame")?.removeAttribute("action"))
+    await this.clickSelector("#outside-frame")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame"), "Frame: Loaded")
+  }
+
+  async "test frame with rendering=update sets innerHTML"() {
+    await this.remote.execute(() => document.getElementById("frame")?.setAttribute("rendering", "update"))
+    await this.clickSelector("#outside-frame")
+    await this.nextBeat
+
+    this.assert.ok(await this.hasSelector("#frame"))
+    this.assert.equal(await this.getVisibleText("#frame"), "Frame: Loaded")
+  }
+
+  async "test link with data-turbo-rendering=after inserts the contents after the frame"() {
+    await this.clickSelector("#frame-after")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame"), "Rendering", "preserves frame contents")
+    this.assert.equal(await this.getVisibleText("#frame ~ h2"), "Frame: Loaded", "inserts contents after frame")
+  }
+
+  async "test link with data-turbo-rendering=append appends the contents"() {
+    await this.clickSelector("#frame-append")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame :first-child"), "Rendering")
+    this.assert.equal(await this.getVisibleText("#frame :last-child"), "Frame: Loaded")
+  }
+
+  async "test link with data-turbo-rendering=before inserts the contents before the frame"() {
+    await this.clickSelector("#frame-before")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame-rendering :first-child"), "Frame: Loaded", "inserts contents before frame")
+    this.assert.equal(await this.getVisibleText("#frame"), "Rendering", "preserves frame contents")
+  }
+
+  async "test link with data-turbo-rendering=prepend prepends the contents"() {
+    await this.clickSelector("#frame-prepend")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame :first-child"), "Frame: Loaded")
+    this.assert.equal(await this.getVisibleText("#frame :last-child"), "Rendering")
+  }
+
+  async "test link with data-turbo-rendering=remove removes the element"() {
+    await this.clickSelector("#frame-remove")
+    await this.nextBeat
+
+    this.assert.notOk(await this.hasSelector("#frame"), "removes existing frame")
+    this.assert.ok(await this.hasSelector("#frame-remove"), "does not navigate the page")
+  }
+
+  async "test link with data-turbo-rendering=replace sets outerHTML"() {
+    await this.clickSelector("#frame-replace")
+    await this.nextBeat
+
+    this.assert.notOk(await this.hasSelector("#frame"), "removes existing frame")
+    this.assert.equal(await this.getVisibleText("#frame-rendering :first-child"), "Frame: Loaded")
+  }
+
+  async "test link with data-turbo-rendering=update sets innerHTML"() {
+    await this.clickSelector("#frame-update")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame"), "Frame: Loaded")
+  }
+
+  async "test form[method=get][data-turbo-rendering=prepend] prepends the contents"() {
+    await this.clickSelector("#frame-form-get-prepend")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame :first-child"), "Frame: Loaded")
+    this.assert.equal(await this.getVisibleText("#frame :last-child"), "Rendering")
+  }
+
+  async "test form[method=post][data-turbo-rendering=prepend] prepends the contents"() {
+    await this.clickSelector("#frame-form-post-prepend")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame :first-child"), "Frame: Loaded")
+    this.assert.equal(await this.getVisibleText("#frame :last-child"), "Rendering")
+  }
+
+  async "test form[method=get] with button[data-turbo-rendering=append] appends the contents"() {
+    await this.clickSelector("#frame-form-get-append")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame :first-child"), "Rendering")
+    this.assert.equal(await this.getVisibleText("#frame :last-child"), "Frame: Loaded")
+  }
+
+  async "test form[method=post] with button[data-turbo-rendering=append] appends the contents"() {
+    await this.clickSelector("#frame-form-post-append")
+    await this.nextBeat
+
+    this.assert.equal(await this.getVisibleText("#frame :first-child"), "Rendering")
+    this.assert.equal(await this.getVisibleText("#frame :last-child"), "Frame: Loaded")
+  }
+
   get assetElements(): Promise<Element[]> {
     return filter(this.headElements, isAssetElement)
   }

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -62,6 +62,10 @@ export class FunctionalTestCase extends InternTestCase {
     return (await this.remote.findByCssSelector(selector)).click()
   }
 
+  async getVisibleText(selector: string): Promise<string> {
+    return this.querySelector(selector).then(element => element.getVisibleText())
+  }
+
   async scrollToSelector(selector: string): Promise<void> {
     const element = await this.remote.findByCssSelector(selector)
     return this.evaluate(element => element.scrollIntoView(), element)

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -51,6 +51,13 @@ router.post("/reject", (request, response) => {
   response.status(parseInt(status || "422", 10)).sendFile(fixture)
 })
 
+router.get("/internal_server_error", (request, response) => {
+  const status = request.params.status || "500"
+  const fixture = path.join(__dirname, `../../src/tests/fixtures/${status}.html`)
+
+  response.status(parseInt(status, 10)).sendFile(fixture)
+})
+
 router.get("/headers", (request, response) => {
   const template = fs.readFileSync("src/tests/fixtures/headers.html").toString()
   response.type("html").status(200).send(template.replace('$HEADERS', JSON.stringify(request.headers, null, 4)))


### PR DESCRIPTION
Note:
---

**This PR depends on the `FrameVisit` extraction introduced in https://github.com/hotwired/turbo/pull/430.**

When reviewing the code and comparing the diffs, the first commit should be ignored: https://github.com/seanpdoyle/turbo/compare/frame-visit-delegate...seanpdoyle:frame-action-with-visit?expand=1

Problem
---

Navigating a `<turbo-frame>` element always renders the new content by
updating the contents with the children from the response. This limits
the utility of `<turbo-frame>` in scenarios involving pagination driven
by "next" and "previous" page links.

Solution
---

Add support for `<turbo-frame rendering="...">`, `<a
data-turbo-rendering="...">`, `<form data-turbo-rendering="...">`, and
`<button data-turbo-rendering="...">` where the value of `[rendering]`
and `[data-turbo-rendering]` is one of the values that `<turbo-stream
action="...">` supports.

By default, `<turbo-frame>` elements will continue to render render with
the behavior equivalent to a `<turbo-stream action="update">` element.

This commit extends that support to also include the other actions:

* `after` will insert the contents of the response frame after the
  request frame
* `append` will extract the contents out of the response frame and
  append them into the request frame
* `before` will insert the contents of the response frame before the
  request frame
* `prepend` will extract the contents out of the response frame and
  append them into the request frame
* `replace` will extract the contents out of the response frame, remove
  the request frame, and inject the extracted contents in its place
  (conceptually similar to setting `outerHTML`)
* `remove` will remove the request frame, and ignore the contents of the
  response frame

This enables behaviors that might have been achievable with
`GET`-request powered Turbo Stream responses.

For example, in-place pagination could be achieved with
`rendering="prepend"` or `rendering="append"`:

```html
<!-- current HTML -->
<turbo-frame id="posts">
  <article id="article_1"><!-- contents --></article>
  <!-- articles 2-9 -->
  <article id="article_10"><!-- contents --></article>

  <a href="/posts?page=2" data-turbo-rendering="append">Next page</a>
</turbo-frame>

<!-- response HTML -->
<turbo-frame id="posts">
  <article id="article_11"><!-- contents --></article>

  <a href="/posts?page=3" data-turbo-rendering="append">Next page</a>
</turbo-frame>

<!-- HTML after the request -->
<turbo-frame id="posts">
  <article id="article_1"><!-- contents --></article>
  <!-- articles 2-9 -->
  <article id="article_10"><!-- contents --></article>
  <a href="/posts?page=2" data-turbo-rendering="append">Next page</a>
  <article id="article_11"><!-- contents --></article>

  <a href="/posts?page=3" data-turbo-rendering="append">Next page</a>
</turbo-frame>
```

Through the power of a CSS rules utilizing `:last-of-type`, we can hide
the pagination links:

```css
  #posts a              { display: none; }
  #posts a:last-of-type { display: block; }
```