### PR TITLE
feat: export PageSnapshot to allow for caching HTML strings

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,10 +4,11 @@ import { Locatable } from "./url"
 import { StreamMessage } from "./streams/stream_message"
 import { StreamSource } from "./types"
 import { VisitOptions } from "./drive/visit"
+import { PageSnapshot } from "./drive/page_snapshot"
 
 const session = new Session
 const { navigator } = session
-export { navigator }
+export { navigator, PageSnapshot }
 
 export function start() {
   session.start()


### PR DESCRIPTION
# Why?

Currently im working on Mrujs, a modern ujs drop-in replacement thats fully client-side and has a built-in navigation adapter which leverages Turbo / Turbolinks. I have a working setup to prevent double navigation on successful form submissions that redirect with Turbolinks, however, I cant do the same with Turbo. This is because the code used to cache PageSnapshots is not exported. With the exported class, I can take advantage of caching a response body from a fetch request and then manually storing it in the cache and then trigger a "restore" visit through Turbo[links] so that it doesnt trigger double navigation and wipe away any flashes.

https://github.com/ParamagicDev/mrujs/blob/b21c2475dc56c635f3cd05c34bf2f1b971c97f3b/src/navigationAdapter.ts#L155-L157

^ Those are the lines of code dependent on the PageSnapshot class.