### PR TITLE
Frames: Set `src` when a `<form>` redirects frame

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -20,9 +20,9 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   readonly formInterceptor: FormInterceptor
   currentURL?: string
   formSubmission?: FormSubmission
-  private loadSourceURLWhenChanged = true
   private resolveVisitPromise = () => {}
   private connected = false
+  private settingSourceURL = false
 
   constructor(element: FrameElement) {
     this.element = element
@@ -69,7 +69,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   async loadSourceURL() {
-    if (this.loadSourceURLWhenChanged && this.isActive && this.sourceURL != this.currentURL) {
+    if (!this.settingSourceURL && this.isActive && this.sourceURL != this.currentURL) {
       const previousURL = this.currentURL
       this.currentURL = this.sourceURL
       if (this.sourceURL) {
@@ -87,9 +87,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
 
   async loadResponse(fetchResponse: FetchResponse) {
     if (fetchResponse.redirected) {
-      this.loadSourceURLWhenChanged = false
-      this.element.src = fetchResponse.response.url
-      this.loadSourceURLWhenChanged = true
+      this.sourceURL = fetchResponse.response.url
     }
 
     try {
@@ -283,6 +281,12 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     if (this.element.src) {
       return this.element.src
     }
+  }
+
+  set sourceURL(sourceURL: string | undefined) {
+    this.settingSourceURL = true
+    this.element.src = sourceURL ?? null
+    this.settingSourceURL = false
   }
 
   get loadingStyle() {

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -169,6 +169,10 @@ export class FormSubmissionTests extends TurboDriveTestCase {
   }
 
   async "test frame form submission with redirect response"() {
+    const path = await this.attributeForSelector("#frame form.redirect input[name=path]", "value") || ""
+    const url = new URL(path, "http://localhost:9000")
+    url.searchParams.set("enctype", "application/x-www-form-urlencoded;charset=UTF-8")
+
     const button = await this.querySelector("#frame form.redirect input[type=submit]")
     await button.click()
     await this.nextBeat
@@ -176,7 +180,9 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     const message = await this.querySelector("#frame div.message")
     this.assert.notOk(await this.hasSelector("#frame form.redirect"))
     this.assert.equal(await message.getVisibleText(), "Frame redirected")
-    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html", "does not redirect _top")
+    this.assert.notOk(await this.search, "does not redirect _top")
+    this.assert.equal(await this.attributeForSelector("#frame", "src"), url.href, "redirects the target frame")
   }
 
   async "test frame form submission with empty created response"() {

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -13,6 +13,7 @@ export class FrameTests extends FunctionalTestCase {
 
     const frame = await this.querySelector("turbo-frame#frame")
     this.assert.equal(await frame.getAttribute("data-loaded-from"), currentPath)
+    this.assert.equal(await frame.getAttribute("src"), await this.propertyForSelector("#hello a", "href"))
   }
 
   async "test following a link to a page without a matching frame results in an empty frame"() {
@@ -30,7 +31,10 @@ export class FrameTests extends FunctionalTestCase {
   }
 
   async "test following a link within a descendant frame whose ancestor declares a target set navigates the descendant frame"() {
-    await this.clickSelector("#nested-root[target=frame] #nested-child a:not([data-turbo-frame])")
+    const link = await this.querySelector("#nested-root[target=frame] #nested-child a:not([data-turbo-frame])")
+    const href = await link.getProperty("href")
+
+    await link.click()
     await this.nextBeat
 
     const frame = await this.querySelector("#frame h2")
@@ -39,6 +43,9 @@ export class FrameTests extends FunctionalTestCase {
     this.assert.equal(await frame.getVisibleText(), "Frames: #frame")
     this.assert.equal(await nestedRoot.getVisibleText(), "Frames: #nested-root")
     this.assert.equal(await nestedChild.getVisibleText(), "Frame: Loaded")
+    this.assert.equal(await this.attributeForSelector("#frame", "src"), null)
+    this.assert.equal(await this.attributeForSelector("#nested-root", "src"), null)
+    this.assert.equal(await this.attributeForSelector("#nested-child", "src"), href)
   }
 
   async "test following a link that declares data-turbo-frame within a frame whose ancestor respects the override"() {
@@ -47,14 +54,20 @@ export class FrameTests extends FunctionalTestCase {
 
     const frameText = await this.querySelector("body > h1")
     this.assert.equal(await frameText.getVisibleText(), "One")
+    this.assert.notOk(await this.hasSelector("#frame"))
+    this.assert.notOk(await this.hasSelector("#nested-root"))
+    this.assert.notOk(await this.hasSelector("#nested-child"))
   }
 
   async "test following a link within a frame with target=_top navigates the page"() {
+    this.assert.equal(await this.attributeForSelector("#navigate-top" ,"src"), null)
+
     await this.clickSelector("#navigate-top a")
     await this.nextBeat
 
     const frameText = await this.querySelector("body > h1")
     this.assert.equal(await frameText.getVisibleText(), "One")
+    this.assert.notOk(await this.hasSelector("#navigate-top"))
   }
 
   async "test following a link to a page with a <turbo-frame recurse> which lazily loads a matching frame"() {

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -51,6 +51,18 @@ export class FunctionalTestCase extends InternTestCase {
     return this.evaluate(element => element.innerHTML, element)
   }
 
+  async attributeForSelector(selector: string, attributeName: string) {
+    const element = await this.querySelector(selector)
+
+    return await element.getAttribute(attributeName)
+  }
+
+  async propertyForSelector(selector: string, attributeName: string) {
+    const element = await this.querySelector(selector)
+
+    return await element.getProperty(attributeName)
+  }
+
   get scrollPosition(): Promise<{ x: number, y: number }> {
     return this.evaluate(() => ({ x: window.scrollX, y: window.scrollY }))
   }
@@ -92,6 +104,10 @@ export class FunctionalTestCase extends InternTestCase {
 
   get pathname(): Promise<string> {
     return this.evaluate(() => location.pathname)
+  }
+
+  get search(): Promise<string> {
+    return this.evaluate(() => location.search)
   }
 
   get searchParams(): Promise<URLSearchParams> {


### PR DESCRIPTION
Closes [#223][]

When handling a `<form>` submission targeting a `<turbo-frame>` element
that results in a `303` redirect, update the `<turbo-frame src="...">`
to reflect the new location.

To account for the fact that `FrameController` instances are monitoring
changes to `<turbo-frame src="...">` via a Custom Elements
[attributeChangedCallback][], momentarily toggle that controller's
ability to respond to those changes to allow for modifying the `src`
attribute without triggering a redundant HTTP request.

Additionally, add coverage to ensure that navigating a `<turbo-frame>`
through an `<a>` sets the `[src]` attribute in way that is public to
the document.

[#223]: https://github.com/hotwired/turbo/issues/223
[attributeChangedCallback]: https://developer.mozilla.org/en-US/docs/Web/Web_Components/Using_custom_elements#using_the_lifecycle_callbacks