### PR TITLE
Reset `reloadable` attribute on reconnect and on form submissions

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -37,6 +37,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   connect() {
     if (!this.connected) {
       this.connected = true
+      this.reloadable = false
       if (this.loadingStyle == FrameLoadingStyle.lazy) {
         this.appearanceObserver.start()
       }
@@ -146,6 +147,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
       this.formSubmission.stop()
     }
 
+    this.reloadable = false
     this.formSubmission = new FormSubmission(this, element, submitter)
     if (this.formSubmission.fetchRequest.isIdempotent) {
       this.navigateFrame(element, this.formSubmission.fetchRequest.url.href)


### PR DESCRIPTION
https://github.com/hotwired/turbo/pull/349 introduced a bug with reloading on reconnect after the first click: https://github.com/hotwired/turbo/pull/349#issuecomment-903564696