### PR TITLE
Support navigating a Frame to its current `src`

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -24,7 +24,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   private currentFetchRequest: FetchRequest | null = null
   private resolveVisitPromise = () => {}
   private connected = false
-  private hasBeenLoaded = false
+  private willEagerLoad = true
   private settingSourceURL = false
 
   constructor(element: FrameElement) {
@@ -40,6 +40,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
       this.connected = true
       this.reloadable = false
       if (this.loadingStyle == FrameLoadingStyle.lazy) {
+        this.willEagerLoad = false
         this.appearanceObserver.start()
       }
       this.linkInterceptor.start()
@@ -64,7 +65,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   sourceURLChanged() {
-    if (this.loadingStyle == FrameLoadingStyle.eager || this.hasBeenLoaded) {
+    if (this.loadingStyle == FrameLoadingStyle.eager || this.willEagerLoad) {
       this.loadSourceURL()
     }
   }
@@ -87,7 +88,6 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
           this.element.loaded = this.visit(this.sourceURL)
           this.appearanceObserver.stop()
           await this.element.loaded
-          this.hasBeenLoaded = true
         } catch (error) {
           this.currentURL = previousURL
           throw error
@@ -121,6 +121,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   // Appearance observer delegate
 
   elementAppearedInViewport(element: Element) {
+    this.willEagerLoad = true
     this.loadSourceURL()
   }
 

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -347,7 +347,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   set sourceURL(sourceURL: string | undefined) {
     this.settingSourceURL = true
     this.element.src = sourceURL ?? null
-    this.currentURL = this.element.src
+    this.currentURL = sourceURL
     this.settingSourceURL = false
   }
 

--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -31,7 +31,7 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
   linkClickIntercepted(element: Element, url: string) {
     const frame = this.findFrameElement(element)
     if (frame) {
-      frame.setAttribute("reloadable", "")
+      frame.delegate.currentURL = null
       frame.src = url
     }
   }
@@ -43,7 +43,6 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
   formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement) {
     const frame = this.findFrameElement(element, submitter)
     if (frame) {
-      frame.removeAttribute("reloadable")
       frame.delegate.formSubmissionIntercepted(element, submitter)
     }
   }

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -11,6 +11,7 @@ export interface FrameElementDelegate {
   formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement): void
   loadResponse(response: FetchResponse): void
   isLoading: boolean
+  currentURL: string | null
 }
 
 /**

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -9,6 +9,8 @@
   <body>
     <h1>Frames</h1>
 
+    <a id="navigates-frame" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="frame">Navigate #frame</a>
+
     <turbo-frame id="frame" data-loaded-from="/src/tests/fixtures/frames.html">
       <h2>Frames: #frame</h2>
     </turbo-frame>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -141,6 +141,16 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.ok(await this.querySelector("#recursive details:not([open])"))
   }
 
+  async "test following a link to the frame's current src refreshes the frame"() {
+    await this.clickSelector("#navigates-frame")
+
+    await this.nextEventNamed("turbo:before-fetch-response")
+
+    await this.clickSelector("#navigates-frame")
+
+    await this.nextEventNamed("turbo:before-fetch-response")
+  }
+
   async "test submitting a form that redirects to a page with a <turbo-frame recurse> which lazily loads a matching frame"() {
     await this.nextBeat
     await this.clickSelector("#recursive summary")


### PR DESCRIPTION
Rename `hasBeenLoaded` to `willEagerLoad`
===

First, rename `hasBeenLoaded` to `willEagerLoad`, and flip the default
from `false` to `true`.

Next, set the flag to `false` if the `FrameController` is initialized
with a `loading="lazy"` frame. Finally, set the flag to `true` once the
element appears in the viewport for the first time.

Support navigating a Frame to its current `src`
===

Re-opens [#248][]
Closes [#245][]

Update the `FrameController.currentURL` from within `set sourceURL()` to
ensure that `currentURL` does not still refer to the previous load's
`sourceURL`.

[#245]: https://github.com/hotwired/turbo/issues/245
[#248]: https://github.com/hotwired/turbo/pull/248

Replace `reloadable` attribute with `currentURL` property
===

Follow-up to [#263][]

As an alternative to leaking internal `FrameController` state to the DOM
as the `[reloadable]` attribute, this commit replaces those assignments
and guard clause checks with references to `currentURL` instead.

When responding to `<a>` clicks and `<form>` submissions, reset the
`<turbo-frame>` element delegates `currentURL = null`.

Adding a "public" (that is, package-internal) accessor to the
`FrameElementDelegate` feels less committal than an end-user facing
`[reloadable]` attribute, and achieves the same outcome.

[#263]: https://github.com/hotwired/turbo/pull/263