### PR TITLE
Navigate a lazy-loaded turbo-frame

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -22,6 +22,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   formSubmission?: FormSubmission
   private resolveVisitPromise = () => {}
   private connected = false
+  private hasBeenLoaded = false
 
   constructor(element: FrameElement) {
     this.element = element
@@ -53,7 +54,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   sourceURLChanged() {
-    if (this.loadingStyle == FrameLoadingStyle.eager) {
+    if (this.loadingStyle == FrameLoadingStyle.eager || this.hasBeenLoaded) {
       this.loadSourceURL()
     }
   }
@@ -76,6 +77,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
           this.element.loaded = this.visit(this.sourceURL)
           this.appearanceObserver.stop()
           await this.element.loaded
+          this.hasBeenLoaded = true
         } catch (error) {
           this.currentURL = previousURL
           throw error

--- a/src/tests/fixtures/frames/hello.html
+++ b/src/tests/fixtures/frames/hello.html
@@ -10,6 +10,8 @@
     <h1>Form</h1>
     <turbo-frame id="hello">
       <h2>Hello from a frame</h2>
+
+      <a href="/src/tests/fixtures/frames.html">Navigate #hello</a>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -43,6 +43,20 @@ export class LoadingTests extends TurboDriveTestCase {
     this.assert.equal(await contents.getVisibleText(), "Hello from a frame")
   }
 
+  async "test navigating a visible frame with loading=lazy navigates"() {
+    await this.clickSelector("#loading-lazy summary")
+    await this.nextBeat
+
+    const initialContents = await this.querySelector("#hello h2")
+    this.assert.equal(await initialContents.getVisibleText(), "Hello from a frame")
+
+    await this.clickSelector("#hello a")
+    await this.nextBeat
+
+    const navigatedContents = await this.querySelector("#hello h2")
+    this.assert.equal(await navigatedContents.getVisibleText(), "Frames: #hello")
+  }
+
   async "test changing src attribute on a frame with loading=lazy defers navigation"() {
     const frameContents = "#loading-lazy turbo-frame h2"
     await this.nextBeat


### PR DESCRIPTION
Problem
---

Consider a `<turbo-frame>` element with `loading="lazy"`. Once it
becomes visible, the `AppearanceObserver` will delegate to the
`FrameController` to load its contents.

However, once visible, subsequent navigations of that frame will
continue to be deferred, since its `[loading]` attribute is still
deferred, in spite of the fact that the element is visible on that page.

Proposed change
---

This commit proposes to immediately navigate a `<turbo-frame>` element
with `[loading="eager"]` _or_ a `<turbo-frame>` element that has been
loaded previously.

Possible alternatives
---

As an alternative to adding another conditional to the guard clause,
could it be worthwhile to treat navigational changes driven by `<a>`
clicks or `<form>` submissions different from programatically modifying
the element's `[src]` attribute? Do Custom Elements support changing an
attribute's value without also kicking off change callbacks?