### PR TITLE
Don't duplicate Form Submitter [name] param

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -169,8 +169,8 @@ function buildFormData(formElement: HTMLFormElement, submitter?: HTMLElement): F
   const name = submitter?.getAttribute("name")
   const value = submitter?.getAttribute("value")
 
-  if (name && formData.get(name) != value) {
-    formData.append(name, value || "")
+  if (name && value != null && formData.get(name) != value) {
+    formData.append(name, value)
   }
 
   return formData

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -59,6 +59,10 @@
         <input type="hidden" name="query" value="2">
         <input type="submit">
       </form>
+      <form method="get" class="button-param">
+        <input type="hidden" name="query" value="1">
+        <button type="submit" name="button">Submit</button>
+      </form>
     </div>
     <hr>
     <div id="reject">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -34,7 +34,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.nextBody
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
-    this.assert.equal(await await this.getSearchParam("query"), "2")
+    this.assert.equal(await this.getSearchParam("query"), "2")
   }
 
   async "test standard form submission with empty created response"() {
@@ -86,20 +86,20 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.nextBody
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
-    this.assert.equal(await await this.getSearchParam("query"), "1")
+    this.assert.equal(await this.getSearchParam("query"), "1")
 
     await this.clickSelector("#no-action form.single input[type=submit]")
     await this.nextBody
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
-    this.assert.equal(await await this.getSearchParam("query"), "1")
+    this.assert.equal(await this.getSearchParam("query"), "1")
 
     await this.goToLocation("/src/tests/fixtures/form.html?query=2")
     await this.clickSelector("#no-action form.single input[type=submit]")
     await this.nextBody
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
-    this.assert.equal(await await this.getSearchParam("query"), "1")
+    this.assert.equal(await this.getSearchParam("query"), "1")
   }
 
   async "test no-action form submission with multiple parameters"() {
@@ -115,6 +115,22 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
     this.assert.deepEqual(await this.getAllSearchParams("query"), [ "1", "2" ])
+  }
+
+  async "test no-action form submission submitter parameters"() {
+    await this.clickSelector("#no-action form.button-param [type=submit]")
+    await this.nextBody
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+    this.assert.equal(await this.getSearchParam("query"), "1")
+    this.assert.deepEqual(await this.getAllSearchParams("button"), [])
+
+    await this.clickSelector("#no-action form.button-param [type=submit]")
+    await this.nextBody
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+    this.assert.equal(await this.getSearchParam("query"), "1")
+    this.assert.deepEqual(await this.getAllSearchParams("button"), [])
   }
 
   async "test invalid form submission with unprocessable entity status"() {


### PR DESCRIPTION
When a `<form>` element's submitter declares a `[name]` attribute
without a `[value]` attribute, it is appended to the submission's
`FormData` instance twice. Due to a quirky difference between Safari and
Firefox + Chrome, the duplication _only_ occurs in Safari, which is a
browser that we are not running our functional test suite against.

In spite of that, this commit adds test coverage to ensure we don't
introduce a similar regression into those browsers.

Testing
---

Oddly enough, there are several occurrences of doubled-up `await await`
keywords, which this commit removes.