### PR TITLE
Ignore noscript elements inside head

### DIFF
--- a/src/core/drive/head_snapshot.ts
+++ b/src/core/drive/head_snapshot.ts
@@ -7,7 +7,9 @@ type ElementDetails = { type?: ElementType, tracked: boolean, elements: Element[
 type ElementType = "script" | "stylesheet"
 
 export class HeadSnapshot extends Snapshot<HTMLHeadElement> {
-  readonly detailsByOuterHTML = this.children.reduce((result, element) => {
+  readonly detailsByOuterHTML = this.children
+    .filter((element) => !elementIsNoscript(element))
+    .reduce((result, element) => {
     const { outerHTML } = element
     const details: ElementDetails
       = outerHTML in result
@@ -91,6 +93,11 @@ function elementIsTracked(element: Element) {
 function elementIsScript(element: Element) {
   const tagName = element.tagName.toLowerCase()
   return tagName == "script"
+}
+
+function elementIsNoscript(element: Element) {
+  const tagName = element.tagName.toLowerCase()
+  return tagName == "noscript"
 }
 
 function elementIsStylesheet(element: Element) {

--- a/src/tests/fixtures/additional_assets.html
+++ b/src/tests/fixtures/additional_assets.html
@@ -6,6 +6,9 @@
     <link rel="stylesheet" type="text/css" href="/src/tests/fixtures/test.css">
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
+    <noscript>
+      <link rel="stylesheet" type="text/css" href="/src/tests/fixtures/noscript.css">
+    </noscript>
   </head>
   <body>
     <h1>Additional assets</h1>

--- a/src/tests/fixtures/noscript.css
+++ b/src/tests/fixtures/noscript.css
@@ -1,0 +1,3 @@
+:root {
+  --black-if-noscript-evaluated: black;
+}

--- a/src/tests/fixtures/test.css
+++ b/src/tests/fixtures/test.css
@@ -1,0 +1,3 @@
+:root {
+  --black-if-evaluated: black;
+}

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -72,6 +72,22 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert(!await this.hasSelector("meta[name=test]"))
   }
 
+  async "test evaluates head stylesheet elements"() {
+    this.assert.equal(await this.isStylesheetEvaluated, false)
+
+    this.clickSelector("#additional-assets-link")
+    await this.nextEventNamed("turbo:render")
+    this.assert.equal(await this.isStylesheetEvaluated, true)
+  }
+
+  async "test does not evaluate head stylesheet elements inside noscript elements"() {
+    this.assert.equal(await this.isNoscriptStylesheetEvaluated, false)
+
+    this.clickSelector("#additional-assets-link")
+    await this.nextEventNamed("turbo:render")
+    this.assert.equal(await this.isNoscriptStylesheetEvaluated, false)
+  }
+
   async "skip evaluates head script elements once"() {
     this.assert.equal(await this.headScriptEvaluationCount, undefined)
 
@@ -207,6 +223,14 @@ export class RenderingTests extends TurboDriveTestCase {
 
   get bodyScriptEvaluationCount(): Promise<number | undefined> {
     return this.evaluate(() => window.bodyScriptEvaluationCount)
+  }
+
+  get isStylesheetEvaluated(): Promise<boolean> {
+    return this.evaluate(() => getComputedStyle(document.body).getPropertyValue("--black-if-evaluated").trim() === "black")
+  }
+
+  get isNoscriptStylesheetEvaluated(): Promise<boolean> {
+    return this.evaluate(() => getComputedStyle(document.body).getPropertyValue("--black-if-noscript-evaluated").trim() === "black")
   }
 
   async modifyBodyBeforeCaching() {


### PR DESCRIPTION
This pull request prevents Turbo from evaluating `<noscript>` elements inside the `<head>` element.

As a descendant of the `<head>` element, a `<noscript>` element can include `<style>` and `<link>` elements. This is useful for example, to show modals for script-enabled users and always to show modal contents for script-disabled users.
ref: [&lt;noscript&gt; - HTML: HyperText Markup Language | MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/noscript)

Currently, Turbo evaluates stylesheets inside `<head>` elements even though those are inside `<noscript>` elements. This causes unexpected style for script-enabled users after a page transition.

When Turbo requests, JavaScript is definitely enabled. So `<noscript>` elements can be safely ignored.