### PR TITLE
Target must be in the document.body to be the event emitter

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -4,9 +4,9 @@ export function dispatch(eventName: string, { target, cancelable, detail }: Part
   const event = new CustomEvent(eventName, { cancelable, bubbles: true, detail })
 
   if (target && document.body.contains(target as Element)) {
-    void target.dispatchEvent(event);
+    target.dispatchEvent(event);
   } else {
-    void document.documentElement.dispatchEvent(event);
+    document.documentElement.dispatchEvent(event);
   }
 
   return event

--- a/src/util.ts
+++ b/src/util.ts
@@ -2,7 +2,13 @@ export type DispatchOptions = { target: EventTarget, cancelable: boolean, detail
 
 export function dispatch(eventName: string, { target, cancelable, detail }: Partial<DispatchOptions> = {}) {
   const event = new CustomEvent(eventName, { cancelable, bubbles: true, detail })
-  void (target || document.documentElement).dispatchEvent(event)
+
+  if (target && document.body.contains(target as Element)) {
+    void target.dispatchEvent(event);
+  } else {
+    void document.documentElement.dispatchEvent(event);
+  }
+
   return event
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -3,7 +3,7 @@ export type DispatchOptions = { target: EventTarget, cancelable: boolean, detail
 export function dispatch(eventName: string, { target, cancelable, detail }: Partial<DispatchOptions> = {}) {
   const event = new CustomEvent(eventName, { cancelable, bubbles: true, detail })
 
-  if (target && document.body.contains(target as Element)) {
+  if (target && (target as Element).isConnected) {
     target.dispatchEvent(event);
   } else {
     document.documentElement.dispatchEvent(event);


### PR DESCRIPTION
It's possible for this not to be true if the target element has been removed from the dom between when a form submission was made and the response is processed. This can happen as a race condition when the same turbo stream removal is triggered by both websocket and server response.