### PR TITLE
Support Custom `<turbo-stream action="...">` value

### DIFF
--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -1,6 +1,10 @@
 import { StreamElement } from "../../elements/stream_element"
 
-export const StreamActions: { [action: string]: (this: StreamElement) => void } = {
+export interface StreamOperations {
+  [action: string]: (this: StreamElement) => void
+}
+
+export const StreamActions: StreamOperations = {
   append() {
     this.targetElement?.append(this.templateContent)
   },

--- a/src/tests/fixtures/stream.html
+++ b/src/tests/fixtures/stream.html
@@ -5,11 +5,27 @@
     <title>Turbo Streams</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script>Turbo.connectStreamSource(new EventSource("/__turbo/messages"))</script>
+    <script>
+      addEventListener("turbo:before-stream-render", ({ detail: { actions } }) => {
+        actions.customUpdate = function() {
+          const marquee = document.createElement("marquee")
+          marquee.append(this.templateContent)
+
+          this.targetElement.append(marquee)
+        }
+      })
+    </script>
   </head>
   <body>
     <form id="create" method="post" action="/__turbo/messages">
       <input type="hidden" name="content" value="Hello world!">
       <input type="hidden" name="type" value="stream">
+      <button type="submit">Create</button>
+    </form>
+    <form id="custom-action" method="post" action="/__turbo/messages">
+      <input type="hidden" name="content" value="Hello world!">
+      <input type="hidden" name="type" value="stream">
+      <input type="hidden" name="actionName" value="customUpdate">
       <button type="submit">Create</button>
     </form>
     <div id="messages">

--- a/src/tests/functional/stream_tests.ts
+++ b/src/tests/functional/stream_tests.ts
@@ -18,6 +18,15 @@ export class StreamTests extends FunctionalTestCase {
     element = await this.querySelector(selector)
     this.assert.equal(await element.getVisibleText(), "Hello world!")
   }
+
+  async "test receiving a stream message with a custom action"() {
+    this.assert.notOk(await this.hasSelector("#messages marquee"))
+
+    await this.clickSelector("#custom-action [type=submit]")
+    await this.nextBeat
+
+    this.assert.ok(await this.hasSelector("#messages marquee"))
+  }
 }
 
 StreamTests.registerSuite()

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -44,12 +44,12 @@ router.post("/reject", (request, response) => {
 })
 
 router.post("/messages", (request, response) => {
-  const { content, status, type } = request.body
+  const { actionName, content, status, type } = request.body
   if (typeof content == "string") {
     receiveMessage(content)
     if (type == "stream" && acceptsStreams(request)) {
       response.type("text/vnd.turbo-stream.html; charset=utf-8")
-      response.send(renderMessage(content))
+      response.send(renderMessage(content, actionName || "append"))
     } else {
       response.sendStatus(parseInt(status || "201", 10))
     }
@@ -99,9 +99,9 @@ function receiveMessage(content: string) {
   }
 }
 
-function renderMessage(content: string) {
+function renderMessage(content: string, action = "append") {
   return `
-    <turbo-stream action="append" target="messages"><template>
+    <turbo-stream action="${action}" target="messages"><template>
       <div class="message">${escapeHTML(content)}</div>
     </template></turbo-stream>
   `


### PR DESCRIPTION
By dispatching the `turbo:before-stream-render` action with an
`event.detail.actions` value set to the default `StreamActions`
instance, clients can merge in their own actions, or override existing
ones by setting mutating `event.detail.actions` in their own event
listeners.