### PR TITLE
Seperate progress bars for form submits and visits

### DIFF
--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -9,7 +9,8 @@ export class BrowserAdapter implements Adapter {
   readonly session: Session
   readonly progressBar = new ProgressBar
 
-  progressBarTimeout?: number
+  visitProgressBarTimeout?: number
+  formProgressBarTimeout?: number
 
   constructor(session: Session) {
     this.session = session
@@ -29,7 +30,7 @@ export class BrowserAdapter implements Adapter {
   visitRequestStarted(visit: Visit) {
     this.progressBar.setValue(0)
     if (visit.hasCachedSnapshot() || visit.action != "restore") {
-      this.showProgressBarAfterDelay()
+      this.showVisitProgressBarAfterDelay()
     } else {
       this.showProgressBar()
     }
@@ -52,7 +53,7 @@ export class BrowserAdapter implements Adapter {
 
   visitRequestFinished(visit: Visit) {
     this.progressBar.setValue(1)
-    this.hideProgressBar()
+    this.hideVisitProgressBar()
   }
 
   visitCompleted(visit: Visit) {
@@ -73,30 +74,44 @@ export class BrowserAdapter implements Adapter {
 
   formSubmissionStarted(formSubmission: FormSubmission) {
     this.progressBar.setValue(0)
-    this.showProgressBarAfterDelay()
+    this.showFormProgressBarAfterDelay()
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {
     this.progressBar.setValue(1)
-    this.hideProgressBar()
+    this.hideFormProgressBar()
   }
 
   // Private
 
-  showProgressBarAfterDelay() {
-    this.progressBarTimeout = window.setTimeout(this.showProgressBar, this.session.progressBarDelay)
+  showVisitProgressBarAfterDelay() {
+    this.visitProgressBarTimeout = window.setTimeout(this.showProgressBar, this.session.progressBarDelay)
+  }
+
+  hideVisitProgressBar() {
+    this.progressBar.hide()
+    if (this.visitProgressBarTimeout != null) {
+      window.clearTimeout(this.visitProgressBarTimeout)
+      delete this.visitProgressBarTimeout
+    }
+  }
+
+  showFormProgressBarAfterDelay() {
+    if (this.formProgressBarTimeout == null) {
+      this.formProgressBarTimeout = window.setTimeout(this.showProgressBar, this.session.progressBarDelay)
+    }
+  }
+
+  hideFormProgressBar() {
+    this.progressBar.hide()
+    if (this.formProgressBarTimeout != null) {
+      window.clearTimeout(this.formProgressBarTimeout)
+      delete this.formProgressBarTimeout
+    }
   }
 
   showProgressBar = () => {
     this.progressBar.show()
-  }
-
-  hideProgressBar() {
-    this.progressBar.hide()
-    if (this.progressBarTimeout != null) {
-      window.clearTimeout(this.progressBarTimeout)
-      delete this.progressBarTimeout
-    }
   }
 
   reload() {


### PR DESCRIPTION
This PR fixes #355. 

This issue occurs due to a race condition and possibly a bug in Safari when a form is submitted via Turbo Drive that redirects. In this case, _both_ the form submission _and_ the visit caused by the redirect call `showFormProgressBarAfterDelay()`.  This should be fine (and is for Firefox and Chrome). The original code stored the timeout for the progress bar under the same property so there is only one to clear.

But for some reason that I cannot explain, if the timing of these calls is _just_ right and `window.clearTimeout(x)` is called at the same time `x = window.setTimeout(...)`, Safari gets confused. While `window.clearTimeout` appears to clear the timeout, there is still some remnant of the one that was just set in the background. This remnant `window.setTimeout` still fires after both the redirect visit and the form submission are both complete and it causes this lingering progress bar to remain on the screen.

I don't really understand what's going on here, but what I _do_ know is after I apply this PR, I am unable to reproduce the issue on any of the three browsers. I think the reason why is we aren't sharing the same underlying timeout property, and nothing is attempting to set the property at the precise time something else is trying to clear it.