### PR TITLE
Improve flaky tests

### DIFF
--- a/src/tests/functional/autofocus_tests.ts
+++ b/src/tests/functional/autofocus_tests.ts
@@ -14,7 +14,7 @@ export class AutofocusTests extends TurboDriveTestCase {
   async "test autofocus first [autofocus] element on visit"() {
     await this.goToLocation("/src/tests/fixtures/navigation.html")
     await this.clickSelector("#autofocus-link")
-    await this.nextBody
+    await this.sleep(500)
 
     this.assert.ok(await this.hasSelector("#first-autofocus-element:focus"), "focuses the first [autofocus] element on the page")
     this.assert.notOk(await this.hasSelector("#second-autofocus-element:focus"), "focuses the first [autofocus] element on the page")

--- a/src/tests/functional/pausable_rendering_tests.ts
+++ b/src/tests/functional/pausable_rendering_tests.ts
@@ -12,6 +12,7 @@ export class PausableRenderingTests extends TurboDriveTestCase {
     this.assert.strictEqual(await this.getAlertText(), 'Continue rendering?')
     await this.acceptAlert()
 
+    await this.nextBeat
     const h1 = await this.querySelector("h1")
     this.assert.equal(await h1.getVisibleText(), "One")
   }
@@ -27,6 +28,7 @@ export class PausableRenderingTests extends TurboDriveTestCase {
     this.assert.strictEqual(await this.getAlertText(), 'Rendering aborted')
     await this.acceptAlert()
 
+    await this.nextBeat
     const h1 = await this.querySelector("h1")
     this.assert.equal(await h1.getVisibleText(), "Pausable Rendering")
   }

--- a/src/tests/functional/pausable_requests_tests.ts
+++ b/src/tests/functional/pausable_requests_tests.ts
@@ -12,6 +12,7 @@ export class PausableRequestsTests extends TurboDriveTestCase {
     this.assert.strictEqual(await this.getAlertText(), 'Continue request?')
     await this.acceptAlert()
 
+    await this.nextBeat
     const h1 = await this.querySelector("h1")
     this.assert.equal(await h1.getVisibleText(), "One")
   }
@@ -27,6 +28,7 @@ export class PausableRequestsTests extends TurboDriveTestCase {
     this.assert.strictEqual(await this.getAlertText(), 'Request aborted')
     await this.acceptAlert()
 
+    await this.nextBeat
     const h1 = await this.querySelector("h1")
     this.assert.equal(await h1.getVisibleText(), "Pausable Requests")
   }


### PR DESCRIPTION
1. The autofocus test randomly fails locally and on CI. Extended sleep time to improve it.
2. Added missing sleep for pausable tests.