### PR TITLE
Read `data-turbo-frame` target from Submitter

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -246,7 +246,6 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
 
   private navigateFrame(element: Element, url: string, submitter?: HTMLElement) {
     const frame = this.findFrameElement(element, submitter)
-    const frame = this.findFrameElement(element)
     frame.setAttribute("reloadable", "")
     frame.src = url
   }

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -152,7 +152,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     this.reloadable = false
     this.formSubmission = new FormSubmission(this, element, submitter)
     if (this.formSubmission.fetchRequest.isIdempotent) {
-      this.navigateFrame(element, this.formSubmission.fetchRequest.url.href)
+      this.navigateFrame(element, this.formSubmission.fetchRequest.url.href, submitter)
     } else {
       const { fetchRequest } = this.formSubmission
       this.prepareHeadersForRequest(fetchRequest.headers, fetchRequest)
@@ -201,7 +201,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   formSubmissionSucceededWithResponse(formSubmission: FormSubmission, response: FetchResponse) {
-    const frame = this.findFrameElement(formSubmission.formElement)
+    const frame = this.findFrameElement(formSubmission.formElement, formSubmission.submitter)
     frame.delegate.loadResponse(response)
   }
 
@@ -244,13 +244,13 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     })
   }
 
-  private navigateFrame(element: Element, url: string) {
-    const frame = this.findFrameElement(element)
+  private navigateFrame(element: Element, url: string, submitter?: HTMLElement) {
+    const frame = this.findFrameElement(element, submitter)
     frame.src = url
   }
 
-  private findFrameElement(element: Element) {
-    const id = element.getAttribute("data-turbo-frame") || this.element.getAttribute("target")
+  private findFrameElement(element: Element, submitter?: HTMLElement) {
+    const id = submitter?.getAttribute("data-turbo-frame") || element.getAttribute("data-turbo-frame") || this.element.getAttribute("target")
     return getFrameElementById(id) ?? this.element
   }
 
@@ -277,7 +277,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   private shouldInterceptNavigation(element: Element, submitter?: Element) {
-    const id = element.getAttribute("data-turbo-frame") || this.element.getAttribute("target")
+    const id = submitter?.getAttribute("data-turbo-frame") || element.getAttribute("data-turbo-frame") || this.element.getAttribute("target")
 
     if (!this.enabled || id == "_top") {
       return false

--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -40,7 +40,7 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
   }
 
   formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement) {
-    const frame = this.findFrameElement(element)
+    const frame = this.findFrameElement(element, submitter)
     if (frame) {
       frame.removeAttribute("reloadable")
       frame.delegate.formSubmissionIntercepted(element, submitter)
@@ -48,12 +48,12 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
   }
 
   private shouldRedirect(element: Element, submitter?: HTMLElement) {
-    const frame = this.findFrameElement(element)
+    const frame = this.findFrameElement(element, submitter)
     return frame ? frame != element.closest("turbo-frame") : false
   }
 
-  private findFrameElement(element: Element) {
-    const id = element.getAttribute("data-turbo-frame")
+  private findFrameElement(element: Element, submitter?: HTMLElement) {
+    const id = submitter?.getAttribute("data-turbo-frame") || element.getAttribute("data-turbo-frame")
     if (id && id != "_top") {
       const frame = this.element.querySelector(`#${id}:not([disabled])`)
       if (frame instanceof FrameElement) {

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -13,6 +13,7 @@
     </style>
   </head>
   <body>
+    <h1>Form</h1>
     <div id="standard">
       <form action="/__turbo/redirect" method="post" class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
@@ -107,6 +108,15 @@
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
         <input type="submit" formenctype="multipart/form-data">
       </form>
+
+      <form action="/src/tests/fixtures/frames/form.html" method="get">
+        <button type="submit" data-turbo-frame="frame">GET to Frame</button>
+      </form>
+
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html">
+        <button type="submit" data-turbo-frame="frame">POST to Frame</button>
+      </form>
     </div>
     <hr>
     <div id="turbo-false">
@@ -189,9 +199,25 @@
         <input type="hidden" name="content" value="Hello!">
         <input type="submit">
       </form>
+      <form action="/src/tests/fixtures/one.html" method="get">
+        <button type="submit" data-turbo-frame="_top">Break-out of Frame with GET</button>
+      </form>
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <button type="submit" data-turbo-frame="_top">Break-out of Frame with POST</button>
+      </form>
+      <form action="/src/tests/fixtures/frames/hello.html" method="get">
+        <button type="submit" data-turbo-frame="hello">Navigate other Frame with GET</button>
+      </form>
+      <form action="/__turbo/redirect" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/hello.html">
+        <button type="submit" data-turbo-frame="hello">Navigate other Frame with POST</button>
+      </form>
       <div id="messages">
       </div>
     </turbo-frame>
     <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="link-method-outside-frame">Stream link outside frame</a>
+    <hr>
+    <turbo-frame id="hello"></turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/frames/hello.html
+++ b/src/tests/fixtures/frames/hello.html
@@ -7,7 +7,7 @@
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
-    <h1>Form</h1>
+    <h1>Hello</h1>
     <turbo-frame id="hello">
       <h2>Hello from a frame</h2>
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -219,6 +219,62 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(enctype?.startsWith("multipart/form-data"), "submits a multipart/form-data request")
   }
 
+  async "test submitter GET submission from submitter with data-turbo-frame"() {
+    await this.clickSelector("#submitter form[method=get] [type=submit][data-turbo-frame]")
+    await this.nextBeat
+
+    const message = await this.querySelector("#frame div.message")
+    const title = await this.querySelector("h1")
+    this.assert.equal(await title.getVisibleText(), "Form")
+    this.assert.equal(await message.getVisibleText(), "Frame redirected")
+  }
+
+  async "test submitter POST submission from submitter with data-turbo-frame"() {
+    await this.clickSelector("#submitter form[method=post] [type=submit][data-turbo-frame]")
+    await this.nextBeat
+
+    const message = await this.querySelector("#frame div.message")
+    const title = await this.querySelector("h1")
+    this.assert.equal(await title.getVisibleText(), "Form")
+    this.assert.equal(await message.getVisibleText(), "Frame redirected")
+  }
+
+  async "test frame form GET submission from submitter with data-turbo-frame=_top"() {
+    await this.clickSelector("#frame form[method=get] [type=submit][data-turbo-frame=_top]")
+    await this.nextBody
+
+    const title = await this.querySelector("h1")
+    this.assert.equal(await title.getVisibleText(), "One")
+  }
+
+  async "test frame form POST submission from submitter with data-turbo-frame=_top"() {
+    await this.clickSelector("#frame form[method=post] [type=submit][data-turbo-frame=_top]")
+    await this.nextBody
+
+    const title = await this.querySelector("h1")
+    this.assert.equal(await title.getVisibleText(), "One")
+  }
+
+  async "test frame form GET submission from submitter referencing another frame"() {
+    await this.clickSelector("#frame form[method=get] [type=submit][data-turbo-frame=hello]")
+    await this.nextBeat
+
+    const title = await this.querySelector("h1")
+    const frameTitle = await this.querySelector("#hello h2")
+    this.assert.equal(await frameTitle.getVisibleText(), "Hello from a frame")
+    this.assert.equal(await title.getVisibleText(), "Form")
+  }
+
+  async "test frame form POST submission from submitter referencing another frame"() {
+    await this.clickSelector("#frame form[method=post] [type=submit][data-turbo-frame=hello]")
+    await this.nextBeat
+
+    const title = await this.querySelector("h1")
+    const frameTitle = await this.querySelector("#hello h2")
+    this.assert.equal(await frameTitle.getVisibleText(), "Hello from a frame")
+    this.assert.equal(await title.getVisibleText(), "Form")
+  }
+
   async "test frame form submission with redirect response"() {
     const path = await this.attributeForSelector("#frame form.redirect input[name=path]", "value") || ""
     const url = new URL(path, "http://localhost:9000")


### PR DESCRIPTION
Adds support for reading the value of `data-turbo-frame` from a
`submitter` (transmitted as part of the `SubmitEvent.submitter`
property) as if it were a `<button>` element's [formtarget][] attribute.

This change comes with an added benefit of meshing with Rails'
[button_to][] helper:

```ruby
button_to "Submit to turbo-frame#frame_id",
  form: { data: { turbo_frame: "frame_id" } } # before

button_to "Submit to  turbo-frame#frame_id",
  data: { turbo_frame: "frame_id" }           # after
```

[formtarget]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLButtonElement
[button_to]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/UrlHelper.html#method-i-button_to