### PR TITLE
Allow to set target="_self" in a link

### DIFF
--- a/src/tests/fixtures/frame_navigation.html
+++ b/src/tests/fixtures/frame_navigation.html
@@ -14,6 +14,7 @@
         <h2>Frame Navigation</h2>
 
         <a id="inside" href="/src/tests/fixtures/frame_navigation.html">Inside Frame</a>
+        <a id="self" href="/src/tests/fixtures/frame_navigation.html" data-turbo-frame="_self">Self Frame</a>
         <a id="top" href="/src/tests/fixtures/frame_navigation.html" data-turbo-frame="_top">Top</a>
       </turbo-frame>
     </div>

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -30,6 +30,7 @@
 
     <turbo-frame id="navigate-top" target="_top">
       <a href="/src/tests/fixtures/one.html">Visit one.html</a>
+      <a href="/src/tests/fixtures/one.html" data-turbo-frame="_self">Visit self</a>
     </turbo-frame>
 
     <turbo-frame id="missing">

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -13,5 +13,9 @@
     <!--styles ensure that the element will be scrolled to top when navigated to via an anchored link -->
     <a name="named-anchor"></a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
+
+    <turbo-frame id="navigate-top">
+      Replaced only the frame
+    </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/frame_navigation_tests.ts
+++ b/src/tests/functional/frame_navigation_tests.ts
@@ -11,6 +11,12 @@ export class FrameNavigationTests extends TurboDriveTestCase {
     await this.nextEventOnTarget("frame", "turbo:frame-load")
   }
 
+  async "test frame navigation with self link"() {
+    await this.clickSelector("#self")
+
+    await this.nextEventOnTarget("frame", "turbo:frame-load")
+  }
+
   async "test frame navigation with exterior link"() {
     await this.clickSelector("#outside")
 

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -78,12 +78,25 @@ export class FrameTests extends TurboDriveTestCase {
   async "test following a link within a frame with target=_top navigates the page"() {
     this.assert.equal(await this.attributeForSelector("#navigate-top" ,"src"), null)
 
-    await this.clickSelector("#navigate-top a")
+    await this.clickSelector("#navigate-top a:not([data-turbo-frame])")
     await this.nextBeat
 
     const frameText = await this.querySelector("body > h1")
     this.assert.equal(await frameText.getVisibleText(), "One")
-    this.assert.notOk(await this.hasSelector("#navigate-top"))
+    this.assert.notOk(await this.hasSelector("#navigate-top a"))
+  }
+
+  async "test following a link that declares data-turbo-frame='_self' within a frame with target=_top navigates the frame itself"() {
+    this.assert.equal(await this.attributeForSelector("#navigate-top" ,"src"), null)
+
+    await this.clickSelector("#navigate-top a[data-turbo-frame='_self']")
+    await this.nextBeat
+
+    const title = await this.querySelector("body > h1")
+    this.assert.equal(await title.getVisibleText(), "Frames")
+    this.assert.ok(await this.hasSelector("#navigate-top"))
+    const frame = await this.querySelector("#navigate-top")
+    this.assert.equal(await frame.getVisibleText(), "Replaced only the frame")
   }
 
   async "test following a link to a page with a <turbo-frame recurse> which lazily loads a matching frame"() {


### PR DESCRIPTION
Fixes #252: we wanted a new property to target the nearest frame.

As we read [this page](https://www.tagindex.net/html/frame/a_target.html) we realised that `target="_self"` is what we were looking after and not `target="_parent"` (which might still be a different option).

When we started implementing the tests for that, we realised that it's already possible to do that! 
Probably not on purpose but because by setting `data-turbo-target='an_id_that_does_not_exist'` simply overrides the default set in the parent frame (in our case `_top`) and always replaces the frame itself. Is this actually a bug or intentional?

We decided that the test implemented here is meaningful anyway and might work as regression test in case the current behaviour was unexpected.

Co-authored-by: @simon-isler