### PR TITLE
Emit `turbo:submit-failed` when form is rejected

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -136,6 +136,8 @@ export class FormSubmission {
 
   requestSucceededWithResponse(request: FetchRequest, response: FetchResponse) {
     if (response.clientError || response.serverError) {
+      this.result = { success: false, fetchResponse: response }
+      dispatch("turbo:submit-failed", { target: this.formElement, detail: { formSubmission: this, ...this.result } })
       this.delegate.formSubmissionFailedWithResponse(this, response)
     } else if (this.requestMustRedirect(request) && responseSucceededWithoutRedirect(response)) {
       const error = new Error("Form responses must redirect to another location")
@@ -149,6 +151,7 @@ export class FormSubmission {
 
   requestFailedWithResponse(request: FetchRequest, response: FetchResponse) {
     this.result = { success: false, fetchResponse: response }
+    dispatch("turbo:submit-failed", { target: this.formElement, detail: { formSubmission: this, ...this.result } })
     this.delegate.formSubmissionFailedWithResponse(this, response)
   }
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -5,6 +5,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.goToLocation("/src/tests/fixtures/form.html")
     await this.remote.execute(() => {
       addEventListener("turbo:submit-start", () => document.documentElement.setAttribute("data-form-submitted", ""), { once: true })
+      addEventListener("turbo:submit-failed", () => document.documentElement.setAttribute("data-form-failed", ""), { once: true })
     })
   }
 
@@ -138,6 +139,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.nextBody
 
     const title = await this.querySelector("h1")
+    this.assert.ok(await this.formFailed)
     this.assert.equal(await title.getVisibleText(), "Unprocessable Entity", "renders the response HTML")
     this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
   }
@@ -147,6 +149,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     await this.nextBody
 
     const title = await this.querySelector("h1")
+    this.assert.ok(await this.formFailed)
     this.assert.equal(await title.getVisibleText(), "Internal Server Error", "renders the response HTML")
     this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
   }
@@ -347,6 +350,10 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     const message = await this.querySelector("#frame div.message")
     this.assert.equal(await message.getVisibleText(), "Link!")
+  }
+
+  get formFailed(): Promise<boolean> {
+    return this.hasSelector("html[data-form-failed]")
   }
 
   get formSubmitted(): Promise<boolean> {


### PR DESCRIPTION
## Description
This PR adds a new event to the Turbo Drive form submission lifecycle called `turbo:submit-failed`.This event is dispatched when a form is rejected by the server or the server throws an error. 

## Why a new event?
In a situation where a form submission is successful, Turbo Drive will follow the redirect and kick off a `turbo:visit` event. A lot of JS libs explicitly look out for this event to correct their state with the DOM is redrawn. One example is [Intercom](https://github.com/intercom/intercom-rails/issues/336). In this situation, everything works as expected.

But when a form is rejected by the server, new HTML is rendered in the DOM, but no `turbo:visit` event is ever fired. This means external scripts that may need to redraw HTML elements in a situation where they may already have state attached to `window` cannot do so.

I think the event could also be useful in other JS contexts (ex: like sending a report to an error monitoring service, or scrolling the window to a specific position), but I wanted to be honest about my need for it.