### PR TITLE
Navigation: Scroll to select assertion

### DIFF
--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -81,7 +81,7 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
     this.assert.equal(await this.hash, "#named-anchor")
     this.assert.equal(await this.visitAction, "advance")
-    this.assert(await this.isScrolledToSelector("[name=named-anchor]"))
+    this.assert.ok(await this.isScrolledToSelector("[name=named-anchor]"), "scrolls to [name=named-anchor]")
   }
 
   async "test following a cross-origin unannotated link"() {


### PR DESCRIPTION
The suite consistently fails in Firefox locally:

```
× firefox on mac 20.3.0 - NavigationTests - following a same-origin link to a named anchor (0.309s)
    AssertionError: Unspecified AssertionError
      at NavigationTests.test following a same-origin link to a named anchor @ src/tests/functional/navigation_tests.ts:84:9
      at runMicrotasks @ anonymous
      at processTicksAndRejections @ internal/process/task_queues.js:93:5
      at async NavigationTests.runTest @ src/tests/helpers/intern_test_case.ts:43:6
```

This commit adds an assertion message to the test for better failure
state communication.