### PR TITLE
Turn links with methods into form submissions

### DIFF
--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -47,6 +47,7 @@
         <input type="hidden" name="query" value="2">
         <input type="submit">
       </form>
+      <a href="/__turbo/redirect?path=/src/tests/fixtures/form.html&greeting=Hello%20from%20a%20redirect" data-turbo-method="post" id="link-method-redirect">Redirect link</a>
     </div>
     <hr>
     <div id="no-action">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -331,6 +331,15 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
   }
 
+  async "test link method form submission"() {
+    await this.clickSelector("#link-method-redirect")
+    await this.nextBody
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+    this.assert.equal(await this.visitAction, "advance")
+    this.assert.equal(await this.getSearchParam("greeting"), "Hello from a redirect")
+  }
+
   get formSubmitted(): Promise<boolean> {
     return this.hasSelector("html[data-form-submitted]")
   }


### PR DESCRIPTION
Rails UJS offered a path to turn links into form submissions via the data-method attribute. This PR recreates that capability under data-turbo-method (but also with data-method for compatibility with existing apps built to Rails UJS). 

The link is turned into a form that's added next to the link in the dom, such that all the frame scopes still apply, and corresponding behavior is triggered.

For accessibility reasons, we should continue to promote buttons rather than method links, but this makes Hotwire much easier to fit into existing applications that were built to Rails UJS standards.