### PR TITLE
Fix restoring a visit without a cached snapshot available

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -372,9 +372,7 @@ export class Visit implements FetchRequestDelegate {
   }
 
   shouldIssueRequest() {
-    const hasCachedSnapshot = this.hasCachedSnapshot()
-
-    if (this.action == "restore" && !hasCachedSnapshot) {
+    if (this.action == "restore" && !this.hasCachedSnapshot()) {
       return true
     } else if (this.isSamePage) {
       return false

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -372,10 +372,14 @@ export class Visit implements FetchRequestDelegate {
   }
 
   shouldIssueRequest() {
-    if (this.isSamePage) {
+    const hasCachedSnapshot = this.hasCachedSnapshot()
+
+    if (this.action == "restore" && !hasCachedSnapshot) {
+      return true
+    } else if (this.isSamePage) {
       return false
     } else if (this.action == "restore") {
-      return !this.hasCachedSnapshot()
+      return false
     } else {
       return true
     }


### PR DESCRIPTION
There may not always be a cached snapshot available when restoring a visit. We need to issue a new request in that situation.

This fixes a regression from #298. Bug report here: https://github.com/hotwired/turbo-android/issues/184

cc @domchristie 