### PR TITLE
Allow Drive to submit a form when spot-enabled but submitter is null 

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -189,7 +189,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   // Form submit observer delegate
 
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {
-    return this.elementDriveEnabled(form) && this.elementDriveEnabled(submitter)
+    return this.elementDriveEnabled(form) && (!submitter || this.elementDriveEnabled(submitter))
   }
 
   formSubmitted(form: HTMLFormElement, submitter?: HTMLElement) {

--- a/src/tests/fixtures/drive_disabled.html
+++ b/src/tests/fixtures/drive_disabled.html
@@ -5,6 +5,19 @@
     <title>Drive (Disabled by Default)</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
+    <script type="module">
+      addEventListener("click", event => {
+        if (event.target.id == "requestSubmit") {
+          event.preventDefault()
+          const form = event.target.closest('form')
+          if(typeof form.requestSubmit === "function"){
+            form.requestSubmit()
+          } else {
+            form.submit()
+          }
+        }
+      })
+    </script>
     <script>
       Turbo.session.drive = false
     </script>
@@ -19,5 +32,11 @@
     <div>
       <a id="drive_disabled" href="/src/tests/fixtures/drive_disabled.html">Drive disabled link</a>
     </div>
+
+    <form action="/__turbo/redirect" method="post" id="no_submitter_drive_enabled" data-turbo="true">
+      <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
+      <input type="hidden" name="greeting" value="Hello from a redirect">
+      <a href="#" id="requestSubmit">Drive enabled submit via JS</a>
+    </form>
   </body>
 </html>

--- a/src/tests/functional/drive_disabled_tests.ts
+++ b/src/tests/functional/drive_disabled_tests.ts
@@ -20,6 +20,22 @@ export class DriveDisabledTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, this.path)
     this.assert.equal(await this.visitAction, "advance")
   }
+
+  async "test drive disabled by default; submit form inside data-turbo='true'"() {
+    await this.remote.execute(() => {
+      addEventListener("turbo:submit-start", () => document.documentElement.setAttribute("data-form-submitted", ""), { once: true })
+    })
+    this.clickSelector("#no_submitter_drive_enabled a#requestSubmit")
+    await this.nextBody
+    this.assert.ok(await this.formSubmitted)
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
+    this.assert.equal(await this.visitAction, "advance")
+    this.assert.equal(await this.getSearchParam("greeting"), "Hello from a redirect")
+  }
+
+  get formSubmitted(): Promise<boolean> {
+    return this.hasSelector("html[data-form-submitted]")
+  }
 }
 
 


### PR DESCRIPTION
Fixes #392 

When you disable Turbo Drive wholesale with `Turbo.session.drive = false` and spot enable it on a form without a submit button with `data-turbo=true` Turbo Drive still wouldn't fire because it couldn't verify that the submitter (which was null) had a container where turbo was enabled.

This pulls in the fix @willcosgrove recommends as it's wise to never assume the DOM placement and logic for a submitter that is null. 