### PR TITLE
Display progress bar on form submissions

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -74,7 +74,10 @@ export class Navigator {
   // Form submission delegate
 
   formSubmissionStarted(formSubmission: FormSubmission) {
-    this.adapter.formSubmissionStarted(formSubmission)
+    // Not all adapaters implement formSubmissionStarted
+    if (typeof this.adapter.formSubmissionStarted === 'function') {
+      this.adapter.formSubmissionStarted(formSubmission)
+    }
   }
 
   async formSubmissionSucceededWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse) {
@@ -107,7 +110,10 @@ export class Navigator {
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {
-    this.adapter.formSubmissionFinished(formSubmission)
+    // Not all adapaters implement formSubmissionFinished
+    if (typeof this.adapter.formSubmissionFinished === 'function') {
+      this.adapter.formSubmissionFinished(formSubmission)
+    }
   }
 
   // Visit delegate

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -74,7 +74,7 @@ export class Navigator {
   // Form submission delegate
 
   formSubmissionStarted(formSubmission: FormSubmission) {
-
+    this.adapter.formSubmissionStarted(formSubmission)
   }
 
   async formSubmissionSucceededWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse) {
@@ -107,7 +107,7 @@ export class Navigator {
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {
-
+    this.adapter.formSubmissionFinished(formSubmission)
   }
 
   // Visit delegate

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -74,7 +74,7 @@ export class Navigator {
   // Form submission delegate
 
   formSubmissionStarted(formSubmission: FormSubmission) {
-    // Not all adapaters implement formSubmissionStarted
+    // Not all adapters implement formSubmissionStarted
     if (typeof this.adapter.formSubmissionStarted === 'function') {
       this.adapter.formSubmissionStarted(formSubmission)
     }
@@ -110,7 +110,7 @@ export class Navigator {
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {
-    // Not all adapaters implement formSubmissionFinished
+    // Not all adapters implement formSubmissionFinished
     if (typeof this.adapter.formSubmissionFinished === 'function') {
       this.adapter.formSubmissionFinished(formSubmission)
     }

--- a/src/core/native/adapter.ts
+++ b/src/core/native/adapter.ts
@@ -11,7 +11,7 @@ export interface Adapter {
   visitRequestFailedWithStatusCode(visit: Visit, statusCode: number): void
   visitRequestFinished(visit: Visit): void
   visitRendered(visit: Visit): void
-  formSubmissionStarted(formSubmission: FormSubmission): void
-  formSubmissionFinished(formSubmission: FormSubmission): void
+  formSubmissionStarted?(formSubmission: FormSubmission): void
+  formSubmissionFinished?(formSubmission: FormSubmission): void
   pageInvalidated(): void
 }

--- a/src/core/native/adapter.ts
+++ b/src/core/native/adapter.ts
@@ -1,4 +1,5 @@
 import { Visit, VisitOptions } from "../drive/visit"
+import { FormSubmission } from "../drive/form_submission"
 
 export interface Adapter {
   visitProposedToLocation(location: URL, options?: Partial<VisitOptions>): void
@@ -10,5 +11,7 @@ export interface Adapter {
   visitRequestFailedWithStatusCode(visit: Visit, statusCode: number): void
   visitRequestFinished(visit: Visit): void
   visitRendered(visit: Visit): void
+  formSubmissionStarted(formSubmission: FormSubmission): void
+  formSubmissionFinished(formSubmission: FormSubmission): void
   pageInvalidated(): void
 }

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -1,6 +1,7 @@
 import { Adapter } from "./adapter"
 import { ProgressBar } from "../drive/progress_bar"
 import { SystemStatusCode, Visit, VisitOptions } from "../drive/visit"
+import { FormSubmission } from "../drive/form_submission"
 import { Session } from "../session"
 import { uuid } from "../../util"
 
@@ -68,6 +69,16 @@ export class BrowserAdapter implements Adapter {
 
   visitRendered(visit: Visit) {
 
+  }
+
+  formSubmissionStarted(formSubmission: FormSubmission) {
+    this.progressBar.setValue(0)
+    this.showProgressBarAfterDelay()
+  }
+
+  formSubmissionFinished(formSubmission: FormSubmission) {
+    this.progressBar.setValue(1)
+    this.hideProgressBar()
   }
 
   // Private

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -43,6 +43,11 @@
         <input type="hidden" name="greeting" value="Hello from a form">
         <input type="submit">
       </form>
+      <form action="/__turbo/redirect" method="post" class="sleep">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
+        <input type="hidden" name="sleep" value="500">
+        <input type="submit">
+      </form>
       <form action="/src/tests/fixtures/form.html?query=1" method="get" class="conflicting-values">
         <input type="hidden" name="query" value="2">
         <input type="submit">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -8,6 +8,26 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     })
   }
 
+  async "test standard form submission renders a progress bar"() {
+    await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
+    await this.clickSelector("#standard form.sleep input[type=submit]")
+
+    await this.waitUntilSelector("progress")
+    this.assert.ok(await this.hasSelector("progress[value]"), "displays progress bar")
+
+    await this.nextBody
+    await this.waitUntilNoSelector("progress")
+
+    this.assert.notOk(await this.hasSelector("progress"), "hides progress bar")
+  }
+
+  async "test standard form submission does not render a progress bar before expiring the delay"() {
+    await this.remote.execute(() => window.Turbo.setProgressBarDelay(500))
+    await this.clickSelector("#standard form.redirect input[type=submit]")
+
+    this.assert.notOk(await this.hasSelector("progress"), "does not show progress bar before delay")
+  }
+
   async "test standard form submission with redirect response"() {
     await this.clickSelector("#standard form.redirect input[type=submit]")
     await this.nextBody

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -12,20 +12,20 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
     await this.clickSelector("#standard form.sleep input[type=submit]")
 
-    await this.waitUntilSelector("progress")
-    this.assert.ok(await this.hasSelector("progress[value]"), "displays progress bar")
+    await this.waitUntilSelector(".turbo-progress-bar")
+    this.assert.ok(await this.hasSelector(".turbo-progress-bar"), "displays progress bar")
 
     await this.nextBody
-    await this.waitUntilNoSelector("progress")
+    await this.waitUntilNoSelector(".turbo-progress-bar")
 
-    this.assert.notOk(await this.hasSelector("progress"), "hides progress bar")
+    this.assert.notOk(await this.hasSelector(".turbo-progress-bar"), "hides progress bar")
   }
 
   async "test standard form submission does not render a progress bar before expiring the delay"() {
     await this.remote.execute(() => window.Turbo.setProgressBarDelay(500))
     await this.clickSelector("#standard form.redirect input[type=submit]")
 
-    this.assert.notOk(await this.hasSelector("progress"), "does not show progress bar before delay")
+    this.assert.notOk(await this.hasSelector(".turbo-progress-bar"), "does not show progress bar before delay")
   }
 
   async "test standard form submission with redirect response"() {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -9,20 +9,20 @@ export class NavigationTests extends TurboDriveTestCase {
     await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
     await this.clickSelector("a:first-of-type")
 
-    await this.waitUntilSelector("progress")
-    this.assert.ok(await this.hasSelector("progress[value]"), "displays progress bar")
+    await this.waitUntilSelector(".turbo-progress-bar")
+    this.assert.ok(await this.hasSelector(".turbo-progress-bar"), "displays progress bar")
 
     await this.nextBody
-    await this.waitUntilNoSelector("progress")
+    await this.waitUntilNoSelector(".turbo-progress-bar")
 
-    this.assert.notOk(await this.hasSelector("progress"), "hides progress bar")
+    this.assert.notOk(await this.hasSelector(".turbo-progress-bar"), "hides progress bar")
   }
 
   async "test navigating does not render a progress bar before expiring the delay"() {
     await this.remote.execute(() => window.Turbo.setProgressBarDelay(1000))
     await this.clickSelector("a:first-of-type")
 
-    this.assert.notOk(await this.hasSelector("progress"), "does not show progress bar before delay")
+    this.assert.notOk(await this.hasSelector(".turbo-progress-bar"), "does not show progress bar before delay")
   }
 
   async "test after loading the page"() {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -5,6 +5,26 @@ export class NavigationTests extends TurboDriveTestCase {
     await this.goToLocation("/src/tests/fixtures/navigation.html")
   }
 
+  async "test navigating renders a progress bar"() {
+    await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
+    await this.clickSelector("a:first-of-type")
+
+    await this.waitUntilSelector("progress")
+    this.assert.ok(await this.hasSelector("progress[value]"), "displays progress bar")
+
+    await this.nextBody
+    await this.waitUntilNoSelector("progress")
+
+    this.assert.notOk(await this.hasSelector("progress"), "hides progress bar")
+  }
+
+  async "test navigating does not render a progress bar before expiring the delay"() {
+    await this.remote.execute(() => window.Turbo.setProgressBarDelay(1000))
+    await this.clickSelector("a:first-of-type")
+
+    this.assert.notOk(await this.hasSelector("progress"), "does not show progress bar before delay")
+  }
+
   async "test after loading the page"() {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
     this.assert.equal(await this.visitAction, "load")

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -7,7 +7,7 @@ export class NavigationTests extends TurboDriveTestCase {
 
   async "test navigating renders a progress bar"() {
     await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
-    await this.clickSelector("a:first-of-type")
+    await this.clickSelector("#same-origin-unannotated-link")
 
     await this.waitUntilSelector(".turbo-progress-bar")
     this.assert.ok(await this.hasSelector(".turbo-progress-bar"), "displays progress bar")
@@ -20,7 +20,7 @@ export class NavigationTests extends TurboDriveTestCase {
 
   async "test navigating does not render a progress bar before expiring the delay"() {
     await this.remote.execute(() => window.Turbo.setProgressBarDelay(1000))
-    await this.clickSelector("a:first-of-type")
+    await this.clickSelector("#same-origin-unannotated-link")
 
     this.assert.notOk(await this.hasSelector(".turbo-progress-bar"), "does not show progress bar before delay")
   }

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -38,6 +38,22 @@ export class FunctionalTestCase extends InternTestCase {
     return this.remote.findByCssSelector(selector)
   }
 
+  async waitUntilSelector(selector: string): Promise<void> {
+    return (async () => {
+      let hasSelector = false
+      do hasSelector = await this.hasSelector(selector)
+      while (!hasSelector)
+    })()
+  }
+
+  async waitUntilNoSelector(selector: string): Promise<void> {
+    return (async () => {
+      let hasSelector = true
+      do hasSelector = await this.hasSelector(selector)
+      while (hasSelector)
+    })()
+  }
+
   async querySelectorAll(selector: string) {
     return this.remote.findAllByCssSelector(selector)
   }

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -17,13 +17,13 @@ router.use((request, response, next) => {
 })
 
 router.post("/redirect", (request, response) => {
-  const { path, ...query } = request.body
+  const { path, sleep, ...query } = request.body
   const pathname = path ?? "/src/tests/fixtures/one.html"
   const enctype = request.get("Content-Type")
   if (enctype) {
     query.enctype = enctype
   }
-  response.redirect(303, url.format({ pathname, query }))
+  setTimeout(() => response.redirect(303, url.format({ pathname, query })), parseInt(sleep || "0", 10))
 })
 
 router.get("/redirect", (request, response) => {

--- a/src/tests/unit/deprecated_adapter_support_test.ts
+++ b/src/tests/unit/deprecated_adapter_support_test.ts
@@ -1,4 +1,5 @@
 import { VisitOptions, Visit } from "../../core/drive/visit"
+import { FormSubmission } from "../../core/drive/form_submission"
 import { Adapter } from "../../core/native/adapter"
 import * as Turbo from "../../index"
 import { DOMTestCase } from "../helpers/dom_test_case"
@@ -67,6 +68,14 @@ export class DeprecatedAdapterSupportTest extends DOMTestCase implements Adapter
   }
 
   visitRendered(visit: Visit): void {
+
+  }
+
+  formSubmissionStarted(formSubmission: FormSubmission): void {
+
+  }
+
+  formSubmissionFinished(formSubmission: FormSubmission): void {
 
   }
 


### PR DESCRIPTION
Fixes #61

Note: This PR is simply an extraction from the unmerged PR #164.

### Description

Currently when forms are submitted using Turbo Drive there is no progress bar shown when the request is taking a bit. This PR fixes that by bolting on two new formSubmission methods to the generic Adapter interface and implementing them in the browser adapter. 

### Android/iOS considerations

While I know extending the adapter interface could make extra work for the `turbo-ios` and `turbo-android` maintainers, I think there might be enough differentiated behavior in form submissions to make separate methods a better choice in the long-term vs genericizing the `visitRequestStarted` and `visitRequestFinished` methods.
