### PR TITLE
Prevent reloading pages when tapping same-page anchors

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -9,6 +9,7 @@ import { PageSnapshot } from "./page_snapshot"
 export type NavigatorDelegate = VisitDelegate & {
   allowsVisitingLocation(location: URL): boolean
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>): void
+  notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
 
 export class Navigator {
@@ -122,6 +123,10 @@ export class Navigator {
   locationWithActionIsSamePage(location: URL, action: Action): boolean {
     return getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
       (getAnchor(location) != null || action == "restore")
+  }
+
+  visitScrolledToSamePageLocation(oldURL: URL, newURL: URL) {
+    this.delegate.visitScrolledToSamePageLocation(oldURL, newURL)
   }
 
   // Visits

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -2,7 +2,7 @@ import { Action, isAction } from "../types"
 import { FetchMethod } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { FormSubmission } from "./form_submission"
-import { expandURL, Locatable } from "../url"
+import { expandURL, getAnchor, getRequestURL, Locatable } from "../url"
 import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
@@ -117,6 +117,11 @@ export class Navigator {
 
   visitCompleted(visit: Visit) {
     this.delegate.visitCompleted(visit)
+  }
+
+  locationWithActionIsSamePage(location: URL, action: Action): boolean {
+    return getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
+      (getAnchor(location) != null || action == "restore")
   }
 
   // Visits

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -310,8 +310,9 @@ export class Visit implements FetchRequestDelegate {
   }
 
   scrollToAnchor() {
-    if (getAnchor(this.location)) {
-      this.view.scrollToAnchor(getAnchor(this.location))
+    const anchor = getAnchor(this.location)
+    if (anchor != null) {
+      this.view.scrollToAnchor(anchor)
       return true
     }
   }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -2,7 +2,7 @@ import { Adapter } from "../native/adapter"
 import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { History } from "./history"
-import { getAnchor, getRequestURL } from "../url"
+import { getAnchor } from "../url"
 import { PageSnapshot } from "./page_snapshot"
 import { Action } from "../types"
 import { uuid } from "../../util"
@@ -15,6 +15,7 @@ export interface VisitDelegate {
 
   visitStarted(visit: Visit): void
   visitCompleted(visit: Visit): void
+  locationWithActionIsSamePage(location: URL, action: Action): boolean
 }
 
 export enum TimingMetric {
@@ -90,11 +91,7 @@ export class Visit implements FetchRequestDelegate {
     this.referrer = referrer
     this.snapshotHTML = snapshotHTML
     this.response = response
-
-    this.isSamePage = (
-      getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
-      (getAnchor(location) != null || this.action == "restore")
-    )
+    this.isSamePage = this.delegate.locationWithActionIsSamePage(this.location, this.action)
   }
 
   get adapter() {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -84,7 +84,7 @@ export class Visit implements FetchRequestDelegate {
     this.location = location
     this.isSamePage = (
       getAnchor(location) != null &&
-      getRequestURL(location) === getRequestURL(new URL(window.location.href))
+      getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation)
     )
 
     this.restorationIdentifier = restorationIdentifier || uuid()

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -16,6 +16,7 @@ export interface VisitDelegate {
   visitStarted(visit: Visit): void
   visitCompleted(visit: Visit): void
   locationWithActionIsSamePage(location: URL, action: Action): boolean
+  visitScrolledToSamePageLocation(oldURL: URL, newURL: URL): void
 }
 
 export enum TimingMetric {
@@ -313,6 +314,10 @@ export class Visit implements FetchRequestDelegate {
       } else {
         this.scrollToAnchor() || this.scrollToTop()
       }
+      if (this.isSamePage) {
+        this.delegate.visitScrolledToSamePageLocation(this.view.lastRenderedLocation, this.location)
+      }
+
       this.scrolled = true
     }
   }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -2,7 +2,7 @@ import { Adapter } from "../native/adapter"
 import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { History } from "./history"
-import { getAnchor } from "../url"
+import { getAnchor, getRequestURL } from "../url"
 import { PageSnapshot } from "./page_snapshot"
 import { Action } from "../types"
 import { uuid } from "../../util"
@@ -70,6 +70,7 @@ export class Visit implements FetchRequestDelegate {
   frame?: number
   historyChanged = false
   location: URL
+  isSamePage: boolean
   redirectedToLocation?: URL
   request?: FetchRequest
   response?: VisitResponse
@@ -81,6 +82,11 @@ export class Visit implements FetchRequestDelegate {
   constructor(delegate: VisitDelegate, location: URL, restorationIdentifier: string | undefined, options: Partial<VisitOptions> = {}) {
     this.delegate = delegate
     this.location = location
+    this.isSamePage = (
+      getAnchor(location) != null &&
+      getRequestURL(location) === getRequestURL(new URL(window.location.href))
+    )
+
     this.restorationIdentifier = restorationIdentifier || uuid()
 
     const { action, historyChanged, referrer, snapshotHTML, response } = { ...defaultOptions, ...options }
@@ -234,10 +240,14 @@ export class Visit implements FetchRequestDelegate {
       const isPreview = this.shouldIssueRequest()
       this.render(async () => {
         this.cacheSnapshot()
-        await this.view.renderPage(snapshot, isPreview)
-        this.adapter.visitRendered(this)
-        if (!isPreview) {
-          this.complete()
+        if (this.isSamePage) {
+          this.adapter.visitRendered(this)
+        } else {
+          await this.view.renderPage(snapshot, isPreview)
+          this.adapter.visitRendered(this)
+          if (!isPreview) {
+            this.complete()
+          }
         }
       })
     }
@@ -248,6 +258,15 @@ export class Visit implements FetchRequestDelegate {
       this.location = this.redirectedToLocation
       this.history.replace(this.redirectedToLocation, this.restorationIdentifier)
       this.followedRedirect = true
+    }
+  }
+
+  goToSamePageAnchor() {
+    if (this.isSamePage) {
+      this.render(async () => {
+        this.cacheSnapshot()
+        this.adapter.visitRendered(this)
+      })
     }
   }
 
@@ -346,9 +365,13 @@ export class Visit implements FetchRequestDelegate {
   }
 
   shouldIssueRequest() {
-    return this.action == "restore"
-      ? !this.hasCachedSnapshot()
-      : true
+    if (this.action == "restore") {
+      return !this.hasCachedSnapshot()
+    } else if (this.isSamePage) {
+      return false
+    } else {
+      return true
+    }
   }
 
   cacheSnapshot() {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -82,11 +82,6 @@ export class Visit implements FetchRequestDelegate {
   constructor(delegate: VisitDelegate, location: URL, restorationIdentifier: string | undefined, options: Partial<VisitOptions> = {}) {
     this.delegate = delegate
     this.location = location
-    this.isSamePage = (
-      getAnchor(location) != null &&
-      getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation)
-    )
-
     this.restorationIdentifier = restorationIdentifier || uuid()
 
     const { action, historyChanged, referrer, snapshotHTML, response } = { ...defaultOptions, ...options }
@@ -95,6 +90,11 @@ export class Visit implements FetchRequestDelegate {
     this.referrer = referrer
     this.snapshotHTML = snapshotHTML
     this.response = response
+
+    this.isSamePage = (
+      getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
+      (getAnchor(location) != null || this.action == "restore")
+    )
   }
 
   get adapter() {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -312,7 +312,7 @@ export class Visit implements FetchRequestDelegate {
   performScroll() {
     if (!this.scrolled) {
       if (this.action == "restore") {
-        this.scrollToRestoredPosition() || this.scrollToTop()
+        this.scrollToRestoredPosition() || this.scrollToAnchor() || this.scrollToTop()
       } else {
         this.scrollToAnchor() || this.scrollToTop()
       }
@@ -365,10 +365,10 @@ export class Visit implements FetchRequestDelegate {
   }
 
   shouldIssueRequest() {
-    if (this.action == "restore") {
-      return !this.hasCachedSnapshot()
-    } else if (this.isSamePage) {
+    if (this.isSamePage) {
       return false
+    } else if (this.action == "restore") {
+      return !this.hasCachedSnapshot()
     } else {
       return true
     }

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -21,6 +21,7 @@ export class BrowserAdapter implements Adapter {
   visitStarted(visit: Visit) {
     visit.issueRequest()
     visit.changeHistory()
+    visit.goToSamePageAnchor()
     visit.loadCachedSnapshot()
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -172,6 +172,10 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     this.notifyApplicationAfterPageLoad(visit.getTimingMetrics())
   }
 
+  locationWithActionIsSamePage(location: URL, action: Action): boolean {
+    return this.navigator.locationWithActionIsSamePage(location, action)
+  }
+
   // Form submit observer delegate
 
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -176,6 +176,10 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     return this.navigator.locationWithActionIsSamePage(location, action)
   }
 
+  visitScrolledToSamePageLocation(oldURL: URL, newURL: URL) {
+    this.notifyApplicationAfterVisitingSamePageLocation(oldURL, newURL)
+  }
+
   // Form submit observer delegate
 
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {
@@ -265,6 +269,10 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
 
   notifyApplicationAfterPageLoad(timing: TimingData = {}) {
     return dispatch("turbo:load", { detail: { url: this.location.href, timing }})
+  }
+
+  notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL) {
+    dispatchEvent(new HashChangeEvent("hashchange", { oldURL: oldURL.toString(), newURL: newURL.toString() }))
   }
 
   // Private

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -9,11 +9,11 @@ export class Snapshot<E extends Element = Element> {
     return [ ...this.element.children ]
   }
 
-  hasAnchor(anchor: string) {
+  hasAnchor(anchor: string | undefined) {
     return this.getElementForAnchor(anchor) != null
   }
 
-  getElementForAnchor(anchor: string) {
+  getElementForAnchor(anchor: string | undefined) {
     try {
       return this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`)
     } catch {

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -10,8 +10,6 @@ export function getAnchor(url: URL) {
     return url.hash.slice(1)
   } else if (anchorMatch = url.href.match(/#(.*)$/)) {
     return anchorMatch[1]
-  } else {
-    return ""
   }
 }
 

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -26,13 +26,15 @@ export function isPrefixedBy(baseURL: URL, url: URL) {
   return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
 }
 
+export function getRequestURL(url: URL) {
+  const anchor = getAnchor(url)
+  return anchor != null
+    ? url.href.slice(0, -(anchor.length + 1))
+    : url.href
+}
+
 export function toCacheKey(url: URL) {
-  const anchorLength = url.hash.length
-  if (anchorLength < 2) {
-    return url.href
-  } else {
-    return url.href.slice(0, -anchorLength)
-  }
+  return getRequestURL(url)
 }
 
 export function urlsAreEqual(left: string, right: string) {

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -26,6 +26,7 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
     const element = this.snapshot.getElementForAnchor(anchor)
     if (element) {
       this.scrollToElement(element)
+      this.focusElement(element)
     } else {
       this.scrollToPosition({ x: 0, y: 0 })
     }
@@ -41,6 +42,13 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
 
   get scrollRoot(): { scrollTo(x: number, y: number): void } {
     return window
+  }
+
+  focusElement(element: Element | HTMLElement) {
+    const tabindex = element.getAttribute('tabindex')
+    element.setAttribute('tabindex', '-1')
+    if ('focus' in element) element.focus()
+    tabindex ? element.setAttribute('tabindex', tabindex) : element.removeAttribute('tabindex')
   }
 
   // Rendering

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -1,6 +1,7 @@
 import { Renderer } from "./renderer"
 import { Snapshot } from "./snapshot"
 import { Position } from "./types"
+import { getAnchor } from "./url"
 
 export interface ViewDelegate<S extends Snapshot> {
   allowsImmediateRender(snapshot: S, resume: (value: any) => void): boolean
@@ -22,7 +23,7 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
 
   // Scrolling
 
-  scrollToAnchor(anchor: string) {
+  scrollToAnchor(anchor: string | undefined) {
     const element = this.snapshot.getElementForAnchor(anchor)
     if (element) {
       this.scrollToElement(element)
@@ -30,6 +31,10 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
     } else {
       this.scrollToPosition({ x: 0, y: 0 })
     }
+  }
+
+  scrollToAnchorFromLocation(location: URL) {
+    this.scrollToAnchor(getAnchor(location))
   }
 
   scrollToElement(element: Element) {

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -36,19 +36,24 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
     element.scrollIntoView()
   }
 
+  focusElement(element: Element) {
+    if (element instanceof HTMLElement) {
+      if (element.hasAttribute("tabindex")) {
+        element.focus()
+      } else {
+        element.setAttribute("tabindex", "-1")
+        element.focus()
+        element.removeAttribute("tabindex")
+      }
+    }
+  }
+
   scrollToPosition({ x, y }: Position) {
     this.scrollRoot.scrollTo(x, y)
   }
 
   get scrollRoot(): { scrollTo(x: number, y: number): void } {
     return window
-  }
-
-  focusElement(element: Element | HTMLElement) {
-    const tabindex = element.getAttribute('tabindex')
-    element.setAttribute('tabindex', '-1')
-    if ('focus' in element) element.focus()
-    tabindex ? element.setAttribute('tabindex', tabindex) : element.removeAttribute('tabindex')
   }
 
   // Rendering

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -7,7 +7,11 @@
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
-    <section>
+    <a href="#main">Skip Link</a>
+
+    <a href="#ignored-link" id="ignored-link">Skipped Content</a>
+
+    <section id="main" style="height: 200vh">
       <h1>Navigation</h1>
       <p><a id="same-origin-unannotated-link" href="/src/tests/fixtures/one.html">Same-origin unannotated link</a></p>
       <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button>Same-origin unannotated form</button></form></p>

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -145,37 +145,35 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/hello.html")
   }
 
-  async "test skip link with hash-only path"() {
+  async "test skip link with hash-only path scrolls to the anchor without a visit"() {
     const bodyElementId = (await this.body).elementId
     await this.clickSelector('a[href="#main"]')
-
     await this.nextBeat
-    this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
-    this.assert.equal(await this.hash, "#main")
-    this.assert.equal((await this.body).elementId, bodyElementId, "does not reload page")
-    this.assert.ok(await this.isScrolledToSelector("#main"))
 
+    this.assert.equal((await this.body).elementId, bodyElementId, "does not reload page")
+    this.assert.ok(await this.isScrolledToSelector("#main"), "scrolled to #main")
+  }
+
+  async "test skip link with hash-only path moves focus and changes tab order"() {
+    await this.clickSelector('a[href="#main"]')
+    await this.nextBeat
     await this.pressTab()
-    const activeElement = await this.remote.getActiveElement()
-    const skippedLink = await this.querySelector("#ignored-link")
-    const firstLinkWithinMain = await this.querySelector("#main a:first-of-type")
-    this.assert.notOk(await activeElement.equals(skippedLink), "skips interactive elements before #main")
-    this.assert.ok(await activeElement.equals(firstLinkWithinMain), "skips to first interactive element after #main")
+
+    this.assert.notOk(await this.selectorHasFocus("#ignored-link"), "skips interactive elements before #main")
+    this.assert.ok(await this.selectorHasFocus("#main a:first-of-type"), "skips to first interactive element after #main")
   }
 
   async "test navigating back to anchored URL"() {
     await this.clickSelector('a[href="#main"]')
-    this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
-    this.assert.equal(await this.hash, "#main")
-    this.assert.ok(await this.isScrolledToSelector("#main"))
+    await this.nextBeat
 
-    this.clickSelector("#same-origin-unannotated-link")
+    await this.clickSelector("#same-origin-unannotated-link")
     await this.nextBody
-    this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+    await this.nextBeat
+
     await this.goBack()
-    this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
-    this.assert.equal(await this.hash, "#main")
-    this.assert.ok(await this.isScrolledToSelector("#main"))
+
+    this.assert.ok(await this.isScrolledToSelector("#main"), "scrolled to #main")
   }
 }
 

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -162,6 +162,21 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.notOk(await activeElement.equals(skippedLink), "skips interactive elements before #main")
     this.assert.ok(await activeElement.equals(firstLinkWithinMain), "skips to first interactive element after #main")
   }
+
+  async "test navigating back to anchored URL"() {
+    await this.clickSelector('a[href="#main"]')
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
+    this.assert.equal(await this.hash, "#main")
+    this.assert.ok(await this.isScrolledToSelector("#main"))
+
+    this.clickSelector("#same-origin-unannotated-link")
+    await this.nextBody
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+    await this.goBack()
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
+    this.assert.equal(await this.hash, "#main")
+    this.assert.ok(await this.isScrolledToSelector("#main"))
+  }
 }
 
 NavigationTests.registerSuite()

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -146,10 +146,13 @@ export class NavigationTests extends TurboDriveTestCase {
   }
 
   async "test skip link with hash-only path"() {
+    const bodyElementId = (await this.body).elementId
     await this.clickSelector('a[href="#main"]')
 
+    await this.nextBeat
     this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
     this.assert.equal(await this.hash, "#main")
+    this.assert.equal((await this.body).elementId, bodyElementId, "does not reload page")
     this.assert.ok(await this.isScrolledToSelector("#main"))
 
     await this.pressTab()

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -144,6 +144,21 @@ export class NavigationTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/hello.html")
   }
+
+  async "test skip link with hash-only path"() {
+    await this.clickSelector('a[href="#main"]')
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
+    this.assert.equal(await this.hash, "#main")
+    this.assert.ok(await this.isScrolledToSelector("#main"))
+
+    await this.pressTab()
+    const activeElement = await this.remote.getActiveElement()
+    const skippedLink = await this.querySelector("#ignored-link")
+    const firstLinkWithinMain = await this.querySelector("#main a:first-of-type")
+    this.assert.notOk(await activeElement.equals(skippedLink), "skips interactive elements before #main")
+    this.assert.ok(await activeElement.equals(firstLinkWithinMain), "skips to first interactive element after #main")
+  }
 }
 
 NavigationTests.registerSuite()

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -28,6 +28,12 @@ export class FunctionalTestCase extends InternTestCase {
     return (await this.remote.findAllByCssSelector(selector)).length > 0
   }
 
+  async selectorHasFocus(selector: string) {
+    const activeElement = await this.remote.getActiveElement()
+
+    return activeElement.equals(await this.querySelector(selector))
+  }
+
   async querySelector(selector: string) {
     return this.remote.findByCssSelector(selector)
   }

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -45,6 +45,10 @@ export class FunctionalTestCase extends InternTestCase {
     return this.evaluate(element => element.scrollIntoView(), element)
   }
 
+  async pressTab(): Promise<void> {
+    return this.remote.getActiveElement().then(activeElement => activeElement.type(('\uE004'))) // TAB
+  }
+
   async outerHTMLForSelector(selector: string): Promise<string> {
     const element = await this.remote.findByCssSelector(selector)
     return this.evaluate(element => element.outerHTML, element)


### PR DESCRIPTION
This is a port of https://github.com/hotwired/turbo/pull/57 and https://github.com/turbolinks/turbolinks/pull/285 to resolve https://github.com/turbolinks/turbolinks/issues/75, https://github.com/turbolinks/turbolinks/issues/214, https://github.com/turbolinks/turbolinks/issues/192, and https://github.com/hotwired/turbo/issues/42

## The Problem

Clicking on a link which references an anchor on the current page issues an unnecessary request. This can cause problems when linking to content which is lazily loaded (see https://agile-reef-88023.herokuapp.com/posts/1), as well as with [analytics](https://github.com/turbolinks/turbolinks/issues/75#issuecomment-255867311) and [skip links](https://github.com/hotwired/turbo/issues/42). Disabling Turbo completely on those links prevents the request, but because the view is not cached, this approach breaks the Back button.

## The Solution

This PR detects whether the visit is to an anchor on the same page, and if so, prevents the request. It takes a snapshot and performs the scroll, bypassing any rendering and `turbo:load` triggering. A similar flow handles restorations to same-page anchors. Correct focusing is achieved by temporarily adding `tabindex=-1` and calling `focus` on the target.

## Notes

1. I'm getting a reliably failing test (`chrome on linux - FrameTests - evaluates frame script elements on each render (0.297s) AssertionError: expected 1 to equal 2`), which doesn't _seem_ to be related to these changes, and it's passing locally on my machine
2. the [Turbolinks version](https://github.com/turbolinks/turbolinks/pull/285) of this PR performed [the same-page check in the session](https://github.com/turbolinks/turbolinks/pull/285/files#diff-da4d3d3a97b9ed26e47b50d9a5d2f5795434467e001f8a6deba72c361a23baa7R330-R333) (née controller). This allowed the [native adapters to check for same-page anchors](https://github.com/turbolinks/turbolinks-ios/pull/126/files#diff-db83eae543943038c85ab2f7a4c437adda02ed30411e803d0091f5a7fc32d0acR57) and handle accordingly. The session is not so accessible from the Visit, so I'd welcome some tips on how to solve this (or whether it's even necessary now?).

## Todo
- [x] Manual tests to double-check
- [x] Investigate Firefox bug when navigating back after first anchor click
- [x] Trigger hash change event when scrolling to same-page anchor

Fixes https://github.com/hotwired/turbo/issues/42
Closes https://github.com/hotwired/turbo/pull/152