### PR TITLE
Fix for get response html/text in locked body

### DIFF
--- a/src/http/fetch_response.ts
+++ b/src/http/fetch_response.ts
@@ -44,12 +44,12 @@ export class FetchResponse {
   }
 
   get responseText(): Promise<string> {
-    return this.response.text()
+    return this.response.clone().text()
   }
 
   get responseHTML(): Promise<string | undefined> {
     if (this.isHTML) {
-      return this.response.text()
+      return this.response.clone().text()
     } else {
       return Promise.resolve(undefined)
     }

--- a/src/tests/fixtures/sample_short_response.html
+++ b/src/tests/fixtures/sample_short_response.html
@@ -1,0 +1,1 @@
+Sample response

--- a/src/tests/fixtures/visit.html
+++ b/src/tests/fixtures/visit.html
@@ -10,6 +10,7 @@
     <section>
       <h1>Visit</h1>
       <p><a id="same-origin-link" href="/src/tests/fixtures/one.html">Same-origin link</a></p>
+      <p><a id="sample-response" href="/src/tests/fixtures/sample_short_response.html">Sample response</a></p>
     </section>
   </body>
 </html>

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -79,6 +79,27 @@ export class VisitTests extends TurboDriveTestCase {
     this.assert.include(url, "/src/tests/fixtures/one.html")
   }
 
+  async "test turbo:before-fetch-response open new site"() {
+    this.remote.execute(() => addEventListener("turbo:before-fetch-response", async function eventListener(event: any) {
+      removeEventListener("turbo:before-fetch-response", eventListener, false);
+
+      document.body.innerText = 'Received fetch response';
+
+      if (await event.detail.fetchResponse.responseHTML === 'Sample response') {
+        document.body.innerText += ' html';
+      }
+
+      if (await event.detail.fetchResponse.responseText === 'Sample response') {
+        document.body.innerText += ' text';
+      }
+    }, false))
+
+    await this.clickSelector("#sample-response")
+    const body = await this.nextBody;
+
+    this.assert(await body.getVisibleText(), "Received fetch response html text")
+  }
+
   async visitLocation(location: string) {
     this.remote.execute((location: string) => window.Turbo.visit(location), [location])
   }


### PR DESCRIPTION
Hi,

I detected a small bug during migrating from turbolinks to turbo. :)

![Zrzut ekranu z 2021-08-30 20-19-56](https://user-images.githubusercontent.com/34351740/131402804-f9e048e7-d69d-41f8-bf5a-b4031180f105.png)


It appears when he wants to get `responseHTML` or `responeText` on event: `turbo: before-fetch-response`