### PR TITLE
Make visit action accessible from visit event

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -165,7 +165,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
 
   visitStarted(visit: Visit) {
     extendURLWithDeprecatedProperties(visit.location)
-    this.notifyApplicationAfterVisitingLocation(visit.location)
+    this.notifyApplicationAfterVisitingLocation(visit.location, visit.action)
   }
 
   visitCompleted(visit: Visit) {
@@ -243,8 +243,8 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     return dispatch("turbo:before-visit", { detail: { url: location.href }, cancelable: true })
   }
 
-  notifyApplicationAfterVisitingLocation(location: URL) {
-    return dispatch("turbo:visit", { detail: { url: location.href } })
+  notifyApplicationAfterVisitingLocation(location: URL, action: Action) {
+    return dispatch("turbo:visit", { detail: { url: location.href, action } })
   }
 
   notifyApplicationBeforeCachingSnapshot() {


### PR DESCRIPTION
When developing the proof-of-concept for [animated page transitions using paused rendering](https://resonant-inky-replace.glitch.me/), it was useful to know whether a visit was a restoration or otherwise. For example, it felt weird to animate a Back restoration visit in the same way as an Advance visit.

This pull request adds the visit's `action` to the `turbo:visit` event to make this possible.