### PR TITLE
Fix check for anchor in `scrollToAnchor`

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -310,7 +310,7 @@ export class Visit implements FetchRequestDelegate {
   }
 
   scrollToAnchor() {
-    if (getAnchor(this.location) != null) {
+    if (getAnchor(this.location)) {
       this.view.scrollToAnchor(getAnchor(this.location))
       return true
     }


### PR DESCRIPTION
When there is no anchor but there is an element on the page with an empty `id` or `name` attribute, `scrollToAnchor` scrolls to that element.

This is because `getAnchor` returns an empty string but the current code checks for `null`.