### PR TITLE
Render 4xx-5xx responses within frame

### DIFF
--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -47,13 +47,30 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
 
   private shouldRedirect(element: Element, submitter?: HTMLElement) {
     const frame = this.findFrameElement(element)
-    return frame ? frame != element.closest("turbo-frame") : false
+    if (frame) {
+      if (frame == element.closest("turbo-frame")) {
+        if (element instanceof HTMLFormElement) {
+          return frame.getAttribute("data-turbo-frame") == "_top" || element.getAttribute("data-turbo-frame") == "_top"
+        } else {
+          return frame.getAttribute("data-turbo-frame") == "_top"
+        }
+      } else {
+        return true
+      }
+    } else {
+      return false
+    }
   }
 
   private findFrameElement(element: Element) {
     const id = element.getAttribute("data-turbo-frame")
     if (id && id != "_top") {
       const frame = this.element.querySelector(`#${id}:not([disabled])`)
+      if (frame instanceof FrameElement) {
+        return frame
+      }
+    } else if (id == "_top") {
+      const frame = element.closest(`turbo-frame:not([disabled])`)
       if (frame instanceof FrameElement) {
         return frame
       }

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -13,6 +13,8 @@
     </style>
   </head>
   <body>
+    <h1 id="form-title">Form</h1>
+
     <div id="standard">
       <form action="/__turbo/redirect" method="post" class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
@@ -168,6 +170,14 @@
       </form>
       <div id="messages">
       </div>
+      <form action="/__turbo/redirect" method="post" class="redirect" data-turbo-frame="_top">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="submit">
+      </form>
+      <form class="unprocessable_entity" action="/__turbo/reject" method="post" data-turbo-frame="_top">
+        <input type="hidden" name="status" value="422">
+        <input type="submit">
+      </form>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -202,6 +202,16 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), null, "removes [busy] from the #frame")
   }
 
+  async "test frame form submission with [data-turbo-frame=_top]"() {
+    await this.clickSelector("#frame form.redirect[data-turbo-frame=_top] input[type=submit]")
+    await this.nextBody
+
+    const title = await this.querySelector("h1")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+    this.assert.equal(await title.getVisibleText(), "One", "follows form redirect")
+    this.assert.notOk(await this.hasSelector("#frame"), "redirects entire page")
+  }
+
   async "test frame form submission with empty created response"() {
     const htmlBefore = await this.outerHTMLForSelector("#frame")
     const button = await this.querySelector("#frame form.created input[type=submit]")
@@ -246,6 +256,15 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     const title = await this.querySelector("#frame h2")
     this.assert.ok(await this.hasSelector("#reject form"), "only replaces frame")
     this.assert.equal(await title.getVisibleText(), "Frame: Internal Server Error")
+  }
+
+  async "test invalid frame form submission in turbo-frame[data-turbo-frame=_top]"() {
+    await this.clickSelector("#frame form.unprocessable_entity[data-turbo-frame=_top] input[type=submit]")
+    await this.nextBeat
+
+    const title = await this.querySelector("#frame h2")
+    this.assert.equal(await title.getVisibleText(), "Frame: Unprocessable Entity", "renders the response HTML inside the frame")
+    this.assert.ok(await this.hasSelector("#form-title"), "does no replace entire page")
   }
 
   async "test frame form submission with stream response"() {


### PR DESCRIPTION
Render 4xx-5xx responses within frame
===

Closes https://github.com/hotwired/turbo/issues/138

The use case
---

Consider submitting a `<form data-turbo-frame="_top">` from within a
`<turbo-frame>`:

```html
<dialog open>
  <turbo-frame id="dialog">
    <form data-turbo-target="_top" method="POST" action="/posts">
      <!-- ... -->
    </form>
  </turbo-frame>
</dialog>
```

In the case of success, the response will be a [303 redirecting to
another URL][303].

In the case of a failed submission, the response will be a [422 with an
HTML body][422]:

```ruby
class PostsController < ApplicationController
  def create
    @post = Post.create!(post_params)

    redirect_to post_url(@post)
  rescue ActiveRecord::RecordNotSaved
    render inline: <<~HTML, status: :unprocessable_entity
      <turbo-frame id="dialog">
        <form data-turbo-target="_top" method="POST" action="/posts">
          <!-- ... -->
        </form>
      </turbo-frame>
    HTML
  end
end
```

[303]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
[422]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/422

The current behavior
---

Since the `<form>` element declares its target as `_top`, a successful
submission resulting in the [303][] response, the entire page redirect.

Similarly, in the case of an invalid submission, _the entire page's
HTML_ will be replaced by the response, in spite of the submission
occurring within a `<turbo-frame>` element.

The desired outcome
---

A valid submission behaves as expected and desired: redirect the `_top`
(entire page) to the URL.

In the case of a submission without Turbo, a failed submission would
result in a full re-render of the page, keeping the `<dialog>`
containing the form open. Any information or context in the "background"
would be re-rendered, but would exist.

With the introduction of Turbo Frames to the situation as a progressive
enhancement, a developer might expect the server's response to be
limited to only replacing the contents of the `<turbo-frame>` after a
failure.

A potential work-around
---

As a workaround, the server could respond with a `<turbo-stream>` to
replace the inner contents of the `<dialog>` element's `<turbo-frame>`.

Proposed change
---

Currently, the implementation treats submissions from within a
`<turbo-frame>` that target `_top` differently from elements without a
`[data-turbo-frame]` attribute, or one that refers to another element on
the page.

To account for the proposed change in behavior, _all_ frame submissions
would use the same machinery, and the different treatment would be
deferred to _after_ the submission is determined to be a success.

Implemention change
===

Importing the `navigator` reference from the package's `core` module is
a bit of a hacky workaround, but enables delegation to a Navigator in
the case of a `_top` submission redirect.

