### PR TITLE
Clear a target's content from the DOM

### DIFF
--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -14,7 +14,9 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
   },
 
   clear() {
-    this.targetElement?.replaceWith("")
+    if (this.targetElement) {
+      this.targetElement.innerHTML = ""
+    }
   },
 
   replace() {

--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -13,6 +13,10 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
     this.targetElement?.remove()
   },
 
+  clear() {
+    this.targetElement?.replaceWith("")
+  },
+
   replace() {
     this.targetElement?.replaceWith(this.templateContent)
   },

--- a/src/tests/unit/stream_element_tests.ts
+++ b/src/tests/unit/stream_element_tests.ts
@@ -40,6 +40,17 @@ export class StreamElementTests extends DOMTestCase {
     this.assert.isNull(element.parentElement)
   }
 
+  async "test action=clear"() {
+    const element = createStreamElement("clear", "hello")
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, "")
+    this.assert.isNull(element.parentElement)
+  }
+
   async "test action=replace"() {
     const element = createStreamElement("replace", "hello", createTemplateElement(`<h1 id="hello">Hello Turbo</h1>`))
     this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")


### PR DESCRIPTION
Introduce a little helper to clear the content of a target in the DOM. This is useful eg when you are closing a modal

__Before:__

```js
<turbo-stream action="replace" target="message_1">
  <template>
    <div id="message_1">
    </div>
  </template>
</turbo-stream>
```

__After:__

```js
<turbo-stream action="clear" target="message_1">
</turbo-stream>
```

--

_Originally opened a PR in https://github.com/hotwired/turbo-rails/pull/131_