### PR TITLE
Support verb overrides through _method

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -45,6 +45,7 @@ export class FormSubmission {
   readonly submitter?: HTMLElement
   readonly formData: FormData
   readonly fetchRequest: FetchRequest
+  readonly method: FetchMethod
   readonly mustRedirect: boolean
   state = FormSubmissionState.initialized
   result?: FormSubmissionResult
@@ -54,13 +55,9 @@ export class FormSubmission {
     this.formElement = formElement
     this.submitter = submitter
     this.formData = buildFormData(formElement, submitter)
+    this.method = getFetchMethod(this.formData, this.formElement, this.submitter)
     this.fetchRequest = new FetchRequest(this, this.method, this.location, this.body)
     this.mustRedirect = mustRedirect
-  }
-
-  get method(): FetchMethod {
-    const method = this.submitter?.getAttribute("formmethod") || this.formElement.getAttribute("method") || ""
-    return fetchMethodFromString(method.toLowerCase()) || FetchMethod.get
   }
 
   get action(): string {
@@ -174,6 +171,16 @@ function buildFormData(formElement: HTMLFormElement, submitter?: HTMLElement): F
   }
 
   return formData
+}
+
+function getFetchMethod(formData: FormData, formElement: HTMLFormElement, submitter?: HTMLElement) {
+  const methodFromFormData = formData.get("_method")
+  const methodOverride = methodFromFormData instanceof File ? "" : methodFromFormData
+  const method = submitter?.getAttribute("formmethod") || methodOverride || formElement.getAttribute("method") || ""
+
+  formData.delete("_method")
+
+  return fetchMethodFromString(method.toLowerCase()) || FetchMethod.get
 }
 
 function getCookieValue(cookieName: string | null) {

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -81,6 +81,13 @@
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
         <input type="submit" formenctype="multipart/form-data">
       </form>
+      <form action="/__turbo/redirect">
+        <button type="submit" name="_method" value="get" formmethod="post">Submit</button>
+      </form>
+      <form action="/__turbo/redirect" class="put">
+        <input type="hidden" name="_method" value="put">
+        <input type="submit" formmethod="post">
+      </form>
     </div>
     <hr>
     <div id="turbo-false">
@@ -148,6 +155,17 @@
         <input type="hidden" name="type" value="stream">
         <input type="hidden" name="content" value="Hello!">
         <input type="submit">
+      </form>
+      <form action="/__turbo/messages/1" method="post" class="stream method">
+        <input type="hidden" name="_method" value="put">
+        <input type="hidden" name="type" value="stream">
+        <input type="hidden" name="content" value="Hello!">
+        <input type="submit">
+      </form>
+      <form action="/__turbo/messages/1" method="post" class="stream">
+        <input type="hidden" name="type" value="stream">
+        <input type="hidden" name="content" value="Hello!">
+        <button type="submit" name="_method" value="put">Submit</button>
       </form>
       <div id="messages">
       </div>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -144,6 +144,24 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await this.visitAction, "advance")
   }
 
+  async "test standard form submission respects formmethod on submitter over _method in body"() {
+    await this.clickSelector("#submitter form.put [type=submit][formmethod]")
+    await this.nextBody
+
+    this.assert.ok(await this.formSubmitted)
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+    this.assert.equal(await this.visitAction, "advance")
+  }
+
+  async "test standard form submission respects formmethod on submitter over _method on submitter"() {
+    await this.clickSelector("#submitter button[type=submit][name=_method][value=get][formmethod=post]")
+    await this.nextBody
+
+    this.assert.ok(await this.formSubmitted)
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+    this.assert.equal(await this.visitAction, "advance")
+  }
+
   async "test submitter POST form submission with multipart/form-data formenctype"() {
     await this.clickSelector("#submitter form[method=post]:not([enctype]) input[formenctype]")
     await this.nextBeat
@@ -216,6 +234,38 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.clickSelector("#frame form.put.stream input[type=submit]")
     await this.nextBeat
 
+    const message = await this.querySelector("#frame div.message")
+    this.assert.ok(await this.hasSelector("#frame form.redirect"))
+    this.assert.equal(await message.getVisibleText(), "1: Hello!")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+  }
+
+  async "test POST form submission with _method in body"() {
+    await this.clickSelector("#frame form.method.stream input[type=submit]")
+    await this.nextBeat
+
+    const message = await this.querySelector("#frame div.message")
+    this.assert.ok(await this.hasSelector("#frame form.redirect"))
+    this.assert.equal(await message.getVisibleText(), "1: Hello!")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+  }
+
+  async "test POST form submission with _method on submitter"() {
+    await this.clickSelector("#frame form.stream button[type=submit][name=_method]")
+    await this.nextBeat
+
+    this.assert.ok(await this.formSubmitted)
+    const message = await this.querySelector("#frame div.message")
+    this.assert.ok(await this.hasSelector("#frame form.redirect"))
+    this.assert.equal(await message.getVisibleText(), "1: Hello!")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+  }
+
+  async "test POST form submission with formmethod on submitter and _method in form"() {
+    await this.clickSelector("#frame form.stream button[type=submit][name=_method]")
+    await this.nextBeat
+
+    this.assert.ok(await this.formSubmitted)
     const message = await this.querySelector("#frame div.message")
     this.assert.ok(await this.hasSelector("#frame form.redirect"))
     this.assert.equal(await message.getVisibleText(), "1: Hello!")

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -8,6 +8,11 @@ const streamResponses: Set<Response> = new Set
 
 router.use(multer().none())
 
+router.use((request, _, next) => {
+  request.method = request.body._method || request.method
+  next()
+})
+
 router.use((request, response, next) => {
   if (request.accepts(["text/html", "application/xhtml+xml"])) {
     next()


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/154.
Closes https://github.com/hotwired/turbo/pull/155.

---

To match the Rails idiom of override a form's `method` to support
requests that are not `GET` and `POST`, this commit adds test coverage
for existing functional behavior, along with some edge cases:

* considering a submitter's `formmethod` value over a `<input
  type="hidden" name="_method" value="...">` value

* considering a submitter's `formmethod` value over a competing
  submitter `name="_method" value="..."` pairing

To do so, change `FormSubmission.method` to be a read-only property
generated at construction time, and remove the property.

To read the `_method` requires destructively modifying the `FormData`
instance, so make sure we only do that once.

Co-authored-by: at-fffx <fangxing204@gmail.com>