### PR TITLE
Introduce test runner options

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,14 +55,14 @@ The html files needed for the tests are stored in: `src/tests/fixtures/`
 
 ### Run single test
 
-To focus on single test you need to add the following line in `src/tests/runner.js`:
+To focus on single test grep for it:
 ```javascript
-intern.configure({ grep: /TEST_CASE_NAME/ })
+yarn test --grep TEST_CASE_NAME
 ```
 
 Where the `TEST_CASE_NAME` is the name of test you want to run. For example:
 ```javascript
-intern.configure({ grep: /triggers before-render and render events/ })
+yarn test --grep 'triggers before-render and render events'
 ```
 
 ### Local webserver

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "@rollup/plugin-typescript": "^6.0.0",
     "@types/multer": "^1.4.5",
     "intern": "^4.9.0",
+    "arg": "^4.1.0",
     "multer": "^1.4.2",
     "rollup": "^2.35.1",
     "tslib": "^2.0.3",

--- a/src/tests/runner.js
+++ b/src/tests/runner.js
@@ -3,8 +3,16 @@ const configuration = require("../../intern.json")
 const intern = require("intern").default
 const arg = require("arg");
 
+const args = arg({
+  "--grep": String
+});
+
 intern.configure(configuration)
 intern.configure({ reporters: [ "runner" ] })
+
+if (args["--grep"]) {
+  intern.configure({ grep: args["--grep"] })
+}
 
 const firstArg = args["_"][0]
 if (firstArg == "serveOnly") {

--- a/src/tests/runner.js
+++ b/src/tests/runner.js
@@ -1,12 +1,13 @@
 const { TestServer } = require("../../dist/tests/server")
 const configuration = require("../../intern.json")
 const intern = require("intern").default
+const arg = require("arg");
 
 intern.configure(configuration)
 intern.configure({ reporters: [ "runner" ] })
 
-const arg = process.argv[2]
-if (arg == "serveOnly") {
+const firstArg = args["_"][0]
+if (firstArg == "serveOnly") {
   intern.configure({ serveOnly: true })
 } else {
   const { spawnSync } = require("child_process")

--- a/src/tests/runner.js
+++ b/src/tests/runner.js
@@ -4,7 +4,8 @@ const intern = require("intern").default
 const arg = require("arg");
 
 const args = arg({
-  "--grep": String
+  "--grep": String,
+  "--environment": String
 });
 
 intern.configure(configuration)
@@ -12,6 +13,12 @@ intern.configure({ reporters: [ "runner" ] })
 
 if (args["--grep"]) {
   intern.configure({ grep: args["--grep"] })
+}
+
+if (args["--environment"]) {
+  const envName = args["--environment"]
+  const newEnvs = configuration.environments.filter(env => env.browserName === envName)
+  intern.configure({ environments : newEnvs })
 }
 
 const firstArg = args["_"][0]


### PR DESCRIPTION
Allow passing command-line options to the test runner like `--grep` and `--environment` to make development easier.

I used `arg` which is already a dependency (required by `ts-node`).