### PR TITLE
Fix form in nested turbo-frame with target=_top

### DIFF
--- a/src/core/frames/form_interceptor.ts
+++ b/src/core/frames/form_interceptor.ts
@@ -21,8 +21,8 @@ export class FormInterceptor {
   }
 
   submitBubbled = <EventListener>((event: SubmitEvent) => {
-    if (event.target instanceof HTMLFormElement) {
-      const form = event.target
+    const form = event.target
+    if (form instanceof HTMLFormElement && form.closest("turbo-frame, html") == this.element) {
       const submitter = event.submitter || undefined
       if (this.delegate.shouldInterceptFormSubmission(form, submitter)) {
         event.preventDefault()

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -31,6 +31,12 @@
         <a href="/src/tests/fixtures/frames/frame.html">Load #nested-child</a>
         <a href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
       </turbo-frame>
+
+      <turbo-frame id="nested-child-navigate-top" target="_top">
+        <form method="get" action="/src/tests/fixtures/one.html">
+          <input id="nested-child-navigate-top-submit" type="submit" value="Nested Child form submit">
+        </form>
+      </turbo-frame>
     </turbo-frame>
 
     <turbo-frame id="navigate-top" target="_top">

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -30,6 +30,10 @@
         <h2>Frames: #nested-child</h2>
         <a href="/src/tests/fixtures/frames/frame.html">Load #nested-child</a>
         <a href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
+
+        <form method="get" action="/src/tests/fixtures/one.html" data-turbo-frame="_top">
+          <input id="nested-child-navigate-form-top-submit" type="submit" value="Nested Child form submit">
+        </form>
       </turbo-frame>
 
       <turbo-frame id="nested-child-navigate-top" target="_top">

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -75,7 +75,18 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.notOk(await this.hasSelector("#nested-child"))
   }
 
-  async "test following a form within a nested frame with target top"() {
+  async "test following a form within a nested frame with form target top"() {
+    await this.clickSelector("#nested-child-navigate-form-top-submit")
+    await this.nextBeat
+
+    const frameText = await this.querySelector("body > h1")
+    this.assert.equal(await frameText.getVisibleText(), "One")
+    this.assert.notOk(await this.hasSelector("#frame"))
+    this.assert.notOk(await this.hasSelector("#nested-root"))
+    this.assert.notOk(await this.hasSelector("#nested-child"))
+  }
+
+  async "test following a form within a nested frame with child frame target top"() {
     await this.clickSelector("#nested-child-navigate-top-submit")
     await this.nextBeat
 

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -75,6 +75,17 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.notOk(await this.hasSelector("#nested-child"))
   }
 
+  async "test following a form within a nested frame with target top"() {
+    await this.clickSelector("#nested-child-navigate-top-submit")
+    await this.nextBeat
+
+    const frameText = await this.querySelector("body > h1")
+    this.assert.equal(await frameText.getVisibleText(), "One")
+    this.assert.notOk(await this.hasSelector("#frame"))
+    this.assert.notOk(await this.hasSelector("#nested-root"))
+    this.assert.notOk(await this.hasSelector("#nested-child-navigate-top"))
+  }
+
   async "test following a link within a frame with target=_top navigates the page"() {
     this.assert.equal(await this.attributeForSelector("#navigate-top" ,"src"), null)
 


### PR DESCRIPTION
#396 

The class LinkInterceptor checks if the target is a valid Element and if the closest turbo-frame matches the current turbo-frame. 

```javascript
    class LinkInterceptor {
        constructor(delegate, element) {
          //...
          if (this.respondsToEventTarget(event.target)) 

          respondsToEventTarget(target) {
              const element = target instanceof Element
                  ? target
                  : target instanceof Node
                      ? target.parentElement
                      : null;
              return element && element.closest("turbo-frame, html") == this.element;
          }
```

The FormInterceptor checks if the target is a HTMLFormElement, but does not check if the closest turbo-frame matches the current turbo-frame.

```javascript
    class FormInterceptor {
        constructor(delegate, element) {
            //...
                if (event.target instanceof HTMLFormElement) {
```

As a result, a nested turbo-frame will bubble up to the parent turbo-frame when the turbo-frame is not disabled or the target == "_top".  The parent turbo-frame should not be handling form events nested in a child turbo-frame.