### PR TITLE
Handle server errors for form submissions

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -100,7 +100,11 @@ export class Navigator {
 
     if (responseHTML) {
       const snapshot = PageSnapshot.fromHTMLString(responseHTML)
-      await this.view.renderPage(snapshot)
+      if (fetchResponse.serverError) {
+        await this.view.renderError(snapshot)
+      } else {
+        await this.view.renderPage(snapshot)
+      }
       this.view.scrollToTop()
       this.view.clearSnapshotCache()
     }

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -5,7 +5,7 @@
     <title>Form</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
-    <style>
+    <style id="form-fixture-styles">
       dialog {
         display: block;
         position: static;

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -192,11 +192,13 @@ export class FormSubmissionTests extends TurboDriveTestCase {
   }
 
   async "test invalid form submission with server error status"() {
+    this.assert(await this.hasSelector("head > #form-fixture-styles"))
     await this.clickSelector("#reject form.internal_server_error input[type=submit]")
     await this.nextBody
 
     const title = await this.querySelector("h1")
     this.assert.equal(await title.getVisibleText(), "Internal Server Error", "renders the response HTML")
+    this.assert.notOk(await this.hasSelector("head > #form-fixture-styles"), "replaces head")
     this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
   }
 


### PR DESCRIPTION
Closes #208, closes #234.

Call `View.renderError` when receiving server error (5XX) after form submission.