### PR TITLE
Include url in `turbo:before-fetch-request` event

### DIFF
--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -132,7 +132,7 @@ export class FetchRequest {
 
   private async allowRequestToBeIntercepted(fetchOptions: RequestInit) {
     const requestInterception = new Promise(resolve => this.resolveRequestPromise = resolve)
-    const event = dispatch("turbo:before-fetch-request", { cancelable: true, detail: { fetchOptions, resume: this.resolveRequestPromise } })
+    const event = dispatch("turbo:before-fetch-request", { cancelable: true, detail: { fetchOptions, url: this.url.href, resume: this.resolveRequestPromise } })
     if (event.defaultPrevented) await requestInterception
   }
 }

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -5,7 +5,7 @@ declare const Turbo: any
 
 export class VisitTests extends TurboDriveTestCase {
   async setup() {
-    this.goToLocation("/src/tests/fixtures/visit.html")
+    await this.goToLocation("/src/tests/fixtures/visit.html")
   }
 
   async "test programmatically visiting a same-origin location"() {

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -71,6 +71,14 @@ export class VisitTests extends TurboDriveTestCase {
     this.assert(await this.changedBody)
   }
 
+  async "test turbo:before-fetch-request event.detail"() {
+    await this.clickSelector("#same-origin-link")
+    const { url, fetchOptions } = await this.nextEventNamed("turbo:before-fetch-request")
+
+    this.assert.equal(fetchOptions.method, "GET")
+    this.assert.include(url, "/src/tests/fixtures/one.html")
+  }
+
   async visitLocation(location: string) {
     this.remote.execute((location: string) => window.Turbo.visit(location), [location])
   }


### PR DESCRIPTION
Hello all and thank you for Turbo.

Although the `turbo:before-fetch-request` event includes the request's `fetchOptions` (method, headers, etc), it doesn't include the URL itself. With this patch applied you can access it with `event.detail.url`.

If it gets accepted I can send a PR to add a reference to the `events` documentation in https://github.com/hotwired/turbo-site/.