### PR TITLE
turbo-frame[busy] attribute

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -186,7 +186,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   // Form submission delegate
 
   formSubmissionStarted(formSubmission: FormSubmission) {
-
+    const frame = this.findFrameElement(formSubmission.formElement)
+    frame.setAttribute("busy", "")
   }
 
   formSubmissionSucceededWithResponse(formSubmission: FormSubmission, response: FetchResponse) {
@@ -203,7 +204,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {
-
+    const frame = this.findFrameElement(formSubmission.formElement)
+    frame.removeAttribute("busy")
   }
 
   // View delegate

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -115,8 +115,13 @@
     </div>
     <hr>
     <div id="targets-frame">
-      <form action="/__turbo/redirect" method="post" data-turbo-frame="frame">
+      <form action="/__turbo/redirect" method="post" data-turbo-frame="frame" class="one">
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <button type="submit">Submit</button>
+      </form>
+
+      <form action="/__turbo/redirect" method="post" data-turbo-frame="frame" class="frame">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
         <button type="submit">Submit</button>
       </form>
     </div>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -9,7 +9,15 @@
   function eventListener(event) {
     eventLogs.push([event.type, event.detail])
   }
+  window.mutationLogs = []
 
+   new MutationObserver((mutations) => {
+     for (const { attributeName, target } of mutations.filter(({ type }) => type == "attributes")) {
+       if (target instanceof Element) {
+         mutationLogs.push([attributeName, target.id, target.getAttribute(attributeName)])
+       }
+     }
+   }).observe(document, { subtree: true, childList: true, attributes: true })
 })([
   "turbo:before-cache",
   "turbo:before-render",

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -185,6 +185,23 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await this.attributeForSelector("#frame", "src"), url.href, "redirects the target frame")
   }
 
+  async "test frame form submission toggles the ancestor frame's [busy] attribute"() {
+    await this.clickSelector("#frame form.redirect input[type=submit]")
+
+    this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), "", "sets [busy] on the #frame")
+    this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), null, "removes [busy] from the #frame")
+  }
+
+  async "test frame form submission toggles the target frame's [busy] attribute"() {
+    await this.clickSelector('#targets-frame form.frame [type="submit"]')
+
+    this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), "", "sets [busy] on the #frame")
+
+    const title = await this.querySelector("#frame h2")
+    this.assert.equal(await title.getVisibleText(), "Frame: Loaded")
+    this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), null, "removes [busy] from the #frame")
+  }
+
   async "test frame form submission with empty created response"() {
     const htmlBefore = await this.outerHTMLForSelector("#frame")
     const button = await this.querySelector("#frame form.created input[type=submit]")
@@ -300,7 +317,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
   async "test form submission targets disabled frame"() {
     this.remote.execute(() => document.getElementById("frame")?.setAttribute("disabled", ""))
-    await this.clickSelector('#targets-frame [type="submit"]')
+    await this.clickSelector('#targets-frame form.one [type="submit"]')
     await this.nextBody
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -25,6 +25,13 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.equal(otherEvents.length, 0, "no more events")
   }
 
+  async "test following a link driving a frame toggles the [busy] attribute"() {
+    await this.clickSelector("#hello a")
+
+    this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), "", "sets [busy] on the #frame")
+    this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), null, "removes [busy] from the #frame")
+  }
+
   async "test following a link to a page without a matching frame results in an empty frame"() {
     await this.clickSelector("#missing a")
     await this.nextBeat

--- a/src/tests/helpers/turbo_drive_test_case.ts
+++ b/src/tests/helpers/turbo_drive_test_case.ts
@@ -3,9 +3,11 @@ import { RemoteChannel } from "./remote_channel"
 import { Element } from "@theintern/leadfoot"
 
 type EventLog = [string, any]
+type MutationLog = [string, string | null, string | null]
 
 export class TurboDriveTestCase extends FunctionalTestCase {
   eventLogChannel: RemoteChannel<EventLog> = new RemoteChannel(this.remote, "eventLogs")
+  mutationLogChannel: RemoteChannel<MutationLog> = new RemoteChannel(this.remote, "mutationLogs")
   lastBody?: Element
 
   async beforeTest() {
@@ -36,6 +38,16 @@ export class TurboDriveTestCase extends FunctionalTestCase {
   async noNextEventNamed(eventName: string): Promise<boolean> {
     const records = await this.eventLogChannel.read(1)
     return !records.some(([name]) => name == eventName)
+  }
+
+  async nextAttributeMutationNamed(elementId: string, attributeName: string): Promise<string | null> {
+    let record: MutationLog | undefined
+    while (!record) {
+      const records = await this.mutationLogChannel.read(1)
+      record = records.find(([name, id]) => name == attributeName && id == elementId)
+    }
+    const attributeValue = record[2]
+    return attributeValue
   }
 
   get nextBody(): Promise<Element> {


### PR DESCRIPTION
During the request lifecycle, `<turbo-frame>` elements will toggle the
`[busy]` boolean attribute to true when the request starts, and then
remove it when the request ends.

Additionally, form submissions were not triggering the same `[busy]` toggling behavior, so this commit adds coverage for that behavior as well.

This commit adds functional test coverage for that behavior.