### PR TITLE
Add a "reload" method to the frame element

### DIFF
--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -35,6 +35,12 @@ export class FrameElement extends HTMLElement {
     this.delegate.disconnect()
   }
 
+  reload() {
+    const { src } = this;
+    this.src = null;
+    this.src = src;
+  }
+
   attributeChangedCallback(name: string) {
     if (name == "loading") {
       this.delegate.loadingStyleChanged()

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -84,6 +84,19 @@ export class LoadingTests extends TurboDriveTestCase {
     this.assert.equal(await contents.getVisibleText(), "Frames: #frame")
   }
 
+  async "test reloading a frame reloads the content"() {
+    await this.nextBeat
+
+    await this.clickSelector("#loading-eager summary")
+    await this.nextBeat
+
+    const frameContent = "#loading-eager turbo-frame#frame h2"
+    this.assert.ok(await this.hasSelector(frameContent))
+    // @ts-ignore
+    await this.remote.execute(() => document.querySelector("#loading-eager turbo-frame")?.reload())
+    this.assert.ok(await this.hasSelector(frameContent))
+  }
+
   async "test navigating away from a page does not reload its frames"() {
     await this.clickSelector("#one")
     await this.nextBody


### PR DESCRIPTION
As proposed in #202, this PR adds a `.reload()` method on the frame that allows to refresh its content.

Open points:

* I am not happy with the test. It actually does not test anything interesting. I'd like the content of the frame to change upon reloading and verify that, but I have no clue on how to do that. A bit of help or an idea would be appreciated. I left it there to give an idea of what I wanted to do, but as of now, it could be removed.
* What if the frame has no src attribute? In my implementation, a call to `reload()` will simply have no effect. To me this is simple and stupid, so it should be fine.