### PR TITLE
Skip form[data-turbo="false"] submissions in frame

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -11,6 +11,7 @@ import { FormInterceptor, FormInterceptorDelegate } from "./form_interceptor"
 import { FrameView } from "./frame_view"
 import { LinkInterceptor, LinkInterceptorDelegate } from "./link_interceptor"
 import { FrameRenderer } from "./frame_renderer"
+import { elementIsNavigable } from "../session"
 
 export class FrameController implements AppearanceObserverDelegate, FetchRequestDelegate, FormInterceptorDelegate, FormSubmissionDelegate, FrameElementDelegate, LinkInterceptorDelegate, ViewDelegate<Snapshot<FrameElement>> {
   readonly element: FrameElement
@@ -105,8 +106,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
 
   // Form interceptor delegate
 
-  shouldInterceptFormSubmission(element: HTMLFormElement) {
-    return this.shouldInterceptNavigation(element)
+  shouldInterceptFormSubmission(element: HTMLFormElement, submitter?: Element) {
+    return this.shouldInterceptNavigation(element, submitter)
   }
 
   formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement) {
@@ -233,7 +234,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     return new FrameElement()
   }
 
-  private shouldInterceptNavigation(element: Element) {
+  private shouldInterceptNavigation(element: Element, submitter?: Element) {
     const id = element.getAttribute("data-turbo-frame") || this.element.getAttribute("target")
 
     if (!this.enabled || id == "_top") {
@@ -247,7 +248,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
       }
     }
 
-    return true
+    return elementIsNavigable(element) && (submitter ? elementIsNavigable(submitter) : true)
   }
 
   // Computed properties

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -1,6 +1,6 @@
 import { Adapter } from "./native/adapter"
 import { BrowserAdapter } from "./native/browser_adapter"
-import { FormSubmitObserver } from "../observers/form_submit_observer"
+import { FormSubmitObserver, FormSubmitObserverDelegate } from "../observers/form_submit_observer"
 import { FrameRedirector } from "./frames/frame_redirector"
 import { History, HistoryDelegate } from "./drive/history"
 import { LinkClickObserver, LinkClickObserverDelegate } from "../observers/link_click_observer"
@@ -18,7 +18,7 @@ import { PageSnapshot } from "./drive/page_snapshot"
 
 export type TimingData = {}
 
-export class Session implements HistoryDelegate, LinkClickObserverDelegate, NavigatorDelegate, PageObserverDelegate, PageViewDelegate {
+export class Session implements FormSubmitObserverDelegate, HistoryDelegate, LinkClickObserverDelegate, NavigatorDelegate, PageObserverDelegate, PageViewDelegate {
   readonly navigator = new Navigator(this)
   readonly history = new History(this)
   readonly view = new PageView(this, document.documentElement)
@@ -122,7 +122,7 @@ export class Session implements HistoryDelegate, LinkClickObserverDelegate, Navi
   // Link click observer delegate
 
   willFollowLinkToLocation(link: Element, location: URL) {
-    return this.elementIsNavigable(link)
+    return elementIsNavigable(link)
       && this.locationIsVisitable(location)
       && this.applicationAllowsFollowingLinkToLocation(link, location)
   }
@@ -155,7 +155,7 @@ export class Session implements HistoryDelegate, LinkClickObserverDelegate, Navi
   // Form submit observer delegate
 
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {
-    return this.elementIsNavigable(form) && this.elementIsNavigable(submitter)
+    return elementIsNavigable(form) && elementIsNavigable(submitter)
   }
 
   formSubmitted(form: HTMLFormElement, submitter?: HTMLElement) {
@@ -249,21 +249,21 @@ export class Session implements HistoryDelegate, LinkClickObserverDelegate, Navi
     return isAction(action) ? action : "advance"
   }
 
-  elementIsNavigable(element?: Element) {
-    const container = element?.closest("[data-turbo]")
-    if (container) {
-      return container.getAttribute("data-turbo") != "false"
-    } else {
-      return true
-    }
-  }
-
   locationIsVisitable(location: URL) {
     return isPrefixedBy(location, this.snapshot.rootLocation) && isHTML(location)
   }
 
   get snapshot() {
     return this.view.snapshot
+  }
+}
+
+export function elementIsNavigable(element?: Element) {
+  const container = element?.closest("[data-turbo]")
+  if (container) {
+    return container.getAttribute("data-turbo") != "false"
+  } else {
+    return true
   }
 }
 

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -139,6 +139,14 @@
         <input type="hidden" name="status" value="500">
         <input type="submit">
       </form>
+      <form action="/__turbo/redirect" method="post" data-turbo="false">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="submit">
+      </form>
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="submit" data-turbo="false">
+      </form>
       <form action="/__turbo/messages" method="post" class="stream">
         <input type="hidden" name="type" value="stream">
         <input type="hidden" name="content" value="Hello!">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -222,7 +222,23 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
   }
 
-  async "test form submission with Turbo disabled on the form"() {
+  async "test frame form submission with [data-turbo=false] on the form"() {
+    await this.clickSelector('#frame form[data-turbo="false"] input[type=submit]')
+    await this.nextBody
+    await this.querySelector("#element-id")
+
+    this.assert.notOk(await this.formSubmitted)
+  }
+
+  async "test frame form submission with [data-turbo=false] on the submitter"() {
+    await this.clickSelector('#frame form:not([data-turbo]) input[data-turbo="false"]')
+    await this.nextBody
+    await this.querySelector("#element-id")
+
+    this.assert.notOk(await this.formSubmitted)
+  }
+
+  async "test form submission with [data-turbo=false] on the form"() {
     await this.clickSelector('#turbo-false form[data-turbo="false"] input[type=submit]')
     await this.nextBody
     await this.querySelector("#element-id")


### PR DESCRIPTION
Closes [#227][]

Adds a set of conditional guards to the
`FrameController.shouldInterceptFormSubmission()` method, similar to the
[Session.willSubmitForm()][] method, implementing a [identical guard
logic][]

[#227]: https://github.com/hotwired/turbo/issues/227
[Session.willSubmitForm()]: https://github.com/hotwired/turbo/blob/8bce5f17cd697716600d3b34836365ebcdc04b3f/src/core/session.ts#L157-L159
[identical guard logic]: https://github.com/hotwired/turbo/blob/8bce5f17cd697716600d3b34836365ebcdc04b3f/src/core/session.ts#L252-L259