### PR TITLE
Add support for a reload action in a turbo stream.

### DIFF
--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -27,6 +27,14 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
     this.targetElements.forEach(e => e.replaceWith(this.templateContent))
   },
 
+  reload() {
+    this.targetElements.forEach(e => {
+      if (typeof(e["reload"]) == "function") {
+        e.reload()
+      }
+    })
+  },
+
   update() {
     this.targetElements.forEach(e => { 
       e.innerHTML = ""


### PR DESCRIPTION
<turbo-stream action="reload" target="mainFrame"/>

I've implemented this in a turbo:before-stream-render event handler and it seems to be a logical and possibly desirable function so I added it to turbo directly.

My use case for this was to push via a cable socket and leave the fetching to the web browser, with the content loading then, therefore, being subject to all the normal server side request validation and scoping.

Writing  tests for this is a little out of my depth at the moment.