### PR TITLE
Remove target children with duplicate ID before append/prepend

### DIFF
--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -2,10 +2,12 @@ import { StreamElement } from "../../elements/stream_element"
 
 export const StreamActions: { [action: string]: (this: StreamElement) => void } = {
   append() {
+    this.removeDuplicateTargetChildren()
     this.targetElement?.append(this.templateContent)
   },
 
   prepend() {
+    this.removeDuplicateTargetChildren()
     this.targetElement?.prepend(this.templateContent)
   },
 

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -28,7 +28,20 @@ export class StreamElement extends HTMLElement {
   disconnect() {
     try { this.remove() } catch {}
   }
+ 
+  removeDuplicateTargetChildren() {
+    this.duplicateChildren.forEach(({targetChild}) => {
+      targetChild.remove();
+    })
+  }
 
+  get duplicateChildren() {
+    return [...this.templateContent?.children].map(templateChild => {
+      let targetChild = [...this.targetElement!.children].filter(c => c.id === templateChild.id)[0]
+      return { targetChild , templateChild }
+    }).filter(({targetChild}) => targetChild);
+  }
+  
   get performAction() {
     if (this.action) {
       const actionFunction = StreamActions[this.action]

--- a/src/tests/unit/stream_element_tests.ts
+++ b/src/tests/unit/stream_element_tests.ts
@@ -18,6 +18,23 @@ export class StreamElementTests extends DOMTestCase {
     this.assert.isNull(element.parentElement)
   }
 
+  async "test action=append with children ID already present in target"() {
+    const element = createStreamElement("append", "hello", createTemplateElement(' <div id="child_1">First</div> tail1 '))
+    const element2 = createStreamElement("append", "hello", createTemplateElement('<div id="child_1">New First</div> <div id="child_2">Second</div> tail2 '))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo First tail1 ')
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo  tail1 New First Second tail2 ')
+  }
+
   async "test action=prepend"() {
     const element = createStreamElement("prepend", "hello", createTemplateElement("Streams "))
     this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
@@ -27,6 +44,23 @@ export class StreamElementTests extends DOMTestCase {
 
     this.assert.equal(this.find("#hello")?.textContent, "Streams Hello Turbo")
     this.assert.isNull(element.parentElement)
+  }
+
+  async "test action=prepend with children ID already present in target"() {
+    const element = createStreamElement("prepend", "hello", createTemplateElement('<div id="child_1">First</div> tail1 '))
+    const element2 = createStreamElement("prepend", "hello", createTemplateElement('<div id="child_1">New First</div> <div id="child_2">Second</div> tail2 '))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'First tail1 Hello Turbo')
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'New First Second tail2  tail1 Hello Turbo')
   }
 
   async "test action=remove"() {


### PR DESCRIPTION
Fixes #132

@dhh this implements Option C of https://github.com/hotwired/turbo/issues/132#issuecomment-813040051

When appending/prepending, children of the template may contain the same ID as children of the existing target.
_(this is common when using turbo-rails or other frameworks where the append/prepend action comes both as a result of the response to the original action and as a broadcasted action from a background job)_.

When this is the case, the generated result contains duplicate children ID which is undesirable.

This PR changes the behaviour of the append/prepend actions so that the existing children of the target which match the children of the template are removed before appending the template.

Assuming the following contrived example:
Target: 
```html
<ul id="vehicles">
  <li id="vehicle_1">Old car</li>
  <li id="vehicle_2">New car</li>
</ul>
```
Stream element:
```html
<turbo-stream action="append" target="vehicles">
  <template>
      <li id="vehicle_1">Old car with updates</li>
      <li id="vehicle_3">Newer car</li>
  </template>
</turbo-stream>
```

With the current code, the result is:
```html
<ul id="vehicles">
  <li id="vehicle_1">Old car</li>
  <li id="vehicle_2">New car</li>
  <li id="vehicle_1">Old car with updates</li>
  <li id="vehicle_3">Newer car</li>
</ul>
```

This PR changes it so the result is
```html
<ul id="vehicles">
  <li id="vehicle_2">New car</li>
  <li id="vehicle_1">Old car with updates</li>
  <li id="vehicle_3">Newer car</li>
</ul>
```
