### PR TITLE
Prevent Streams from {pre,app}ending duplicates

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -64,7 +64,7 @@ export class FormSubmission {
   }
 
   get action(): string {
-    return this.submitter?.getAttribute("formaction") || this.formElement.action
+    return this.submitter?.getAttribute("formaction") || this.formElement.getAttribute("action") || this.formElement.action
   }
 
   get location(): URL {

--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -2,10 +2,14 @@ import { StreamElement } from "../../elements/stream_element"
 
 export const StreamActions: { [action: string]: (this: StreamElement) => void } = {
   append() {
+    removeMatchingElements(this.templateContent, this.targetElement)
+
     this.targetElement?.append(this.templateContent)
   },
 
   prepend() {
+    removeMatchingElements(this.templateContent, this.targetElement)
+
     this.targetElement?.prepend(this.templateContent)
   },
 
@@ -21,6 +25,14 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
     if (this.targetElement) {
       this.targetElement.innerHTML = ""
       this.targetElement.append(this.templateContent)
+    }
+  }
+}
+
+function removeMatchingElements(fragment: DocumentFragment, target: Element | null) {
+  if (target) {
+    for (const { id } of fragment.children) {
+      [ ...target.children ].find(element => element.id == id)?.remove()
     }
   }
 }

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -20,10 +20,14 @@
         <input type="submit">
       </form>
       <form action="/__turbo/messages" method="post" class="created">
+        <input type="hidden" name="action" value="append">
+        <input type="hidden" name="target" value="messages">
         <input type="hidden" name="content" value="Hello!">
         <input type="submit" style="">
       </form>
       <form action="/__turbo/messages" method="post" class="no-content">
+        <input type="hidden" name="action" value="append">
+        <input type="hidden" name="target" value="messages">
         <input type="hidden" name="content" value="Hello!">
         <input type="hidden" name="status" value="204">
         <input type="submit" style="">
@@ -127,6 +131,8 @@
         <input type="submit" style="">
       </form>
       <form action="/__turbo/messages" method="post" class="no-content">
+        <input type="hidden" name="action" value="append">
+        <input type="hidden" name="target" value="messages">
         <input type="hidden" name="content" value="Hello!">
         <input type="hidden" name="status" value="204">
         <input type="submit" style="">
@@ -140,11 +146,15 @@
         <input type="submit">
       </form>
       <form action="/__turbo/messages" method="post" class="stream">
+        <input type="hidden" name="action" value="append">
+        <input type="hidden" name="target" value="messages">
         <input type="hidden" name="type" value="stream">
         <input type="hidden" name="content" value="Hello!">
         <input type="submit">
       </form>
       <form action="/__turbo/messages/1" method="put" class="stream put">
+        <input type="hidden" name="action" value="append">
+        <input type="hidden" name="target" value="messages">
         <input type="hidden" name="type" value="stream">
         <input type="hidden" name="content" value="Hello!">
         <input type="submit">

--- a/src/tests/fixtures/frames/form.html
+++ b/src/tests/fixtures/frames/form.html
@@ -9,6 +9,8 @@
   <body>
     <turbo-frame id="frame">
       <form action="/__turbo/messages" method="post" class="stream">
+        <input type="hidden" name="action" value="append">
+        <input type="hidden" name="target" value="messages">
         <input type="hidden" name="content" value="Hello!">
         <input id="frames-form-first-autofocus-element" autofocus type="submit">
       </form>

--- a/src/tests/fixtures/stream.html
+++ b/src/tests/fixtures/stream.html
@@ -7,13 +7,34 @@
     <script>Turbo.connectStreamSource(new EventSource("/__turbo/messages"))</script>
   </head>
   <body>
-    <form id="create" method="post" action="/__turbo/messages">
+    <form id="append_messages" method="post" action="/__turbo/messages">
+      <input type="hidden" name="action" value="append">
+      <input type="hidden" name="target" value="messages">
       <input type="hidden" name="content" value="Hello world!">
       <input type="hidden" name="type" value="stream">
-      <button type="submit">Create</button>
+      <button type="submit">Append to #messages</button>
     </form>
+
+    <form id="append_message_1" method="put" action="/__turbo/messages/message_1">
+      <input type="hidden" name="action" value="append">
+      <input type="hidden" name="target" value="messages">
+      <input type="hidden" name="content" value="Hello world!">
+      <input type="hidden" name="type" value="stream">
+      <button type="submit">Append #message_1 to #messages</button>
+    </form>
+
+    <form id="prepend_message_3" method="put" action="/__turbo/messages/message_3">
+      <input type="hidden" name="action" value="prepend">
+      <input type="hidden" name="target" value="messages">
+      <input type="hidden" name="content" value="Hello world!">
+      <input type="hidden" name="type" value="stream">
+      <button type="submit">Prepend #message_3 to #messages</button>
+    </form>
+
     <div id="messages">
-      <div class="message">First</div>
+      <div id="message_1" class="message">First</div>
+      <div id="message_2" class="message">Second</div>
+      <div id="message_3" class="message">Third</div>
     </div>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -218,7 +218,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     const message = await this.querySelector("#frame div.message")
     this.assert.ok(await this.hasSelector("#frame form.redirect"))
-    this.assert.equal(await message.getVisibleText(), "1: Hello!")
+    this.assert.equal(await message.getVisibleText(), "Hello!")
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
   }
 

--- a/src/tests/functional/stream_tests.ts
+++ b/src/tests/functional/stream_tests.ts
@@ -10,13 +10,47 @@ export class StreamTests extends FunctionalTestCase {
     const selector = "#messages div.message:last-child"
 
     element = await this.querySelector(selector)
-    this.assert.equal(await element.getVisibleText(), "First")
+    this.assert.equal(await element.getVisibleText(), "Third")
 
-    await this.clickSelector("#create [type=submit]")
+    await this.clickSelector("#append_messages [type=submit]")
     await this.nextBeat
 
     element = await this.querySelector(selector)
     this.assert.equal(await element.getVisibleText(), "Hello world!")
+  }
+
+  async "test append for an existing element first removes the element, then appends"() {
+    let firstMessage = await this.querySelector("#messages div.message:first-child")
+    let lastMessage = await this.querySelector("#messages div.message:last-child")
+
+    this.assert.equal(await firstMessage.getVisibleText(), "First")
+    this.assert.equal(await lastMessage.getVisibleText(), "Third")
+
+    await this.clickSelector("#append_message_1 [type=submit]")
+    await this.nextBeat
+
+    firstMessage = await this.querySelector("#messages div.message:first-child")
+    lastMessage = await this.querySelector("#messages div.message:last-child")
+
+    this.assert.equal(await firstMessage.getVisibleText(), "Second", "removes element prior to append")
+    this.assert.equal(await lastMessage.getVisibleText(), "Hello world!", "appends the element")
+  }
+
+  async "test prepend for an existing element first removes the element, then prepends"() {
+    let firstMessage = await this.querySelector("#messages div.message:first-child")
+    let lastMessage = await this.querySelector("#messages div.message:last-child")
+
+    this.assert.equal(await firstMessage.getVisibleText(), "First")
+    this.assert.equal(await lastMessage.getVisibleText(), "Third")
+
+    await this.clickSelector("#prepend_message_3 [type=submit]")
+    await this.nextBeat
+
+    firstMessage = await this.querySelector("#messages div.message:first-child")
+    lastMessage = await this.querySelector("#messages div.message:last-child")
+
+    this.assert.equal(await firstMessage.getVisibleText(), "Hello world!", "prepends the element")
+    this.assert.equal(await lastMessage.getVisibleText(), "Second", "removes element prior to prepends")
   }
 }
 


### PR DESCRIPTION
In a circumstance where a `<form>` submission triggers a `turbo-stream`
response or a redirect back to the page with the new record on it, a
corresponding Stream update broadcast might occur in the background that
results in an `append` or `prepend` action.

In the case of the broadcast losing the race condition, update the
Stream renderer's page update to prevent prepending or appending
elements with duplicate `[id]` attributes.

Testing
---

Modify the test server to accept `action` and `target` values for
resulting Streams as request body parameters.