### PR TITLE
Update SubmitEvent Polyfill to Workaround Safari 15 bug

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -9,4 +9,5 @@ interface Node {
 
 interface Window {
   Turbo: typeof import("./core/index")
+  SubmitEvent: typeof Event
 }

--- a/src/polyfills/submit-event.ts
+++ b/src/polyfills/submit-event.ts
@@ -17,12 +17,23 @@ function clickCaptured(event: Event) {
 }
 
 (function() {
-  if ("SubmitEvent" in window) return
   if ("submitter" in Event.prototype) return
+
+  let prototype;
+  // Certain versions of Safari 15 have a bug where they won't
+  // populate the submitter. This hurts TurboDrive's enable/disable detection.
+  // See https://bugs.webkit.org/show_bug.cgi?id=229660
+  if ("SubmitEvent" in window && /Apple Computer/.test(navigator.vendor)) {
+    prototype = window.SubmitEvent.prototype;
+  } else if ("SubmitEvent" in window) {
+    return; // polyfill not needed
+  } else {
+    prototype = window.Event.prototype;
+  }
 
   addEventListener("click", clickCaptured, true)
 
-  Object.defineProperty(Event.prototype, "submitter", {
+  Object.defineProperty(prototype, "submitter", {
     get(): HTMLElement | undefined {
       if (this.type == "submit" && this.target instanceof HTMLFormElement) {
         return submittersByForm.get(this.target)


### PR DESCRIPTION
Fixes #390 

This PR updates the Polyfill to work around the Safari 15 bug where the submitter property is sometimes null when a form is submitted with element of type button vs an element of type submit. More info https://bugs.webkit.org/show_bug.cgi?id=229660