### PR TITLE
Allow a frame to navigate to previous url

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -19,7 +19,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   readonly appearanceObserver: AppearanceObserver
   readonly linkInterceptor: LinkInterceptor
   readonly formInterceptor: FormInterceptor
-  currentURL?: string
+  currentURL?: string | null
   formSubmission?: FormSubmission
   private resolveVisitPromise = () => {}
   private connected = false
@@ -312,6 +312,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   set sourceURL(sourceURL: string | undefined) {
     this.settingSourceURL = true
     this.element.src = sourceURL ?? null
+    this.currentURL = this.element.src
     this.settingSourceURL = false
   }
 
@@ -337,7 +338,7 @@ function getFrameElementById(id: string | null) {
   }
 }
 
-function activateElement(element: Element | null, currentURL?: string) {
+function activateElement(element: Element | null, currentURL?: string | null) {
   if (element) {
     const src = element.getAttribute("src")
     if (src != null && currentURL != null && urlsAreEqual(src, currentURL)) {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -40,5 +40,8 @@
     </turbo-frame>
 
     <a id="frame-self" href="/src/tests/fixtures/frames/self.html" data-turbo-frame="frame">Visit self.html</a>
+
+    <a id="navigate-form-redirect" href="/src/tests/fixtures/frames/form-redirect.html" data-turbo-frame="form-redirect">Visit form-redirect.html</a>
+    <turbo-frame id="form-redirect"></turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/frames/form-redirect.html
+++ b/src/tests/fixtures/frames/form-redirect.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frame</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Page One Form</h1>
+    <turbo-frame id="form-redirect">
+      <h2 id="form-redirect-header">Form Redirect</h2>
+
+      <form action="/__turbo/redirect" method="post" enctype="multipart/form-data">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form-redirected.html">
+        <input type="submit" id="submit-form">
+      </form>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/frames/form-redirected.html
+++ b/src/tests/fixtures/frames/form-redirected.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frame</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Form Redirected</h1>
+    <turbo-frame id="form-redirect">
+      <h2 id="form-redirected-header">Form Redirected</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -116,6 +116,23 @@ export class FrameTests extends TurboDriveTestCase {
 
     await this.nextEventNamed("turbo:before-fetch-request")
   }
+
+  async "test redirecting in a form is still navigatable after redirect"() {
+    await this.nextBeat
+    await this.clickSelector("#navigate-form-redirect")
+    await this.nextBeat
+    this.assert.ok(await this.querySelector("#form-redirect"))
+
+    await this.nextBeat
+    await this.clickSelector("#submit-form")
+    await this.nextBeat
+    this.assert.ok(await this.querySelector("#form-redirected-header"))
+
+    await this.nextBeat
+    await this.clickSelector("#navigate-form-redirect")
+    await this.nextBeat
+    this.assert.ok(await this.querySelector("#form-redirect-header"))
+  }
 }
 
 FrameTests.registerSuite()


### PR DESCRIPTION
This is my attempt at a fix based on discussion and the previous PR as well as adding a test for it.

The gist: A frame will only update/make a request if `currentURL` and `sourceURL` are different. `currentURL` was not get updated properly so it was still pointing to the previous value. If `sourceURL` changes back to the original URL of the frame, the values would match and result in the frame not navigating.

Example:
- Frame gets src set to "a". `sourceURL` and `currentURL` are set to "a"
- The frame's src is changed to "b". While `sourceURL` is updated, `currentURL` is still "a". Frame navigates to "b".
- The frame's src is changed back to "a". Because `currentURL` was never changed to "b", navigation doesn't happen because `sourceURL` == `currentURL`. 

Fixes #245 
Fixes #249 (I presume)
Fixes #265 (Reported)