### PR TITLE
Fix navigation via links contained in shadow DOM trees

### DIFF
--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -33,8 +33,13 @@ export class LinkClickObserver {
   }
 
   clickBubbled = (event: MouseEvent) => {
+    // TODO: remove before any merge
+    console.log("event: ", event)
+    console.log("target is: ", event.target)
+    console.log("fixed target is: ", event.composedPath()[0])
     if (this.clickEventIsSignificant(event)) {
-      const link = this.findLinkFromClickTarget(event.target)
+      const target = event.composedPath()[0]
+      const link = this.findLinkFromClickTarget(target)
       if (link) {
         const location = this.getLocationForLink(link)
         if (this.delegate.willFollowLinkToLocation(link, location)) {

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -5,6 +5,22 @@
     <title>Turbo</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
+    <script>
+      class CustomLinkElement extends HTMLElement {
+        constructor() {
+          super()
+          this.attachShadow({ mode: 'open' })
+        }
+        connectedCallback() {
+          this.shadowRoot.innerHTML = `
+            <a href="${this.getAttribute('link')}">
+              ${this.getAttribute('text')}
+            </a>
+          `
+        }
+      }
+      window.customElements.define('custom-link-element', CustomLinkElement)
+    </script>
   </head>
   <body>
     <section>
@@ -26,6 +42,7 @@
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
       <p><a id="link-to-disabled-frame" href="/src/tests/fixtures/frames/hello.html" data-turbo-frame="hello">Disabled turbo-frame</a></p>
       <p><a id="autofocus-link" href="/src/tests/fixtures/autofocus.html">autofocus.html link</a></p>
+      <p><custom-link-element id="same-origin-unannotated-custom-element-link" link="/src/tests/fixtures/one.html" text="Same-origin unannotated custom element link"></custom-link-element></p>
     </section>
 
     <turbo-frame id="hello" disabled></turbo-frame>


### PR DESCRIPTION
[Current link click handling logic](https://github.com/hotwired/turbo/blob/aae03ada8be4b46899330364d712cc1ae57f2400/src/observers/link_click_observer.ts#L62) will search up the DOM tree starting from
the `MouseEvent.target` element for an `a[href]` link element. With
this element present, Turbo can take over navigation from the browser.

However when such a link element finds itself contained within a
shadow DOM tree, browsers will set the `MouseEvent.target` to be
the shadow DOM's parent (both chrome and firefox). This parent is above the link element
and hence Turbo will assume no link was clicked, will stand down
and the browser's default navigation behavior will take over, leading
to a full page navigation.

problem illustrated:
```
...
<my-custom-element>
  #shadow-root (mode=open)
      <a href="next-page.html">Click here</a>
</my-custom-element>
```
for a click on "Click here", current code will seek `MouseEvent.target` which returns `<my-custom-element>`and search up for the link starting from there, and never find it. Updated code using `MouseEvent.composedPath()` will search up starting at `<a href="next-page.html">` which will match.

Using `MouseEvent.composedPath()` allows reaching the 'real' target
of the click.

I am not familiar with any downsides of using `composedPath()`. From a performance point of view, I feel things should be ok as the call is made sparingly.

Here I implement a fix using `composedPath()`. It fixes my app where my buttons and links are encapsulated inside custom elements using shadow DOMs. Seems to work for me.

Writing a test however has been a challenge and **this PR cannot currently be merged**. Please see comments inline.
I'm hoping my challenge in writing a test case is clear enough in the code comment I left, happy to expand.

If this PR seems adequate for this repo, I will be seeking advice on what to do with the test.