### PR TITLE
Skip form{,method}="dialog" when targetting frame

### DIFF
--- a/src/core/frames/form_interceptor.ts
+++ b/src/core/frames/form_interceptor.ts
@@ -24,7 +24,9 @@ export class FormInterceptor {
     if (event.target instanceof HTMLFormElement) {
       const form = event.target
       const submitter = event.submitter || undefined
-      if (this.delegate.shouldInterceptFormSubmission(form, submitter)) {
+      const method = submitter?.getAttribute("formmethod") || form.method
+
+      if (method != "dialog" && this.delegate.shouldInterceptFormSubmission(form, submitter)) {
         event.preventDefault()
         event.stopImmediatePropagation()
         this.delegate.formSubmissionIntercepted(form, submitter)

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -144,6 +144,20 @@
           <button formmethod="dialog">Close</button>
         </form>
       </dialog>
+
+      <dialog id="dialog-method-turbo-frame" open>
+        <form action="/__turbo/redirect" method="dialog">
+          <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+          <button>Close</button>
+        </form>
+      </dialog>
+
+      <dialog id="dialog-formmethod-turbo-frame" open>
+        <form action="/__turbo/redirect" method="post" data-turbo-frame="frame">
+          <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+          <button formmethod="dialog">Close</button>
+        </form>
+      </dialog>
     </div>
     <hr>
     <div id="targets-frame">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -418,11 +418,26 @@ export class FormSubmissionTests extends TurboDriveTestCase {
   }
 
   async "test form submission skipped with submitter formmethod=dialog"() {
+    await this.clickSelector('#dialog-formmethod-turbo-frame [formmethod="dialog"]')
+    await this.nextBeat
+
+    this.assert.notOk(await this.formSubmitted)
+  }
+
+  async "test form submission targetting frame skipped within method=dialog"() {
+    await this.clickSelector('#dialog-method-turbo-frame button')
+    await this.nextBeat
+
+    this.assert.notOk(await this.formSubmitted)
+  }
+
+  async "test form submission targetting frame skipped with submitter formmethod=dialog"() {
     await this.clickSelector('#dialog-formmethod [formmethod="dialog"]')
     await this.nextBeat
 
     this.assert.notOk(await this.formSubmitted)
   }
+
 
   async "test form submission targets disabled frame"() {
     this.remote.execute(() => document.getElementById("frame")?.setAttribute("disabled", ""))


### PR DESCRIPTION
Follow-up to https://github.com/hotwired/turbo/pull/3

---

When a `<form data-turbo-frame="...">` element is submitted, it's
handled by the `Frames/FormInterceptor` class instead of the
`FormSubmitObserver` class, which was originally fixed to cover this
behavior in [#3][].

This commit reproduces the fix so that it's consistent across `<form>`
elements, regardless of their targetting.

[#3]: https://github.com/hotwired/turbo/pull/3