### PR TITLE
Replace children with duplicate id instead of append/prepend

### DIFF
--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -11,6 +11,17 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
     this.targetElement?.prepend(this.templateContent)
   },
 
+  update_children_or_append() {
+    this.replaceDuplicateChildren()
+    this.targetElement?.append(this.templateContent)
+  },
+
+  update_children_or_prepend() {
+    this.replaceDuplicateChildren()
+    this.targetElement?.prepend(this.templateContent)
+  },
+
+
   remove() {
     this.targetElement?.remove()
   },

--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -2,10 +2,12 @@ import { StreamElement } from "../../elements/stream_element"
 
 export const StreamActions: { [action: string]: (this: StreamElement) => void } = {
   append() {
+    this.removeDuplicateTargetChildren()
     this.targetElement?.append(this.templateContent)
   },
 
   prepend() {
+    this.removeDuplicateTargetChildren()
     this.targetElement?.prepend(this.templateContent)
   },
 

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -34,6 +34,13 @@ export class StreamElement extends HTMLElement {
       targetChild.remove();
     })
   }
+ 
+  replaceDuplicateChildren() {
+    this.duplicateChildren.forEach(({targetChild, templateChild}) => {
+      templateChild.remove();
+      targetChild!.replaceWith(templateChild);
+    })
+  }
 
   get duplicateChildren() {
     return [...this.templateContent?.children].map(templateChild => {

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -28,7 +28,20 @@ export class StreamElement extends HTMLElement {
   disconnect() {
     try { this.remove() } catch {}
   }
+ 
+  removeDuplicateTargetChildren() {
+    this.duplicateChildren.forEach(({targetChild}) => {
+      targetChild.remove();
+    })
+  }
 
+  get duplicateChildren() {
+    return [...this.templateContent?.children].map(templateChild => {
+      let targetChild = [...this.targetElement!.children].filter(c => c.id === templateChild.id)[0]
+      return { targetChild , templateChild }
+    }).filter(({targetChild}) => targetChild);
+  }
+  
   get performAction() {
     if (this.action) {
       const actionFunction = StreamActions[this.action]

--- a/src/tests/unit/stream_element_tests.ts
+++ b/src/tests/unit/stream_element_tests.ts
@@ -18,6 +18,23 @@ export class StreamElementTests extends DOMTestCase {
     this.assert.isNull(element.parentElement)
   }
 
+  async "test action=append with children ID already present in target"() {
+    const element = createStreamElement("append", "hello", createTemplateElement(' <div id="child_1">First</div> tail1 '))
+    const element2 = createStreamElement("append", "hello", createTemplateElement('<div id="child_1">New First</div> <div id="child_2">Second</div> tail2 '))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo First tail1 ')
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo  tail1 New First Second tail2 ')
+  }
+
   async "test action=prepend"() {
     const element = createStreamElement("prepend", "hello", createTemplateElement("Streams "))
     this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
@@ -27,6 +44,23 @@ export class StreamElementTests extends DOMTestCase {
 
     this.assert.equal(this.find("#hello")?.textContent, "Streams Hello Turbo")
     this.assert.isNull(element.parentElement)
+  }
+
+  async "test action=prepend with children ID already present in target"() {
+    const element = createStreamElement("prepend", "hello", createTemplateElement('<div id="child_1">First</div> tail1 '))
+    const element2 = createStreamElement("prepend", "hello", createTemplateElement('<div id="child_1">New First</div> <div id="child_2">Second</div> tail2 '))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'First tail1 Hello Turbo')
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'New First Second tail2  tail1 Hello Turbo')
   }
 
   async "test action=remove"() {

--- a/src/tests/unit/stream_element_tests.ts
+++ b/src/tests/unit/stream_element_tests.ts
@@ -63,6 +63,63 @@ export class StreamElementTests extends DOMTestCase {
     this.assert.equal(this.find("#hello")?.textContent, 'New First Second tail2  tail1 Hello Turbo')
   }
 
+  async "test action=update_children_or_append"() {
+    const element = createStreamElement("update_children_or_append", "hello", createTemplateElement(" Streams"))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo Streams")
+    this.assert.isNull(element.parentElement)
+  }
+
+  async "test action=update_children_or_append with children ID already present in target"() {
+    const element = createStreamElement("update_children_or_append", "hello", createTemplateElement(' <div id="child_1">First</div> tail1 '))
+    const element2 = createStreamElement("update_children_or_append", "hello", createTemplateElement('<div id="child_1">New First</div><div id="child_2">Second</div> tail2 '))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo First tail1 ')
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo New First tail1 Second tail2 ')
+  }
+
+  async "test action=update_children_or_prepend"() {
+    const element = createStreamElement("update_children_or_prepend", "hello", createTemplateElement("Streams "))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, "Streams Hello Turbo")
+    this.assert.isNull(element.parentElement)
+  }
+
+  async "test action=update_children_or_prepend with children ID already present in target"() {
+    const element = createStreamElement("update_children_or_prepend", "hello", createTemplateElement('<div id="child_1">First</div> tail1 '))
+    const element2 = createStreamElement("update_children_or_prepend", "hello", createTemplateElement('<div id="child_1">New First</div><div id="child_2">Second</div> tail2 '))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'First tail1 Hello Turbo')
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Second tail2 New First tail1 Hello Turbo')
+  }
+
+
   async "test action=remove"() {
     const element = createStreamElement("remove", "hello")
     this.assert.ok(this.find("#hello"))


### PR DESCRIPTION
This PR introduces 2 new actions `update_children_or_append` and `update_children_or_prepend` which are very similar to `append` and `prepend` except that:
- the contents of the duplicate children are replaced in place (wherever they are in the target) with the contents of the matching children of the template
- the rest of the template (non duplicate children) are appended/prepended to the target

Assuming the following contrived example:
Target: 
```html
<ul id="vehicles">
  <li id="vehicle_1">Old car</li>
  <li id="vehicle_2">New car</li>
</ul>
```
Stream element:
```html
<turbo-stream action="append" target="vehicles">
  <template>
      <li id="vehicle_1">Old car with updates</li>
      <li id="vehicle_3">Newer car</li>
  </template>
</turbo-stream>
```

With the current code, the result is:
```html
<ul id="vehicles">
  <li id="vehicle_1">Old car</li>
  <li id="vehicle_2">New car</li>
  <li id="vehicle_1">Old car with updates</li>
  <li id="vehicle_3">Newer car</li>
</ul>
```

This PR changes it so the result is
```html
<ul id="vehicles">
  <li id="vehicle_1">Old car with updates</li>
  <li id="vehicle_2">New car</li>
  <li id="vehicle_3">Newer car</li>
</ul>
```

For context his was originally introduced as a fix for https://github.com/hotwired/turbo/issues/132#issuecomment-813040051 but after https://github.com/hotwired/turbo/issues/132#issuecomment-817927043 I rebased this PR over #240 and introduced new commands
