### PR TITLE
Ignore nonces in tracked elements when comparing head signatures

### DIFF
--- a/src/core/drive/head_snapshot.ts
+++ b/src/core/drive/head_snapshot.ts
@@ -32,6 +32,7 @@ export class HeadSnapshot extends Snapshot<HTMLHeadElement> {
     return Object.keys(this.detailsByOuterHTML)
       .filter(outerHTML => this.detailsByOuterHTML[outerHTML].tracked)
       .join("")
+      .replace(/nonce=["']([^"']*)["']/, "nonce=\"\"")
   }
 
   getScriptElementsNotInSnapshot(snapshot: HeadSnapshot) {

--- a/src/core/drive/head_snapshot.ts
+++ b/src/core/drive/head_snapshot.ts
@@ -32,7 +32,7 @@ export class HeadSnapshot extends Snapshot<HTMLHeadElement> {
     return Object.keys(this.detailsByOuterHTML)
       .filter(outerHTML => this.detailsByOuterHTML[outerHTML].tracked)
       .join("")
-      .replace(/nonce=["']([^"']*)["']/, "nonce=\"\"")
+      .replace(/nonce=["'][^"']*["']/, "nonce=\"\"")
   }
 
   getScriptElementsNotInSnapshot(snapshot: HeadSnapshot) {

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -21,12 +21,16 @@
         }
       })
     </script>
+    <script type="importmap" nonce="123">
+      { "imports": { "turbo": "/dist/turbo.es2017-umd.js?123"} }
+    </script>
   </head>
   <body>
     <section>
       <h1>Rendering</h1>
       <p><a id="same-origin-link" href="/src/tests/fixtures/one.html">Same-origin link</a></p>
       <p><a id="tracked-asset-change-link" href="/src/tests/fixtures/tracked_asset_change.html">Tracked asset change</a></p>
+      <p><a id="tracked-nonce-tag-link" href="/src/tests/fixtures/tracked_nonce_tag.html">Tracked nonce tag</a></p>
       <p><a id="additional-assets-link" href="/src/tests/fixtures/additional_assets.html">Additional assets</a></p>
       <p><a id="head-script-link" href="/src/tests/fixtures/head_script.html">Head script</a></p>
       <p><a id="body-script-link" href="/src/tests/fixtures/body_script.html">Body script</a></p>

--- a/src/tests/fixtures/tracked_nonce_change.html
+++ b/src/tests/fixtures/tracked_nonce_change.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Tracked nonce tag</title>
+    <script src="/dist/turbo.es2017-umd.js?123" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Tracked nonce tag</h1>
+    <p><a id="tracked-nonce-tag-link" href="/src/tests/fixtures/tracked_nonce_tag.html?no=change">Tracked nonce tag</a></p>
+  </body>
+</html>

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -34,6 +34,13 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert.equal(await this.visitAction, "load")
   }
 
+  async "test wont reload when tracked elements has a nonce"() {
+    this.clickSelector("#tracked-nonce-tag-link")
+    await this.nextBody
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/tracked_nonce_tag.html")
+    this.assert.equal(await this.visitAction, "advance")
+  }
+
   async "test reloads when turbo-visit-control setting is reload"() {
     this.clickSelector("#visit-control-reload-link")
     await this.nextBody


### PR DESCRIPTION
When navigating between pages that have tracked head elements with nonces, Turbo would erroneously perform a load instead of an advance every time, because the browser hides the nonce value in the DOM, while Turbo receives the raw request with the nonce in it from the server. 

Solution is to strip the nonces from all tracked elements when comparing the head signatures.