### PR TITLE
Fix error with form inputs named action

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -64,7 +64,8 @@ export class FormSubmission {
   }
 
   get action(): string {
-    return this.submitter?.getAttribute("formaction") || this.formElement.action
+    const formElementAction = typeof this.formElement.action === 'string' ? this.formElement.action : null
+    return this.submitter?.getAttribute("formaction") || this.formElement.getAttribute("action") || formElementAction || ""
   }
 
   get location(): URL {

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -65,6 +65,19 @@
       </form>
     </div>
     <hr>
+    <div id="action-input">
+      <form class="no-action">
+        <input type="hidden" name="action" value="1">
+        <input type="hidden" name="query" value="1">
+        <input type="submit">
+      </form>
+      <form class="action" action="/src/tests/fixtures/one.html">
+        <input type="hidden" name="action" value="1">
+        <input type="hidden" name="query" value="1">
+        <input type="submit">
+      </form>
+    </div>
+    <hr>
     <div id="reject">
       <form class="unprocessable_entity" action="/__turbo/reject" method="post">
         <input type="hidden" name="status" value="422">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -133,6 +133,24 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.deepEqual(await this.getAllSearchParams("button"), [])
   }
 
+  async "test input named action with no action attribute"() {
+    await this.clickSelector("#action-input form.no-action [type=submit]")
+    await this.nextBody
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+    this.assert.equal(await this.getSearchParam("action"), "1")
+    this.assert.equal(await this.getSearchParam("query"), "1")
+  }
+
+  async "test input named action with action attribute"() {
+    await this.clickSelector("#action-input form.action [type=submit]")
+    await this.nextBody
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+    this.assert.equal(await this.getSearchParam("action"), "1")
+    this.assert.equal(await this.getSearchParam("query"), "1")
+  }
+
   async "test invalid form submission with unprocessable entity status"() {
     await this.clickSelector("#reject form.unprocessable_entity input[type=submit]")
     await this.nextBody


### PR DESCRIPTION
This is a follow up PR based on the great work by @johnnyfreeman  https://github.com/hotwired/turbo/pull/266

Drive form submissions do not work as expected if there is a form field with `name="action"`.

For reference, the Mozilla docs describe the [Issues with Naming Elements](https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#issues_with_naming_elements). Here's the relevant bit:

---

This PR first uses `getAttribute('action')` before checking `form.action`. We also typecheck `form.action` to make sure it is a string and not an element. 

If `getAttribute` and `form.action` don't return a value, we fall back to an empty string. 

It seems like `expandURL` falls back to `document.baseURI`, so using an empty string should might be ok? 

https://github.com/hotwired/turbo/blob/bb6eb5ae670966a53a096afe5f3eaabbef8f7c7b/src/core/url.ts#L3-L5

It also adds related tests to ensure that forms with `<input name="action" value="1">` work as expected. 