### PR TITLE
Toggle [disabled] on form submitter

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -126,6 +126,7 @@ export class FormSubmission {
 
   requestStarted(request: FetchRequest) {
     this.state = FormSubmissionState.waiting
+    this.submitter?.setAttribute("disabled", "")
     dispatch("turbo:submit-start", { target: this.formElement, detail: { formSubmission: this } })
     this.delegate.formSubmissionStarted(this)
   }
@@ -159,6 +160,7 @@ export class FormSubmission {
 
   requestFinished(request: FetchRequest) {
     this.state = FormSubmissionState.stopped
+    this.submitter?.removeAttribute("disabled")
     dispatch("turbo:submit-end", { target: this.formElement, detail: { formSubmission: this, ...this.result }})
     this.delegate.formSubmissionFinished(this)
   }

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -17,7 +17,7 @@
       <form action="/__turbo/redirect" method="post" class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
         <input type="hidden" name="greeting" value="Hello from a redirect">
-        <input type="submit">
+        <input id="standard-form-submit" type="submit">
       </form>
       <form action="/__turbo/messages" method="post" class="created">
         <input type="hidden" name="content" value="Hello!">
@@ -122,7 +122,7 @@
 
       <form action="/__turbo/redirect" method="post" data-turbo-frame="frame" class="frame">
         <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
-        <button type="submit">Submit</button>
+        <button id="targets-frame-form-submit" type="submit">Submit</button>
       </form>
     </div>
     <turbo-frame id="frame">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -8,6 +8,13 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     })
   }
 
+  async "test form submission toggles submitter [disabled] attribute"() {
+    await this.clickSelector("#standard-form-submit")
+
+    this.assert.equal(await this.nextAttributeMutationNamed("standard-form-submit", "disabled"), "", "sets [disabled] on the submitter")
+    this.assert.equal(await this.nextAttributeMutationNamed("standard-form-submit", "disabled"), null, "removes [disabled] from the submitter")
+  }
+
   async "test standard form submission with redirect response"() {
     await this.clickSelector("#standard form.redirect input[type=submit]")
     await this.nextBody
@@ -200,6 +207,13 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     const title = await this.querySelector("#frame h2")
     this.assert.equal(await title.getVisibleText(), "Frame: Loaded")
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), null, "removes [busy] from the #frame")
+  }
+
+  async "test frame form submission toggles submitter's [disabled] attribute"() {
+    await this.clickSelector("#targets-frame-form-submit")
+
+    this.assert.equal(await this.nextAttributeMutationNamed("targets-frame-form-submit", "disabled"), "", "sets [disabled] on the submitter")
+    this.assert.equal(await this.nextAttributeMutationNamed("targets-frame-form-submit", "disabled"), null, "removes [disabled] from the submitter")
   }
 
   async "test frame form submission with empty created response"() {


### PR DESCRIPTION
During a form submission, toggle the [disabled][] attribute on prior to
`turbo:submit-start`, and remove it prior to firing `turbo:submit-end`.

If callers need to control the submitter's [disabled][] attribute more
finely, they can declare listeners to do so.

Combined with CSS rules, consumer applications can hide and show
submission text similar to RailsUJS's support for `data-disable-with`:

```css
button[disabled]       .show-when-disabled { display: initial; }
button:not([disabled]) .show-when-disabled { display: none; }

button[disabled]       .show-when-enabled { display: none; }
button:not([disabled]) .show-when-enabled { display: initial; }
```

```html
<button>
  <span class="show-when-enabled">Submit</span>
  <span class="show-when-disabled">Submitting...</span>
</button>
```

This is only possible with `<button>` elements, since `<input
type="submit">` do not have text content or descendants of their own.

[disabled]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled