### PR TITLE
fixup: late lifecycle attachment

### DIFF
--- a/src/observers/page_observer.ts
+++ b/src/observers/page_observer.ts
@@ -26,6 +26,7 @@ export class PageObserver {
         this.stage = PageStage.loading
       }
       document.addEventListener("readystatechange", this.interpretReadyState, false)
+      this.interpretReadyState(document.readyState);
       addEventListener("pagehide", this.pageWillUnload, false)
       this.started = true
     }


### PR DESCRIPTION
I haven't tested this change, but in theory this should be the right sort of approach to handle late attachment of page state for module scripts that are delayed, in particular as happens when using es-module-shims.

Once tested and assuming there aren't any bugs, this should resolve https://github.com/hotwired/turbo-rails/issues/216.