### PR TITLE
Prevent unexpected side-effects of same-page visit events.

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -7,7 +7,7 @@ import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
-  allowsVisitingLocation(location: URL): boolean
+  allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>): void
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
@@ -22,7 +22,7 @@ export class Navigator {
   }
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
-    if (this.delegate.allowsVisitingLocation(location)) {
+    if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
       this.delegate.visitProposedToLocation(location, options)
     }
   }
@@ -120,7 +120,7 @@ export class Navigator {
     this.delegate.visitCompleted(visit)
   }
 
-  locationWithActionIsSamePage(location: URL, action: Action): boolean {
+  locationWithActionIsSamePage(location: URL, action?: Action): boolean {
     return getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
       (getAnchor(location) != null || action == "restore")
   }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -111,6 +111,10 @@ export class Visit implements FetchRequestDelegate {
     return this.history.getRestorationDataForIdentifier(this.restorationIdentifier)
   }
 
+  get silent() {
+    return this.isSamePage
+  }
+
   start() {
     if (this.state == VisitState.initialized) {
       this.recordTimingMetric(TimingMetric.visitStart)

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -154,8 +154,8 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
 
   // Navigator delegate
 
-  allowsVisitingLocation(location: URL) {
-    return this.applicationAllowsVisitingLocation(location)
+  allowsVisitingLocationWithAction(location: URL, action?: Action) {
+    return this.locationWithActionIsSamePage(location, action) || this.applicationAllowsVisitingLocation(location)
   }
 
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>) {
@@ -165,14 +165,16 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
 
   visitStarted(visit: Visit) {
     extendURLWithDeprecatedProperties(visit.location)
-    this.notifyApplicationAfterVisitingLocation(visit.location, visit.action)
+    if (!visit.silent) {
+      this.notifyApplicationAfterVisitingLocation(visit.location, visit.action)
+    }
   }
 
   visitCompleted(visit: Visit) {
     this.notifyApplicationAfterPageLoad(visit.getTimingMetrics())
   }
 
-  locationWithActionIsSamePage(location: URL, action: Action): boolean {
+  locationWithActionIsSamePage(location: URL, action?: Action): boolean {
     return this.navigator.locationWithActionIsSamePage(location, action)
   }
 
@@ -214,7 +216,9 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   // Page view delegate
 
   viewWillCacheSnapshot() {
-    this.notifyApplicationBeforeCachingSnapshot()
+    if (!this.navigator.currentVisit?.silent) {
+      this.notifyApplicationBeforeCachingSnapshot()
+    }
   }
 
   allowsImmediateRender({ element }: PageSnapshot, resume: (value: any) => void) {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -175,6 +175,23 @@ export class NavigationTests extends TurboDriveTestCase {
 
     this.assert.ok(await this.isScrolledToSelector("#main"), "scrolled to #main")
   }
+
+  async "test same-page anchor visits do not trigger visit events"() {
+    const events = [
+      "turbo:before-visit",
+      "turbo:visit",
+      "turbo:before-cache",
+      "turbo:before-render",
+      "turbo:render",
+      "turbo:load"
+    ]
+
+    for (const eventName in events) {
+      await this.goToLocation("/src/tests/fixtures/navigation.html")
+      await this.clickSelector('a[href="#main"]')
+      this.assert.ok(await this.noNextEventNamed(eventName), `same-page links do not trigger ${eventName} events`)
+    }
+  }
 }
 
 NavigationTests.registerSuite()


### PR DESCRIPTION
Do not trigger unexpected events on same-page visits. Fixes #321