### PR TITLE
Observe changes to turbo-frame[disabled]

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -55,6 +55,12 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     }
   }
 
+  disabledChanged() {
+    if (this.loadingStyle == FrameLoadingStyle.eager) {
+      this.loadSourceURL()
+    }
+  }
+
   sourceURLChanged() {
     if (this.loadingStyle == FrameLoadingStyle.eager || this.hasBeenLoaded) {
       this.loadSourceURL()
@@ -71,7 +77,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   async loadSourceURL() {
-    if (!this.settingSourceURL && this.isActive && this.sourceURL != this.currentURL) {
+    if (!this.settingSourceURL && this.enabled && this.isActive && this.sourceURL != this.currentURL) {
       const previousURL = this.currentURL
       this.currentURL = this.sourceURL
       if (this.sourceURL) {

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -7,6 +7,7 @@ export interface FrameElementDelegate {
   disconnect(): void
   loadingStyleChanged(): void
   sourceURLChanged(): void
+  disabledChanged(): void
   formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement): void
   loadResponse(response: FetchResponse): void
   isLoading: boolean
@@ -19,7 +20,7 @@ export class FrameElement extends HTMLElement {
   readonly delegate: FrameElementDelegate
 
   static get observedAttributes() {
-    return ["loading", "src"]
+    return ["disabled", "loading", "src"]
   }
 
   constructor() {
@@ -40,6 +41,8 @@ export class FrameElement extends HTMLElement {
       this.delegate.loadingStyleChanged()
     } else if (name == "src") {
       this.delegate.sourceURLChanged()
+    } else {
+      this.delegate.disabledChanged()
     }
   }
 

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -98,6 +98,17 @@ export class FrameTests extends TurboDriveTestCase {
     await this.nextBeat
     this.assert.ok(await this.querySelector("#recursive details:not([open])"))
   }
+
+  async "test removing [disabled] attribute from eager-loaded frame navigates it"() {
+    await this.remote.execute(() => document.getElementById("frame")?.setAttribute("disabled", ""))
+    await this.remote.execute((src: string) => document.getElementById("frame")?.setAttribute("src", "/src/tests/fixtures/frames/frame.html"))
+
+    this.assert.ok(await this.noNextEventNamed("turbo:before-fetch-request"), "[disabled] frames do not submit requests")
+
+    await this.remote.execute(() => document.getElementById("frame")?.removeAttribute("disabled"))
+
+    await this.nextEventNamed("turbo:before-fetch-request")
+  }
 }
 
 FrameTests.registerSuite()

--- a/src/tests/helpers/turbo_drive_test_case.ts
+++ b/src/tests/helpers/turbo_drive_test_case.ts
@@ -33,6 +33,11 @@ export class TurboDriveTestCase extends FunctionalTestCase {
     return record[1]
   }
 
+  async noNextEventNamed(eventName: string): Promise<boolean> {
+    const records = await this.eventLogChannel.read(1)
+    return !records.some(([name]) => name == eventName)
+  }
+
   get nextBody(): Promise<Element> {
     return (async () => {
       let body


### PR DESCRIPTION
When a Turbo Frame declares the `[disabled]` attribute, prevent any
navigation.

Once removed, if a Turbo Frame's `[loading="eager"]` and `[src]` exists,
navigate the frame.