### PR TITLE
Add Github Codespace configuration

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,21 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 16, 14, 12
+ARG VARIANT="16-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# [Optional] Uncomment this section to install additional OS packages.
+ENV CHROMIUM_VERSION 90.0.4430.212-1~deb10u1
+RUN apt-get update \
+    && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends \
+        chromium-common=${CHROMIUM_VERSION} chromium-driver=${CHROMIUM_VERSION} chromium-sandbox=${CHROMIUM_VERSION} \
+        openjdk-11-jdk \
+        firefox-esr
+
+# [Optional] Uncomment if you want to install an additional version of node using nvm
+# ARG EXTRA_NODE_VERSION=10
+# RUN su node -c "source /usr/local/share/nvm/nvm.sh && nvm install ${EXTRA_NODE_VERSION}"
+
+# [Optional] Uncomment if you want to install more global node packages
+# RUN su node -c "npm install -g <your-package-list -here>"

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -5,13 +5,28 @@ ARG VARIANT="16-buster"
 FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
 
 # [Optional] Uncomment this section to install additional OS packages.
-ENV CHROMIUM_VERSION 90.0.4430.212-1~deb10u1
 RUN apt-get update \
     && export DEBIAN_FRONTEND=noninteractive \
     && apt-get -y install --no-install-recommends \
-        chromium-common=${CHROMIUM_VERSION} chromium-driver=${CHROMIUM_VERSION} chromium-sandbox=${CHROMIUM_VERSION} \
         openjdk-11-jdk \
         firefox-esr
+
+# Chromium and chrome-driver
+ARG CHROMIUM_DEB_URL=https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+RUN wget -qO - $CHROMIUM_DEB_URL > /tmp/chrome_linux64.deb \
+    && apt -y install /tmp/chrome_linux64.deb -f \
+    && FULL_CHROME_VERSION=$(google-chrome --product-version) \
+    && CHROME_VERSION=${FULL_CHROME_VERSION%.*} \
+    && CHROMEDRIVER_DIR="/usr/local/share/chrome_driver" \
+    && CHROMEDRIVER_BIN="$CHROMEDRIVER_DIR/chromedriver" \
+    && LATEST_CHROMEDRIVER_VERSION=$(curl -sL "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_$CHROME_VERSION") \
+    && CHROMEDRIVER_URL="https://chromedriver.storage.googleapis.com/$LATEST_CHROMEDRIVER_VERSION/chromedriver_linux64.zip" \
+    && wget -qO - $CHROMEDRIVER_URL > /tmp/chromedriver_linux64.zip \
+    && mkdir -p $CHROMEDRIVER_DIR \
+    && unzip -qq /tmp/chromedriver_linux64.zip -d $CHROMEDRIVER_DIR \
+    && chmod +x $CHROMEDRIVER_BIN \
+    && ln -s "$CHROMEDRIVER_BIN" /usr/bin/ \
+    && rm -rf /tmp/chrome*
 
 # [Optional] Uncomment if you want to install an additional version of node using nvm
 # ARG EXTRA_NODE_VERSION=10

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,24 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.191.1/containers/typescript-node
+{
+  "name": "Node.js & TypeScript",
+  "build": {
+    "dockerfile": "Dockerfile",
+    // Update 'VARIANT' to pick a Node version: 12, 14, 16
+    "args": {
+      "VARIANT": "16"
+    }
+  },
+  // Set *default* container specific settings.json values on container create.
+  "settings": {},
+  // Add the IDs of extensions you want installed when the container is created.
+  "extensions": [
+    "dbaeumer.vscode-eslint"
+  ],
+  // Use 'forwardPorts' to make a list of ports inside the container available locally.
+  // "forwardPorts": [],
+  // Use 'postCreateCommand' to run commands after the container is created.
+  "postCreateCommand": "yarn build",
+  // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+  "remoteUser": "node"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -18,7 +18,7 @@
   // Use 'forwardPorts' to make a list of ports inside the container available locally.
   // "forwardPorts": [],
   // Use 'postCreateCommand' to run commands after the container is created.
-  "postCreateCommand": "yarn build",
+  "postCreateCommand": "yarn install && yarn build",
   // Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
   "remoteUser": "node"
 }

--- a/intern.json
+++ b/intern.json
@@ -6,7 +6,7 @@
       "browserName": "chrome",
       "fixSessionCapabilities": true,
       "goog:chromeOptions": {
-        "args": [ "headless", "disable-gpu" ]
+        "args": [ "headless", "disable-gpu", "no-sandbox" ]
       }
     },
     {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -178,6 +178,7 @@ export class NavigationTests extends TurboDriveTestCase {
     await this.nextBeat
 
     await this.goBack()
+    await this.nextBody
 
     this.assert.ok(await this.isScrolledToSelector("#main"), "scrolled to #main")
   }


### PR DESCRIPTION
With the introduction of Github Codespaces, it is easier than ever to contribute to an open source project. In my pursuit of fixing a bug in Turbo, I wanted to use a Codespace. In order to run the test suite, some additional tools are needed in the devcontainer:

- Java for starting a webserver
- Firefox for browser testing
- Chromium for browser testing

My goal is to successfully run `yarn test` after booting a Codespace. I'm running into some issues I don't know how to solve, so this is a WIP PR with a call for some help:

1. Firefox is green for all but one spec about the scroll position. 

  ```
  × firefox on linux 5.4.0-1055-azure - NavigationTests - navigating back to anchored URL (0.783s)
      AssertionError: scrolled to #main: expected false to be truthy
        at NavigationTests.test navigating back to anchored URL @ src/tests/functional/navigation_tests.ts:182:16
        at runMicrotasks @ anonymous
        at processTicksAndRejections @ node:internal/process/task_queues:96:5
        at async NavigationTests.runTest @ src/tests/helpers/intern_test_case.ts:43:6
  ```

2. Chromium doesn't start due to this error, but the weird thing it that `chromedriver` has the exact same version.

```
This version of ChromeDriver only supports Chrome version 91
Current browser version is 90.0.4430.212 with binary path /usr/bin/chromium
```

Anyone suggestions how to solve these last two errors to enable Codespaces for this project?

If you want to test these changes or want to experiment yourself, you can [open this PR with Codespace too](https://docs.github.com/en/codespaces/developing-in-codespaces/using-codespaces-for-pull-requests#opening-a-pull-request-in-codespaces).