### PR TITLE
[RFC] Cancelable rendering

### DIFF
--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -13,7 +13,8 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
   }
 
   static fromDocument({ head, body }: Document) {
-    return new this(body as HTMLBodyElement, new HeadSnapshot(head))
+    // We need to clone the body because a custom renderer might mutate it.
+    return new this((body.cloneNode(true)) as HTMLBodyElement, new HeadSnapshot(head))
   }
 
   readonly headSnapshot: HeadSnapshot

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -2,7 +2,7 @@ import { FrameElement, FrameElementDelegate, FrameLoadingStyle } from "../../ele
 import { FetchMethod, FetchRequest, FetchRequestDelegate, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/appearance_observer"
-import { parseHTMLDocument } from "../../util"
+import { dispatch, parseHTMLDocument } from "../../util"
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
 import { ViewDelegate } from "../view"
@@ -181,7 +181,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   // View delegate
 
   viewWillRenderSnapshot(snapshot: Snapshot, isPreview: boolean) {
-
+    return dispatch("turbo:before-render", { detail: { newBody: snapshot.element}, cancelable: true})
   }
 
   viewRenderedSnapshot(snapshot: Snapshot, isPreview: boolean) {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -190,7 +190,7 @@ export class Session implements HistoryDelegate, LinkClickObserverDelegate, Navi
   }
 
   viewWillRenderSnapshot({ element }: PageSnapshot, isPreview: boolean) {
-    this.notifyApplicationBeforeRender(element)
+    return this.notifyApplicationBeforeRender(element)
   }
 
   viewRenderedSnapshot(snapshot: PageSnapshot, isPreview: boolean) {
@@ -231,7 +231,7 @@ export class Session implements HistoryDelegate, LinkClickObserverDelegate, Navi
   }
 
   notifyApplicationBeforeRender(newBody: HTMLBodyElement) {
-    return dispatch("turbo:before-render", { detail: { newBody }})
+    return dispatch("turbo:before-render", { detail: { newBody }, cancelable: true})
   }
 
   notifyApplicationAfterRender() {

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -3,7 +3,7 @@ import { Snapshot } from "./snapshot"
 import { Position } from "./types"
 
 export interface ViewDelegate<S extends Snapshot> {
-  viewWillRenderSnapshot(snapshot: S, isPreview: boolean): void
+  viewWillRenderSnapshot(snapshot: S, isPreview: boolean): Event
   viewRenderedSnapshot(snapshot: S, isPreview: boolean): void
   viewInvalidated(): void
 }
@@ -50,12 +50,15 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
     }
 
     const { isPreview, shouldRender, newSnapshot: snapshot } = renderer
+
     if (shouldRender) {
       try {
         this.renderer = renderer
         this.prepareToRenderSnapshot(renderer)
-        this.delegate.viewWillRenderSnapshot(snapshot, isPreview)
-        await this.renderSnapshot(renderer)
+        const event = this.delegate.viewWillRenderSnapshot(snapshot, isPreview)
+        if (!event.defaultPrevented) {
+          await this.renderSnapshot(renderer)
+        }
         this.delegate.viewRenderedSnapshot(snapshot, isPreview)
         this.finishRenderingSnapshot(renderer)
       } finally {


### PR DESCRIPTION
This PR allows to cancel the default rendering operation in any `turbo:before-render` handler. Its intended usage is to allow the application of custom rendering logic (e.g. [DOM diffing](https://github.com/turbolinks/turbolinks/issues/184)). It is compatible with full page and frame based rendering. Example usage:

```typescript
import morphdom from 'morphdom';

document.addEventListener('turbo:before-render', e => {
  e.preventDefault();
  const to: Element = (e as any).detail.newBody;
  let frame: HTMLElement | null;
  const from = to.nodeName === 'TURBO-FRAME' && (frame = document.getElementById(to.id)) ? frame : document.body;
  morphdom(from, to);
});
```
This should close #197.

I would add the necessary tests if a maintainer agrees with the general approach.