### PR TITLE
Allow form fields to be named "action"

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -64,7 +64,7 @@ export class FormSubmission {
   }
 
   get action(): string {
-    return this.submitter?.getAttribute("formaction") || this.formElement.action
+    return this.submitter?.getAttribute("formaction") || this.formElement.getAttribute("action")
   }
 
   get location(): URL {

--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -64,7 +64,7 @@ export class FormSubmission {
   }
 
   get action(): string {
-    return this.submitter?.getAttribute("formaction") || this.formElement.getAttribute("action")
+    return this.submitter?.getAttribute("formaction") || this.formElement.getAttribute("action") || this.formElement.action
   }
 
   get location(): URL {


### PR DESCRIPTION
Hi! This is my first pull request here so bare with me...

Drive form submissions do not work as expected if there is a form field with `name="action"`. This PR changes this behavior.

For reference, the Mozilla docs describe the [Issues with Naming Elements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#issues_with_naming_elements). Here's the relevant bit:

> Some names will interfere with JavaScript access to the form’s properties and elements.
> 
> For example:
> 
> `<input name="id">` will take precedence over `<form id="…">`. This means that `form.id` will not refer to the form’s id, but to the element whose name is "id". This will be the case with any other form properties, such as `<input name="action">` or `<input name="post">`.

You can test this by adding something like this to any form:

```html
<input type="hidden" name="action" value="close_after_saving" />
```

Maybe this is the intended behavior? I was unable to find any documentation on it, either way.

Thank you for the work you've put into Turbo/Stimulus. They each have transformed the way I build things in the best way possible. 🥇 