### PR TITLE
Forms: Log Submission failures to the console

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -101,7 +101,7 @@ export class Navigator {
   }
 
   formSubmissionErrored(formSubmission: FormSubmission, error: Error) {
-
+    console.error(error)
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -171,7 +171,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   formSubmissionErrored(formSubmission: FormSubmission, error: Error) {
-
+    console.error(error)
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {


### PR DESCRIPTION
When submitting a Form, Turbo Drive requires that the response redirects
to a `GET` via a [303 HTTP Status Code][303].

This requirement is enforced in
[FormSubmission.requestSucceededWithResponse][]:

```javascript
requestSucceededWithResponse(request: FetchRequest, response: FetchResponse) {
  // ...
  } else if (this.requestMustRedirect(request) && responseSucceededWithoutRedirect(response)) {
    const error = new Error("Form responses must redirect to another location")
    this.delegate.formSubmissionErrored(this, error)
  } else {
  // ...
}
```

Prior to this commit, neither `FormSubmissionDelegate` implementations
(`Navigator` nor `FrameController`) implemented the
`formSubmissionErrored` method.

By comparison, the [FrameController.requestErrored][] method
(implementing part of the `FetchRequestDelegate` interface) logs any
errors to the console.

In an effort to more clearly communicate the reason that the `<form>`
submission failed, implement both methods to pass the error to
[console.error][].

[FormSubmission.requestSucceededWithResponse]: https://github.com/hotwired/turbo/blob/8bce5f17cd697716600d3b34836365ebcdc04b3f/src/core/drive/form_submission.ts#L136-L139
[303]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/303
[FrameController.requestErrored]: https://github.com/hotwired/turbo/blob/a42fa94b69b3a1fd288bdc011654406df15bc3dc/src/core/frames/frame_controller.ts#L149-L152
[console.error]: https://developer.mozilla.org/en-US/docs/Web/API/Console/error