### PR TITLE
fix: check if submit-event polyfill exists

### DIFF
--- a/src/polyfills/submit-event.ts
+++ b/src/polyfills/submit-event.ts
@@ -18,6 +18,7 @@ function clickCaptured(event: Event) {
 
 (function() {
   if ("SubmitEvent" in window) return
+  if ("submitter" in Event.prototype) return
 
   addEventListener("click", clickCaptured, true)
 


### PR DESCRIPTION
It came to my attention that mrujs also uses the submit-event polyfill (and im sure a number of other packages) and perhaps we should add a check if the submit-event polyfill already exists so we dont get the following error:

https://github.com/ParamagicDev/mrujs/issues/113

This behavior is fixed in mrujs `0.4.12` but will require Turbo to run their IIFE first so import order will matter (I think)

https://github.com/ParamagicDev/mrujs/pull/114