### PR TITLE
Handle request abortion

### DIFF
--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -78,7 +78,7 @@ export class FetchRequest {
     this.abortController.abort()
   }
 
-  async perform(): Promise<FetchResponse> {
+  async perform(): Promise<FetchResponse | void> {
     const { fetchOptions } = this
     this.delegate.prepareHeadersForRequest?.(this.headers, this)
     await this.allowRequestToBeIntercepted(fetchOptions)
@@ -87,8 +87,10 @@ export class FetchRequest {
       const response = await fetch(this.url.href, fetchOptions)
       return await this.receive(response)
     } catch (error) {
-      this.delegate.requestErrored(this, error)
-      throw error
+      if (error.name !== 'AbortError') {
+        this.delegate.requestErrored(this, error)
+        throw error
+      }
     } finally {
       this.delegate.requestFinished(this)
     }

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -52,6 +52,7 @@
       <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/one.html">Redirection link</a></p>
       <p><a id="headers-link" href="/__turbo/headers">Headers link</a></p>
       <p><custom-link-element id="custom-link-element" link="/src/tests/fixtures/one.html" text="Same-origin unannotated custom element link"></custom-link-element></p>
+      <p><a id="delayed-link" href="/__turbo/delayed_response">Delayed link</a></p>
     </section>
 
     <turbo-frame id="hello" disabled></turbo-frame>

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -254,6 +254,15 @@ export class NavigationTests extends TurboDriveTestCase {
     const headers = await JSON.parse(await pre.getVisibleText())
     this.assert.equal(headers.referer, 'http://localhost:9000/src/tests/fixtures/navigation.html', `referer header is correctly set`)
   }
+
+  async "test double-clicking on a link"() {
+    this.clickSelector("#delayed-link")
+    this.clickSelector("#delayed-link")
+
+    await this.nextBody
+    this.assert.equal(await this.pathname, "/__turbo/delayed_response")
+    this.assert.equal(await this.visitAction, "advance")
+  }
 }
 
 NavigationTests.registerSuite()

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -56,6 +56,11 @@ router.get("/headers", (request, response) => {
   response.type("html").status(200).send(template.replace('$HEADERS', JSON.stringify(request.headers, null, 4)))
 })
 
+router.get("/delayed_response", (request, response) => {
+  const fixture = path.join(__dirname, "../../src/tests/fixtures/one.html")
+  setTimeout(() => response.status(200).sendFile(fixture), 1000)
+})
+
 router.post("/messages", (request, response) => {
   const params = { ...request.body, ...request.query }
   const { content, status, type, target, targets } = params


### PR DESCRIPTION
Closes #276, closes #253, closes #175.

This PR improves request abortion error handling. This will prevent page reloads on link double-clicks (it was caused by calling `this.delegate.requestErrored` on `AbortError`).