### PR TITLE
Prevent infinite looping when loading frames

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -53,7 +53,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   sourceURLChanged() {
-    if (this.loadingStyle == FrameLoadingStyle.eager) {
+    if (this.loadingStyle == FrameLoadingStyle.eager && this.element.isConnected) {
       this.loadSourceURL()
     }
   }

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,9 +1,7 @@
 export type Locatable = URL | string
 
 export function expandURL(locatable: Locatable) {
-  const anchor = document.createElement("a")
-  anchor.href = locatable.toString()
-  return new URL(anchor.href)
+  return new URL(locatable.toString(), document.baseURI)
 }
 
 export function getAnchor(url: URL) {
@@ -37,6 +35,10 @@ export function toCacheKey(url: URL) {
   } else {
     return url.href.slice(0, -anchorLength)
   }
+}
+
+export function urlsAreEqual(left: string, right: string) {
+  return expandURL(left).href == expandURL(right).href
 }
 
 function getPathComponents(url: URL) {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Frame</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
     <h1>Frames</h1>
@@ -37,5 +38,7 @@
 
     <turbo-frame id="recursive" recurse="composer" src="/src/tests/fixtures/frames/recursive.html">
     </turbo-frame>
+
+    <a id="frame-self" href="/src/tests/fixtures/frames/self.html" data-turbo-frame="frame">Visit self.html</a>
   </body>
 </html>

--- a/src/tests/fixtures/frames/self.html
+++ b/src/tests/fixtures/frames/self.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frames: Self</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <turbo-frame id="frame" src="/src/tests/fixtures/frames/self.html">
+      <h2>Frames: Self</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -17,5 +17,6 @@
   "turbo:load",
   "turbo:render",
   "turbo:before-fetch-request",
+  "turbo:before-fetch-response",
   "turbo:visit"
 ])

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -1,6 +1,6 @@
-import { FunctionalTestCase } from "../helpers/functional_test_case"
+import { TurboDriveTestCase } from "../helpers/turbo_drive_test_case"
 
-export class FrameTests extends FunctionalTestCase {
+export class FrameTests extends TurboDriveTestCase {
   async setup() {
     await this.goToLocation("/src/tests/fixtures/frames.html")
   }
@@ -13,6 +13,18 @@ export class FrameTests extends FunctionalTestCase {
 
     const frame = await this.querySelector("turbo-frame#frame")
     this.assert.equal(await frame.getAttribute("data-loaded-from"), currentPath)
+  }
+
+  async "test a frame whose src references itself does not infinitely loop"() {
+    await this.clickSelector("#frame-self")
+
+    await this.nextEventNamed("turbo:before-fetch-response")
+
+    this.assert.equal(await this.getVisibleText("h2"), "Frames: Self")
+
+    const otherEvents = await this.eventLogChannel.read()
+
+    this.assert.equal(otherEvents.length, 0, "no more events")
   }
 
   async "test following a link to a page without a matching frame results in an empty frame"() {

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -20,10 +20,7 @@ export class FrameTests extends TurboDriveTestCase {
 
     await this.nextEventNamed("turbo:before-fetch-response")
 
-    this.assert.equal(await this.getVisibleText("h2"), "Frames: Self")
-
     const otherEvents = await this.eventLogChannel.read()
-
     this.assert.equal(otherEvents.length, 0, "no more events")
   }
 

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -36,6 +36,10 @@ export class FunctionalTestCase extends InternTestCase {
     return this.remote.findByCssSelector(selector).click()
   }
 
+  async getVisibleText(selector: string): Promise<string> {
+    return this.querySelector(selector).then(element => element.getVisibleText())
+  }
+
   async scrollToSelector(selector: string): Promise<void> {
     const element = await this.remote.findByCssSelector(selector)
     return this.evaluate(element => element.scrollIntoView(), element)

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -36,10 +36,6 @@ export class FunctionalTestCase extends InternTestCase {
     return this.remote.findByCssSelector(selector).click()
   }
 
-  async getVisibleText(selector: string): Promise<string> {
-    return this.querySelector(selector).then(element => element.getVisibleText())
-  }
-
   async scrollToSelector(selector: string): Promise<void> {
     const element = await this.remote.findByCssSelector(selector)
     return this.evaluate(element => element.scrollIntoView(), element)


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/98
Closes https://github.com/hotwired/turbo/issues/182

When a `<turbo-frame>` element declares a `[src]` attribute that
references the URL the frame is loaded from, prevent an infinitely
looping chain of requests.

To do so, extend the `FrameElement.isActive` predicate to also check for
[Node.isConnected][].

[Node.isConnected]: https://developer.mozilla.org/en-US/docs/Web/API/Node/isConnected