### PR TITLE
Add disable-with Behavior to Turbo

### DIFF
--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -193,5 +193,11 @@
       </div>
     </turbo-frame>
     <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="link-method-outside-frame">Stream link outside frame</a>
+    <hr>
+    <div id="disabled">
+      <form action="/__turbo/redirect" method="post" class="redirect" data-turbo-disable-with="Processing...">
+        <input type="submit">
+      </form>
+    </div>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -412,6 +412,15 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(await this.nextEventOnTarget("form_one", "turbo:before-fetch-response"))
   }
 
+  async "test form submission with disable and non-permanent form"() {
+    await this.clickSelector("#disabled form.redirect input[type=submit]")
+    const elemDisabled = await this.querySelector("#disabled form.redirect input[type=submit]")
+    this.assert.notOk(await elemDisabled.isEnabled())
+
+    await this.nextBody
+    this.assert.ok(await this.formSubmitted)
+  }
+
   get formSubmitted(): Promise<boolean> {
     return this.hasSelector("html[data-form-submitted]")
   }


### PR DESCRIPTION
Following some discussion in the GoRails Discord a while back, it looks like there's some popular sentiment that the old Rails UJS behaviors for `confirm` and `disable-with` should be rolled into Turbo. Seeing that #379 implements the `confirm` behavior, I wanted to get the ball rolling on this.

As of right now, the behavior works in the most baseline fashion possible. On a form submission, the submit tag is disabled. Unfortunately, I'm unfamiliar with Intern, so I had some trouble getting the test to work correctly. For some reason I couldn't seem to query for the button fast enough before the page changed.

Additionally, as I see it right now, there's 3 major items that still need to be addressed:

1. Getting the buttons to be un-disabled when the form is a permanent element on the page.
2. Getting the buttons to be un-disabled when the form is targeting a different Turbo frame.
3. Making sure that the buttons are not disabled when navigating using the back button after a full redirect.

I have an idea of how to handle the first two using the `FormSubmissionDelegate` interface, but I'm not sure about the 3rd. I think it involves the way history is tracked.

So if anyone can offer some insight on getting tests working and on how we'd make this work with how Turbo manages history, it'd be a huge help.