### PR TITLE
History needs to visit with a restoration identifier to restore scroll position

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -109,9 +109,9 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
 
   // History delegate
 
-  historyPoppedToLocationWithRestorationIdentifier(location: URL) {
+  historyPoppedToLocationWithRestorationIdentifier(location: URL, restorationIdentifier: string) {
     if (this.enabled) {
-      this.navigator.proposeVisit(location, { action: "restore", historyChanged: true })
+      this.navigator.startVisit(location, restorationIdentifier, { action: "restore", historyChanged: true })
     } else {
       this.adapter.pageInvalidated()
     }

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -76,6 +76,7 @@ export class VisitTests extends TurboDriveTestCase {
     await this.drainEventLog()
     await this.nextBeat
 
+    this.cancelNextVisit()
     await this.goBack()
     this.assert(await this.changedBody)
   }


### PR DESCRIPTION
We don't need to go through proposeVisit, because the visit already passed that check to get into the history.