### PR TITLE
Add an option to Refill a Turbo Frame

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -77,7 +77,9 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   async loadSourceURL() {
-    if (!this.settingSourceURL && this.enabled && this.isActive && this.sourceURL != this.currentURL) {
+    let canLoadSource = !this.settingSourceURL && this.enabled && this.isActive && 
+                        (this.refillable || this.sourceURL != this.currentURL)
+    if (canLoadSource) {
       const previousURL = this.currentURL
       this.currentURL = this.sourceURL
       if (this.sourceURL) {
@@ -312,6 +314,10 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     if (this.element.src) {
       return this.element.src
     }
+  }
+
+  get refillable() {
+    return this.element.refill
   }
 
   set sourceURL(sourceURL: string | undefined) {

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -78,7 +78,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
 
   async loadSourceURL() {
     let canLoadSource = !this.settingSourceURL && this.enabled && this.isActive && 
-                        (this.refillable || this.sourceURL != this.currentURL)
+                        (this.reloadable || this.sourceURL != this.currentURL)
     if (canLoadSource) {
       const previousURL = this.currentURL
       this.currentURL = this.sourceURL
@@ -316,8 +316,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     }
   }
 
-  get refillable() {
-    return this.element.refill
+  get reloadable() {
+    return this.element.reloadable
   }
 
   set sourceURL(sourceURL: string | undefined) {

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -64,6 +64,10 @@ export class FrameElement extends HTMLElement {
     }
   }
 
+  get refill() {
+    return this.getAttribute("refill") == "true"
+  }
+
   get loading(): FrameLoadingStyle {
     return frameLoadingStyleFromString(this.getAttribute("loading") || "")
   }

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -64,8 +64,8 @@ export class FrameElement extends HTMLElement {
     }
   }
 
-  get refill() {
-    return this.getAttribute("refill") == "true"
+  get reloadable() {
+    return this.getAttribute("data-turbo-frame-reload") == "true"
   }
 
   get loading(): FrameLoadingStyle {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -51,5 +51,8 @@
 
     <a id="navigate-form-redirect" href="/src/tests/fixtures/frames/form-redirect.html" data-turbo-frame="form-redirect">Visit form-redirect.html</a>
     <turbo-frame id="form-redirect"></turbo-frame>
+
+    <a id="navigate-frame-refill" href="/src/tests/fixtures/frames/frame-refill.html" data-turbo-frame="frame-refill">Visit frame-refill.html</a>
+    <turbo-frame id="frame-refill" refill></turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -52,7 +52,7 @@
     <a id="navigate-form-redirect" href="/src/tests/fixtures/frames/form-redirect.html" data-turbo-frame="form-redirect">Visit form-redirect.html</a>
     <turbo-frame id="form-redirect"></turbo-frame>
 
-    <a id="navigate-frame-refill" href="/src/tests/fixtures/frames/frame-refill.html" data-turbo-frame="frame-refill">Visit frame-refill.html</a>
-    <turbo-frame id="frame-refill" refill></turbo-frame>
+    <a id="navigate-frame-reload" href="/src/tests/fixtures/frames/frame-reload.html" data-turbo-frame="frame-reload">Visit frame-reload.html</a>
+    <turbo-frame id="frame-reload" data-turbo-frame-reload="true"></turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/frames/frame-refill.html
+++ b/src/tests/fixtures/frames/frame-refill.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frame</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <turbo-frame id="frame-refill">
+      <h2 id="frame-refill-header">Frame Refill</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/frames/frame-reload.html
+++ b/src/tests/fixtures/frames/frame-reload.html
@@ -7,8 +7,8 @@
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
-    <turbo-frame id="frame-refill">
-      <h2 id="frame-refill-header">Frame Refill</h2>
+    <turbo-frame id="frame-reload">
+      <h2 id="frame-reload-header">Frame Reload</h2>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -152,6 +152,20 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.ok(await this.querySelector("#form-redirect-header"))
   }
 
+  async "test refollowing a link with target to frame with refill=true refills the frame"() {
+    await this.clickSelector("#navigate-frame-refill")
+    await this.nextBeat
+    this.assert.ok(await this.querySelector("#frame-refill-header"))
+
+    // Here we need to clean the element #frame-refill
+    // Here we need to test if #frame-refill is empty
+    throw new Error('missing specs')
+
+    await this.clickSelector("#navigate-frame-refill")
+    await this.nextBeat
+    this.assert.ok(await this.querySelector("#frame-refill-header"))
+  }
+
   get frameScriptEvaluationCount(): Promise<number | undefined> {
     return this.evaluate(() => window.frameScriptEvaluationCount)
   }

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -152,18 +152,18 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.ok(await this.querySelector("#form-redirect-header"))
   }
 
-  async "test refollowing a link with target to frame with refill=true refills the frame"() {
-    await this.clickSelector("#navigate-frame-refill")
+  async "test refollowing a link with target to frame with reload=true reloads the frame"() {
+    await this.clickSelector("#navigate-frame-reload")
     await this.nextBeat
-    this.assert.ok(await this.querySelector("#frame-refill-header"))
+    this.assert.ok(await this.querySelector("#frame-reload-header"))
 
     // Here we need to clean the element #frame-refill
     // Here we need to test if #frame-refill is empty
     throw new Error('missing specs')
 
-    await this.clickSelector("#navigate-frame-refill")
+    await this.clickSelector("#navigate-frame-reload")
     await this.nextBeat
-    this.assert.ok(await this.querySelector("#frame-refill-header"))
+    this.assert.ok(await this.querySelector("#frame-reload-header"))
   }
 
   get frameScriptEvaluationCount(): Promise<number | undefined> {


### PR DESCRIPTION
Currently, when we click on a link and a Turbo Frame and the requested content is loaded the `src` attribute of frame is filled and we can't refill this Turbo Frame again with the same URL request.

For example, the code below, where we have a link targeting a TurboFrame.
```
<a href="/my-sample-url" data-turbo-frame="my-turbo-frame">My Link</a>

<turbo-frame id="my-turbo-frame">
</turbo-frame>
```
If I click on link, Turbo Frame loads the content as expected. If I click on the link for a second time, the content of TurboFrame will remain the same as expected to avoid reloading all over again.

But there are some cases we need to reload the content again for some update that could be happen on server side.

I'm proposing to add a new attribute called `refill` to enable a Turbo Frame to be reloaded with the same URL when a request is done.

An example with this new thing would be this code:
```
<a href="/my-sample-url" data-turbo-frame="my-turbo-frame">My Link</a>

<turbo-frame id="my-turbo-frame" refill="true">
</turbo-frame>
```
As TurboFrame has an attribute `refill` set as `true`, whenever we click on the link, the content on TurboFrame will be reloaded.


**:red_circle: :red_circle: :red_circle: DISCLAIMER: I need a help to finish the specs for this feature. I've built the test structure, but I couldn't find a way to clean the content of a TurboFrame on specs. If someone is able to help me on that, it'd be great! =D**