### PR TITLE
Copy CSP nonce to script element inside turbo frames

### DIFF
--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -42,6 +42,9 @@ export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapsh
       return element
     } else {
       const createdScriptElement = document.createElement("script")
+      if (this.cspNonce) {
+        createdScriptElement.nonce = this.cspNonce
+      }
       createdScriptElement.textContent = element.textContent
       createdScriptElement.async = false
       copyElementAttributes(createdScriptElement, element)
@@ -74,6 +77,10 @@ export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapsh
 
   get permanentElementMap() {
     return this.currentSnapshot.getPermanentElementMapForSnapshot(this.newSnapshot)
+  }
+
+  get cspNonce() {
+    return document.head.querySelector('meta[name="csp-nonce"]')?.getAttribute("content")
   }
 }
 


### PR DESCRIPTION
PR #192 added support to evaluate `script` elements in turbo frames. I found out, that it worked for me only when CSP was disabled or sets with `unsafe_inline` for `script_src`.

This small change allows to use it when the CSP nonce generation is used in the application.

I am sorry, but I was not able to find a way how to write a proper test for it. Any help with that will be very welcomed. I only tested it locally with the latest Rails with this CSP setting:

```ruby
Rails.application.config.content_security_policy do |policy|
  policy.script_src :self, :https
end

Rails.application.config.content_security_policy_nonce_generator = -> request { SecureRandom.base64(16) }
Rails.application.config.content_security_policy_nonce_directives = %w[script-src]
```

Thank you for any feedback or help with this PR 🙂