### PR TITLE
Fire 'turbo:after-fetch-render' event after turbo frame renders the view

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -2,7 +2,7 @@ import { FrameElement, FrameElementDelegate, FrameLoadingStyle } from "../../ele
 import { FetchMethod, FetchRequest, FetchRequestDelegate, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/appearance_observer"
-import { parseHTMLDocument } from "../../util"
+import { parseHTMLDocument, dispatch } from "../../util"
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
 import { ViewDelegate } from "../view"
@@ -107,6 +107,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
         const renderer = new FrameRenderer(this.view.snapshot, snapshot, false)
         if (this.view.renderPromise) await this.view.renderPromise
         await this.view.render(renderer)
+        const frame = this.element.id;
+        dispatch("turbo:after-frame-render", { cancelable: true, detail: { fetchResponse, frame } })
       }
     } catch (error) {
       console.error(error)

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -51,5 +51,9 @@
 
     <a id="navigate-form-redirect" href="/src/tests/fixtures/frames/form-redirect.html" data-turbo-frame="form-redirect">Visit form-redirect.html</a>
     <turbo-frame id="form-redirect"></turbo-frame>
+
+    <turbo-frame id="part">
+      <a id="frame-part" href="/src/tests/fixtures/frames/part.html">Load #part</a>
+    </turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/frames/part.html
+++ b/src/tests/fixtures/frames/part.html
@@ -1,0 +1,3 @@
+<turbo-frame id="part">
+  <h2>Frames: #frame-part</h2>
+</turbo-frame>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -26,5 +26,6 @@
   "turbo:render",
   "turbo:before-fetch-request",
   "turbo:before-fetch-response",
+  "turbo:after-frame-render",
   "turbo:visit"
 ])

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -152,6 +152,16 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.ok(await this.querySelector("#form-redirect-header"))
   }
 
+  async "test 'turbo:after-frame-render' is triggered after frame has finished rendering"() {
+    await this.clickSelector("#frame-part")
+
+    await this.nextEventNamed("turbo:after-frame-render") // recursive.html
+    const { frame, fetchResponse } = await this.nextEventNamed("turbo:after-frame-render")
+
+    this.assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/part.html")
+    this.assert.equal(frame, 'part')
+  }
+
   get frameScriptEvaluationCount(): Promise<number | undefined> {
     return this.evaluate(() => window.frameScriptEvaluationCount)
   }


### PR DESCRIPTION
Hello all!

This PR introduces the `turbo:after-fetch-render` event which
gets fired right after a turbo-frame element renders its view.

You can access the current turbo-frame id with `event.detail.frame`
and the fetch response object with `event.detail.fetchResponse`.

