### PR TITLE
Toggle [aria-busy] instead of [busy]

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -129,7 +129,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   requestStarted(request: FetchRequest) {
-    this.element.setAttribute("busy", "")
+    this.element.setAttribute("aria-busy", "true")
   }
 
   requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse) {
@@ -152,13 +152,14 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   requestFinished(request: FetchRequest) {
-    this.element.removeAttribute("busy")
+    this.element.removeAttribute("aria-busy")
   }
 
   // Form submission delegate
 
   formSubmissionStarted(formSubmission: FormSubmission) {
-
+    const frame = this.findFrameElement(formSubmission.formElement)
+    frame.setAttribute("aria-busy", "true")
   }
 
   formSubmissionSucceededWithResponse(formSubmission: FormSubmission, response: FetchResponse) {
@@ -175,7 +176,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {
-
+    const frame = this.findFrameElement(formSubmission.formElement)
+    frame.removeAttribute("aria-busy")
   }
 
   // View delegate


### PR DESCRIPTION
Since `<turbo-frame>` elements are custom elements, the framework has
total control over the names of the attributes.

There are existing semantics for what we've introduced as `[busy]`: the
ARIA guidelines suggest toggling [aria-busy="true"][aria-busy] when an
element is loading more content, and `aria-busy="false"` when the
content is loaded.

This provides an "interface" for loading styles through CSS attribute
selectors, and hints to assistive technologies the state of the frame.

As an alternative, we could continue to toggle the `[busy]` attribute,
and encourage consumer applications to monitor mutations to the `[busy]`
attribute (or listen to [`turbo:frame-visit` and `turbo:frame-load`
events][events]) to toggle it themselves.

[aria-busy]: https://www.w3.org/TR/wai-aria-1.1/#aria-busy
[events]: https://github.com/hotwired/turbo/pull/59