### PR TITLE
Avoid race between visit tests

### DIFF
--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -5,7 +5,7 @@ declare const Turbo: any
 
 export class VisitTests extends TurboDriveTestCase {
   async setup() {
-    this.goToLocation("/src/tests/fixtures/visit.html")
+    await this.goToLocation("/src/tests/fixtures/visit.html")
   }
 
   async "test programmatically visiting a same-origin location"() {


### PR DESCRIPTION
TurboDriveTestCase maintains a eventLogChannel that acts as a cursor
for the page's window.eventLogs array. Before every test the
eventLogChannel is drained by reading all events and its internal
index (cursor) is updated accordingly.

The race was happening when we changed the page location and not
blocking on it: the eventLogChannel was draining the previous page
bumping its internal index. After the page was reload that index was
out of sync since the new page had a new, empty eventLogs array.

Order of events
 * async location change
 * draining eventLogChannel on the previous page
 * actual location change
 * eventLogChannel is out-of-sync

This was fixed as part of #289