### PR TITLE
Prepare Frame Form Submission fetch headers

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -144,6 +144,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     if (this.formSubmission.fetchRequest.isIdempotent) {
       this.navigateFrame(element, this.formSubmission.fetchRequest.url.href)
     } else {
+      const { fetchRequest } = this.formSubmission
+      this.prepareHeadersForRequest(fetchRequest.headers, fetchRequest)
       this.formSubmission.start()
     }
   }

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -205,6 +205,14 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(htmlAfter, htmlBefore)
   }
 
+  async "test frame form submission within a frame submits the Turbo-Frame header"() {
+    await this.clickSelector("#frame form.redirect input[type=submit]")
+
+    const { fetchOptions } = await this.nextEventNamed("turbo:before-fetch-request")
+
+    this.assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
+  }
+
   async "test invalid frame form submission with unprocessable entity status"() {
     await this.clickSelector("#frame form.unprocessable_entity input[type=submit]")
     await this.nextBeat
@@ -296,6 +304,14 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.nextBody
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+  }
+
+  async "test form submission targeting a frame submits the Turbo-Frame header"() {
+    await this.clickSelector('#targets-frame [type="submit"]')
+
+    const { fetchOptions } = await this.nextEventNamed("turbo:before-fetch-request")
+
+    this.assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
   }
 
   get formSubmitted(): Promise<boolean> {


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/86
Closes https://github.com/hotwired/turbo/pull/110

When submitting a Form that is within a `<turbo-frame>` or targets a
`<turbo-frame>`, ensure that the `Turbo-Frame` header is present.

Since the constructive-style
`FetchRequestDelegate.additionalHeadersForRequest()` was replaced by the
mutative style `FetchRequestDelegate.prepareHeadersForRequest()`, this
commit introduces a readonly `FetchRequestHeaders` property created at
constructor-time so that its values can be mutated prior to the
request's submission.

Co-authored-by: tleish <tleish@users.noreply.github.com>

