### PR TITLE
Make links ping

### DIFF
--- a/src/core/drive/ping.ts
+++ b/src/core/drive/ping.ts
@@ -1,0 +1,30 @@
+import { FormSubmission, FormSubmissionDelegate } from "./form_submission"
+import { FetchResponse } from "../../http/fetch_response"
+
+export class Ping implements FormSubmissionDelegate {
+  readonly url: URL
+
+  constructor(url: URL) {
+    this.url = url
+  }
+
+  perform() {
+    const formSubmission = new FormSubmission(this, this.createFormElement())
+    formSubmission.start()
+  }
+
+  createFormElement(): HTMLFormElement {
+    const form = document.createElement("form")
+    form.action = this.url.href
+    form.method = "POST"
+    return form
+  }
+
+  // Form submission delegate
+
+  formSubmissionStarted(formSubmission: FormSubmission): void {}
+  formSubmissionSucceededWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse): void {}
+  formSubmissionFailedWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse): void {}
+  formSubmissionErrored(formSubmission: FormSubmission, error: Error): void {}
+  formSubmissionFinished(formSubmission: FormSubmission): void {}
+}

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -15,6 +15,7 @@ import { dispatch } from "../util"
 import { PageView, PageViewDelegate } from "./drive/page_view"
 import { Visit, VisitOptions } from "./drive/visit"
 import { PageSnapshot } from "./drive/page_snapshot"
+import { Ping } from "./drive/ping"
 
 export type TimingData = {}
 
@@ -130,6 +131,10 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   followedLinkToLocation(link: Element, location: URL) {
     const action = this.getActionForLink(link)
     this.visit(location.href, { action })
+  }
+
+  ping(url: URL) {
+    new Ping(url).perform()
   }
 
   // Navigator delegate

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -3,6 +3,7 @@ import { expandURL } from "../core/url"
 export interface LinkClickObserverDelegate {
   willFollowLinkToLocation(link: Element, location: URL): boolean
   followedLinkToLocation(link: Element, location: URL): void
+  ping(url: URL): void
 }
 
 export class LinkClickObserver {
@@ -41,6 +42,11 @@ export class LinkClickObserver {
           event.preventDefault()
           this.delegate.followedLinkToLocation(link, location)
         }
+
+        if (willPing(link)) {
+          const pings = this.getPingLocationsForLink(link)
+          pings.forEach(url => this.delegate.ping(url))
+        }
       }
     }
   }
@@ -66,4 +72,17 @@ export class LinkClickObserver {
   getLocationForLink(link: Element): URL {
     return expandURL(link.getAttribute("href") || "")
   }
+
+  getPingLocationsForLink(link: Element): URL[] {
+    const attribute = link.getAttribute("ping")
+    if (attribute && attribute.length > 0) {
+      return attribute.split(" ").map(link => expandURL(link))
+    } else {
+      return []
+    }
+  }
+}
+
+function willPing(link: Element) {
+  return link.hasAttribute("ping")
 }

--- a/src/tests/functional/ping_tests.ts
+++ b/src/tests/functional/ping_tests.ts
@@ -1,0 +1,9 @@
+import { TurboDriveTestCase } from "../helpers/turbo_drive_test_case"
+
+declare const Turbo: any
+
+export class PingTests extends TurboDriveTestCase {
+  async "test pinging when clicking a link"() {
+    await this.clickSelector("")
+  }
+}


### PR DESCRIPTION
`<a>` tags have a handy [`ping` attribute](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a#attr-ping) that send POST requests to some specified URLs when you click the link. This can come in handy when, for example, you have a list of notifications that link somewhere in the app, and you want to mark the notification as read when you click through. Eg: `<a href="/messages/232" ping="/notifications/599/readings">`.

Turbo doesn’t do anything with pings at present. This makes it ping.