### PR TITLE
Scroll to top after form submission rejection

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -98,6 +98,8 @@ export class Navigator {
     if (responseHTML) {
       const snapshot = PageSnapshot.fromHTMLString(responseHTML)
       await this.view.renderPage(snapshot)
+      // Ensures users don't miss any error messages at the top of the form
+      window.scroll(0, 0)
       this.view.clearSnapshotCache()
     }
   }

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -98,8 +98,7 @@ export class Navigator {
     if (responseHTML) {
       const snapshot = PageSnapshot.fromHTMLString(responseHTML)
       await this.view.renderPage(snapshot)
-      // Ensures users don't miss any error messages at the top of the form
-      window.scroll(0, 0)
+      this.view.scrollToTop()
       this.view.clearSnapshotCache()
     }
   }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -316,9 +316,9 @@ export class Visit implements FetchRequestDelegate {
   performScroll() {
     if (!this.scrolled) {
       if (this.action == "restore") {
-        this.scrollToRestoredPosition() || this.scrollToAnchor() || this.scrollToTop()
+        this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()
       } else {
-        this.scrollToAnchor() || this.scrollToTop()
+        this.scrollToAnchor() || this.view.scrollToTop()
       }
       if (this.isSamePage) {
         this.delegate.visitScrolledToSamePageLocation(this.view.lastRenderedLocation, this.location)
@@ -342,10 +342,6 @@ export class Visit implements FetchRequestDelegate {
       this.view.scrollToAnchor(anchor)
       return true
     }
-  }
-
-  scrollToTop() {
-    this.view.scrollToPosition({ x: 0, y: 0 })
   }
 
   // Instrumentation

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -59,6 +59,10 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
     this.scrollRoot.scrollTo(x, y)
   }
 
+  scrollToTop() {
+    this.scrollToPosition({ x: 0, y: 0 })
+  }
+
   get scrollRoot(): { scrollTo(x: number, y: number): void } {
     return window
   }

--- a/src/tests/fixtures/422_tall.html
+++ b/src/tests/fixtures/422_tall.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <title>Unprocessable Entity</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <main style="height: 1000vh">
+      <h1>Unprocessable Entity</h1>
+      <turbo-frame id="frame">
+        <h2>Frame: Unprocessable Entity</h2>
+      </turbo-frame>
+    </main>
+  </body>
+</html>

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -79,9 +79,13 @@
     </div>
     <hr>
     <div id="reject">
-      <form class="unprocessable_entity" action="/__turbo/reject" method="post">
+      <form class="unprocessable_entity" action="/__turbo/reject" method="post" style="margin-top:100vh">
         <input type="hidden" name="status" value="422">
         <input type="submit">
+      </form>
+      <form class="unprocessable_entity_with_tall_form" action="/__turbo/reject/tall" method="post">
+        <input type="hidden" name="status" value="422">
+        <input type="submit" style="margin-top:1000vh">
       </form>
       <form class="internal_server_error" action="/__turbo/reject" method="post">
         <input type="hidden" name="status" value="500">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -160,6 +160,17 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
   }
 
+  async "test invalid form submission with long form"() {
+    await this.scrollToSelector("#reject form.unprocessable_entity_with_tall_form input[type=submit]")
+    await this.clickSelector("#reject form.unprocessable_entity_with_tall_form input[type=submit]")
+    await this.nextBody
+
+    const title = await this.querySelector("h1")
+    this.assert.equal(await title.getVisibleText(), "Unprocessable Entity", "renders the response HTML")
+    this.assert(await this.isScrolledToTop(), "page is scrolled to the top")
+    this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
+  }
+
   async "test invalid form submission with server error status"() {
     await this.clickSelector("#reject form.internal_server_error input[type=submit]")
     await this.nextBody

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -81,6 +81,11 @@ export class FunctionalTestCase extends InternTestCase {
     return this.evaluate(() => ({ x: window.scrollX, y: window.scrollY }))
   }
 
+  async isScrolledToTop(): Promise<boolean> {
+    const { y: pageY } = await this.scrollPosition
+    return pageY === 0
+  }
+
   async isScrolledToSelector(selector: string): Promise<boolean> {
     const { y: pageY } = await this.scrollPosition
     const { y: elementY } = await this.remote.findByCssSelector(selector).getPosition()

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -36,6 +36,13 @@ router.get("/redirect", (request, response) => {
   response.redirect(301, url.format({ pathname, query }))
 })
 
+router.post("/reject/tall", (request, response) => {
+  const { status } = request.body
+  const fixture = path.join(__dirname, `../../src/tests/fixtures/422_tall.html`)
+
+  response.status(parseInt(status || "422", 10)).sendFile(fixture)
+})
+
 router.post("/reject", (request, response) => {
   const { status } = request.body
   const fixture = path.join(__dirname, `../../src/tests/fixtures/${status}.html`)


### PR DESCRIPTION
In testing Turbo in my Rails app I noticed after submitting forms that were rejected by the server, the window position remain constant when the form was redrawn. This created a UX issue were if the errors were near the top of the form, outside of the viewport, it may be unclear to the user what happened.

This PR brings simply scrolls the viewport to the top once the error response is rendered . I'm using this in prod on my Rails app and so far it's behaving as expected.

This is my first contribution to a JS lib, so I just wanted to get a sense from the core team if this one-liner was the right way to solve this before I wrote any tests.