### PR TITLE
Fix page loads when refreshing location with anchor

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -121,9 +121,13 @@ export class Navigator {
   }
 
   locationWithActionIsSamePage(location: URL, action?: Action): boolean {
+    const anchor = getAnchor(location)
+    const currentAnchor = getAnchor(this.view.lastRenderedLocation)
+    const isRestorationToTop = action === 'restore' && typeof anchor === 'undefined'
+
     return action !== "replace" &&
       getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
-      (getAnchor(location) != null || action == "restore")
+      (isRestorationToTop || (anchor != null && anchor !== currentAnchor))
   }
 
   visitScrolledToSamePageLocation(oldURL: URL, newURL: URL) {

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -121,7 +121,8 @@ export class Navigator {
   }
 
   locationWithActionIsSamePage(location: URL, action?: Action): boolean {
-    return getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
+    return action !== "replace" &&
+      getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
       (getAnchor(location) != null || action == "restore")
   }
 

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -14,11 +14,7 @@ export class Snapshot<E extends Element = Element> {
   }
 
   getElementForAnchor(anchor: string | undefined) {
-    try {
-      return this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`)
-    } catch {
-      return null
-    }
+    return anchor ? this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`) : null
   }
 
   get isConnected() {

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -9,6 +9,8 @@
   <body>
     <a href="#main">Skip Link</a>
 
+    <a href="#main" id="refresh-link" data-turbo-action="replace">Refresh Link</a>
+
     <a href="#ignored-link" id="ignored-link">Skipped Content</a>
 
     <section id="main" style="height: 200vh">

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -163,6 +163,12 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.ok(await this.selectorHasFocus("#main a:first-of-type"), "skips to first interactive element after #main")
   }
 
+  async "test same-page anchored replace link assumes the intention was a refresh"() {
+    await this.clickSelector('#refresh-link')
+    await this.nextBody
+    this.assert.ok(await this.isScrolledToSelector("#main"), "scrolled to #main")
+  }
+
   async "test navigating back to anchored URL"() {
     await this.clickSelector('a[href="#main"]')
     await this.nextBeat


### PR DESCRIPTION
Currently, if the location is `http://example.com#main`, and we call `Turbo.visit(location.toString())`, the page will just scroll to the anchor without reloading the page. This makes is impossible to refresh a current page via a Turbo visit.

Rather than checking for the presence of a URL hash, this pull request just checks that the hash has changed. If so, it's a same page visit.

/cc @jayohms 
