### PR TITLE
Add package-lock.json to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /dist
 /node_modules
 *.log
+package-lock.json


### PR DESCRIPTION
Removes the risk of accidentally committing the lock file as in https://github.com/hotwired/turbo/pull/121, https://github.com/hotwired/turbo/commit/b15c256aa7fbae199a54f83356cfdf82616df15d.

I might be missing a reason it wasn't in .gitignore already though! 🙇 
Is there maybe a use case I'm overlooking?