### PR TITLE
Let submitter values be null

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -171,7 +171,12 @@ export class FormSubmission {
 function buildFormData(formElement: HTMLFormElement, submitter?: HTMLElement): FormData {
   const formData = new FormData(formElement)
   const name = submitter?.getAttribute("name")
-  const value = submitter?.getAttribute("value")
+  let value = submitter?.getAttribute("value")
+
+  const formMethod = submitter?.getAttribute("formmethod") || formElement.getAttribute("method") || formElement.method
+  if (formMethod.toLowerCase() != "get") {
+    value ??= ""
+  }
 
   if (name && value != null && formData.get(name) != value) {
     formData.append(name, value)


### PR DESCRIPTION
Fixes #272 

If you name a `<button>` in your form, it, together with its value, should get sent through to the server. Turbo handles this, except for one case. When the button has a `value` of null, Turbo won’t send even the button's name in the form data. That’s desirable, probably, for GET requests, since you don’t want a null value in your query string. But it can lead to surprises on POST.

This special cases GET requests so we always send the button param through on POST, even if it has no value.