### PR TITLE
Remove stale elements before cache

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -1,5 +1,6 @@
 import { Adapter } from "./native/adapter"
 import { BrowserAdapter } from "./native/browser_adapter"
+import { CacheObserver } from "../observers/cache_observer"
 import { FormSubmitObserver, FormSubmitObserverDelegate } from "../observers/form_submit_observer"
 import { FrameRedirector } from "./frames/frame_redirector"
 import { History, HistoryDelegate } from "./drive/history"
@@ -25,6 +26,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   adapter: Adapter = new BrowserAdapter(this)
 
   readonly pageObserver = new PageObserver(this)
+  readonly cacheObserver = new CacheObserver()
   readonly linkClickObserver = new LinkClickObserver(this)
   readonly formSubmitObserver = new FormSubmitObserver(this)
   readonly scrollObserver = new ScrollObserver(this)
@@ -39,6 +41,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   start() {
     if (!this.started) {
       this.pageObserver.start()
+      this.cacheObserver.start()
       this.linkClickObserver.start()
       this.formSubmitObserver.start()
       this.scrollObserver.start()
@@ -57,6 +60,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   stop() {
     if (this.started) {
       this.pageObserver.stop()
+      this.cacheObserver.stop()
       this.linkClickObserver.stop()
       this.formSubmitObserver.stop()
       this.scrollObserver.stop()

--- a/src/observers/cache_observer.ts
+++ b/src/observers/cache_observer.ts
@@ -15,12 +15,10 @@ export class CacheObserver {
     }
   }
 
-  get staleElements(): HTMLElement[] {
-    return [ ...document.querySelectorAll('[data-turbo-cache="false"]') ] as any
-  }
-
   removeStaleElements() {
-    for (const element of this.staleElements) {
+    const staleElements = [ ...document.querySelectorAll('[data-turbo-cache="false"]') ]
+
+    for (const element of staleElements) {
        element.remove()
      }
   }

--- a/src/observers/cache_observer.ts
+++ b/src/observers/cache_observer.ts
@@ -1,0 +1,27 @@
+export class CacheObserver {
+  started = false
+
+  start() {
+    if (!this.started) {
+      this.started = true
+      addEventListener("turbo:before-cache", this.removeStaleElements, false)
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.started = false
+      removeEventListener("turbo:before-cache", this.removeStaleElements, false)
+    }
+  }
+
+  get staleElements(): HTMLElement[] {
+    return [ ...document.querySelectorAll('[data-turbo-cache="false"]') ] as any
+  }
+
+  removeStaleElements() {
+    for (const element of this.staleElements) {
+       element.remove()
+     }
+  }
+}

--- a/src/tests/fixtures/cache_observer.html
+++ b/src/tests/fixtures/cache_observer.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+ <html>
+   <head>
+     <meta charset="utf-8">
+     <title>Turbo</title>
+     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+     <script src="/src/tests/fixtures/test.js"></script>
+   </head>
+   <body>
+     <section>
+       <h1>Cache Observer</h1>
+       <div id="flash" data-turbo-cache="false">Rendering</div>
+       <p><a id="link" href="/src/tests/fixtures/rendering.html">rendering</a></p>
+   </body>
+ </html>

--- a/src/tests/functional/cache_observer_tests.ts
+++ b/src/tests/functional/cache_observer_tests.ts
@@ -1,0 +1,18 @@
+import { TurboDriveTestCase } from "../helpers/turbo_drive_test_case"
+
+export class CacheObserverTests extends TurboDriveTestCase {
+  async setup() {
+    await this.goToLocation("/src/tests/fixtures/cache_observer.html")
+  }
+
+  async "test removes stale elements"() {
+    this.assert(await this.hasSelector("#flash"))
+    this.clickSelector("#link")
+    await this.nextBody
+    await this.goBack()
+    await this.nextBody
+    this.assert.notOk(await this.hasSelector("#flash"))
+  }
+}
+
+CacheObserverTests.registerSuite()

--- a/src/tests/functional/index.ts
+++ b/src/tests/functional/index.ts
@@ -1,5 +1,6 @@
 export * from "./async_script_tests"
 export * from "./autofocus_tests"
+export * from "./cache_observer_tests"
 export * from "./form_submission_tests"
 export * from "./frame_tests"
 export * from "./import_tests"


### PR DESCRIPTION
Some content is inherently stale the moment you've shown it to users. Eg in Ruby on Rails it's common that you use flash messages to communicate a message from your controller to your users.

When a user navigates away and returns to the original page, turbo will briefly show cached content:

https://user-images.githubusercontent.com/440926/107358271-78aa4300-6ad3-11eb-8345-3da01cfe7e3d.mov

This PR adds a hook by adding `data-turbo-cache="false"` to individual dom elements to remove them from Turbo's cache.

--

_Originally posted about the issue in https://github.com/hotwired/turbo-rails/issues/117_