### PR TITLE
Revert "Links with method not work if used inside another form"

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -147,12 +147,13 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
       form.method = linkMethod
       form.action = link.getAttribute("href") || "undefined"
 
-      document.body.appendChild(form)
+      link.parentNode?.insertBefore(form, link)
       return dispatch("submit", { cancelable: true, target: form })
     } else {
       return false
     }
   }
+
 
   // Navigator delegate
 

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -193,8 +193,5 @@
       </div>
     </turbo-frame>
     <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="link-method-outside-frame">Stream link outside frame</a>
-    <form>
-      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="link-method-inside-form">Stream link inside form</a>
-    </form>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -400,15 +400,6 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await message.getVisibleText(), "Link!")
   }
 
-  async "test link method form submission inside form"() {
-    await this.clickSelector("#link-method-inside-form")
-
-    await this.nextBeat
-
-    const message = await this.querySelector("#frame div.message")
-    this.assert.equal(await message.getVisibleText(), "Link!")
-  }
-
   get formSubmitted(): Promise<boolean> {
     return this.hasSelector("html[data-form-submitted]")
   }


### PR DESCRIPTION
Reverts hotwired/turbo#341. This breaks links within turbo frames as reported in #358.

CC @davidgil.