### PR TITLE
Expand the FrameElementDelegate interface

### DIFF
--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -24,41 +24,35 @@ export class FrameRedirector implements LinkInterceptorDelegate, FormInterceptor
   }
 
   shouldInterceptLinkClick(element: Element, url: string) {
-    return this.shouldRedirect(element)
+    const frame = this.findFrameElement(element)
+
+    return !!frame && frame.delegate.shouldInterceptLinkClick(element, url)
   }
 
   linkClickIntercepted(element: Element, url: string) {
     const frame = this.findFrameElement(element)
     if (frame) {
-      frame.setAttribute("reloadable", "")
-      frame.src = url
+      frame.delegate.linkClickIntercepted(element, url)
     }
   }
 
   shouldInterceptFormSubmission(element: HTMLFormElement, submitter?: HTMLElement) {
-    return this.shouldRedirect(element, submitter)
+    const frame = this.findFrameElement(element, submitter)
+
+    return !!frame && frame.delegate.shouldInterceptFormSubmission(element, submitter)
   }
 
   formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement) {
     const frame = this.findFrameElement(element, submitter)
     if (frame) {
-      frame.removeAttribute("reloadable")
       frame.delegate.formSubmissionIntercepted(element, submitter)
     }
-  }
-
-  private shouldRedirect(element: Element, submitter?: HTMLElement) {
-    const frame = this.findFrameElement(element, submitter)
-    return frame ? frame != element.closest("turbo-frame") : false
   }
 
   private findFrameElement(element: Element, submitter?: HTMLElement) {
     const id = submitter?.getAttribute("data-turbo-frame") || element.getAttribute("data-turbo-frame")
     if (id && id != "_top") {
-      const frame = this.element.querySelector(`#${id}:not([disabled])`)
-      if (frame instanceof FrameElement) {
-        return frame
-      }
+      return this.element.querySelector<FrameElement>(`turbo-frame#${id}:not([disabled])`)
     }
   }
 }

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -1,14 +1,15 @@
 import { FetchResponse } from "../http/fetch_response"
+import { FormInterceptorDelegate } from "../core/frames/form_interceptor"
+import { LinkInterceptorDelegate } from "../core/frames/link_interceptor"
 
 export enum FrameLoadingStyle { eager = "eager", lazy = "lazy" }
 
-export interface FrameElementDelegate {
+export interface FrameElementDelegate extends LinkInterceptorDelegate, FormInterceptorDelegate {
   connect(): void
   disconnect(): void
   loadingStyleChanged(): void
   sourceURLChanged(): void
   disabledChanged(): void
-  formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement): void
   loadResponse(response: FetchResponse): void
   isLoading: boolean
 }


### PR DESCRIPTION
Expand the `FrameElementDelegate` to extend from both
`FormInterceptorDelegate` and `LinkInterceptorDelegate`.

After that change, replace conditionals in the `FrameRedirector` with
calls to the `FrameElement` instance's delegate when one is found.

This reduces the surface area for duplicate logic and improves
guarantees of consistency across semantically similar situations.