### PR TITLE
Make links with method work everywhere, not only inside turbo frames

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -122,11 +122,11 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   // Link interceptor delegate
 
   shouldInterceptLinkClick(element: Element, url: string) {
-    const linkMethod = element.getAttribute("data-turbo-method") || element.getAttribute("data-method")
-    if (linkMethod)
+    if (element.hasAttribute("data-turbo-method")) {
       return false
-
-    return this.shouldInterceptNavigation(element)
+    } else {
+      return this.shouldInterceptNavigation(element)
+    }
   }
 
   linkClickIntercepted(element: Element, url: string) {

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -122,6 +122,10 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   // Link interceptor delegate
 
   shouldInterceptLinkClick(element: Element, url: string) {
+    const linkMethod = element.getAttribute("data-turbo-method") || element.getAttribute("data-method")
+    if (linkMethod)
+      return false
+
     return this.shouldInterceptNavigation(element)
   }
 

--- a/src/core/frames/link_interceptor.ts
+++ b/src/core/frames/link_interceptor.ts
@@ -1,5 +1,3 @@
-import { dispatch } from "../../util"
-
 export interface LinkInterceptorDelegate {
   shouldInterceptLinkClick(element: Element, url: string): boolean
   linkClickIntercepted(element: Element, url: string): void
@@ -40,9 +38,7 @@ export class LinkInterceptor {
       if (this.delegate.shouldInterceptLinkClick(event.target, event.detail.url)) {
         this.clickEvent.preventDefault()
         event.preventDefault()
-        
-        this.convertLinkWithMethodClickToFormSubmission(event.target) || 
-          this.delegate.linkClickIntercepted(event.target, event.detail.url)
+        this.delegate.linkClickIntercepted(event.target, event.detail.url)
       }
     }
     delete this.clickEvent
@@ -50,21 +46,6 @@ export class LinkInterceptor {
 
   willVisit = () => {
     delete this.clickEvent
-  }
-
-  convertLinkWithMethodClickToFormSubmission(link: Element) {
-    const linkMethod = link.getAttribute("data-turbo-method") || link.getAttribute("data-method")
-
-    if (linkMethod) {
-      const form = document.createElement("form")
-      form.method = linkMethod
-      form.action = link.getAttribute("href") || "undefined"
-
-      link.parentNode?.insertBefore(form, link)
-      return dispatch("submit", { target: form })
-    } else {
-      return false
-    }
   }
 
   respondsToEventTarget(target: EventTarget | null) {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -133,8 +133,24 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
 
   followedLinkToLocation(link: Element, location: URL) {
     const action = this.getActionForLink(link)
-    this.visit(location.href, { action })
+    this.convertLinkWithMethodClickToFormSubmission(link) || this.visit(location.href, { action })
   }
+
+  convertLinkWithMethodClickToFormSubmission(link: Element) {
+    const linkMethod = link.getAttribute("data-turbo-method") || link.getAttribute("data-method")
+
+    if (linkMethod) {
+      const form = document.createElement("form")
+      form.method = linkMethod
+      form.action = link.getAttribute("href") || "undefined"
+
+      link.parentNode?.insertBefore(form, link)
+      return dispatch("submit", { target: form })
+    } else {
+      return false
+    }
+  }
+
 
   // Navigator delegate
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -145,7 +145,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
       form.action = link.getAttribute("href") || "undefined"
 
       link.parentNode?.insertBefore(form, link)
-      return dispatch("submit", { target: form })
+      return dispatch("submit", { cancelable: true, target: form })
     } else {
       return false
     }

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -137,7 +137,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   }
 
   convertLinkWithMethodClickToFormSubmission(link: Element) {
-    const linkMethod = link.getAttribute("data-turbo-method") || link.getAttribute("data-method")
+    const linkMethod = link.getAttribute("data-turbo-method")
 
     if (linkMethod) {
       const form = document.createElement("form")

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -47,7 +47,6 @@
         <input type="hidden" name="query" value="2">
         <input type="submit">
       </form>
-      <a href="/__turbo/redirect?path=/src/tests/fixtures/form.html&greeting=Hello%20from%20a%20redirect" data-turbo-method="post" id="link-method-redirect">Redirect link</a>
     </div>
     <hr>
     <div id="no-action">
@@ -162,6 +161,7 @@
         <input type="hidden" name="content" value="Hello!">
         <input type="submit">
       </form>
+      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="link-method-inside-frame">Stream link inside frame</a>
       <form action="/__turbo/messages/1" method="put" class="stream put">
         <input type="hidden" name="type" value="stream">
         <input type="hidden" name="content" value="Hello!">
@@ -170,5 +170,6 @@
       <div id="messages">
       </div>
     </turbo-frame>
+    <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="link-method-outside-frame">Stream link outside frame</a>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -331,13 +331,22 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
   }
 
-  async "test link method form submission"() {
-    await this.clickSelector("#link-method-redirect")
-    await this.nextBody
+  async "test link method form submission inside frame"() {
+    await this.clickSelector("#link-method-inside-frame")
 
-    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
-    this.assert.equal(await this.visitAction, "advance")
-    this.assert.equal(await this.getSearchParam("greeting"), "Hello from a redirect")
+    await this.nextBeat
+
+    const message = await this.querySelector("#frame div.message")
+    this.assert.equal(await message.getVisibleText(), "Link!")
+  }
+
+  async "test link method form submission outside frame"() {
+    await this.clickSelector("#link-method-outside-frame")
+
+    await this.nextBeat
+
+    const message = await this.querySelector("#frame div.message")
+    this.assert.equal(await message.getVisibleText(), "Link!")
   }
 
   get formSubmitted(): Promise<boolean> {

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -44,7 +44,8 @@ router.post("/reject", (request, response) => {
 })
 
 router.post("/messages", (request, response) => {
-  const { content, status, type, target, targets } = request.body
+  const params = { ...request.body, ...request.query }
+  const { content, status, type, target, targets } = params
   if (typeof content == "string") {
     receiveMessage(content, target)
     if (type == "stream" && acceptsStreams(request)) {


### PR DESCRIPTION
This is the continuation of #277 that introduced `data-turbo-method`. Unfortunately it only worked within turbo-frames.
This PR aims to make it work globally.