### PR TITLE
Read `[data-turbo-action]` during Form Submissions

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -92,8 +92,9 @@ export class Navigator {
           this.view.clearSnapshotCache()
         }
 
+        const action = this.getActionForFormSubmission(formSubmission)
         const { statusCode } = fetchResponse
-        const visitOptions = { response: { statusCode, responseHTML } }
+        const visitOptions = { action, response: { statusCode, responseHTML } }
         this.proposeVisit(fetchResponse.location, visitOptions)
       }
     }

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -35,8 +35,8 @@
       <p><a id="same-origin-unannotated-link" href="/src/tests/fixtures/one.html">Same-origin unannotated link</a></p>
       <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button>Same-origin unannotated form</button></form></p>
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>
-      <p><form id="same-origin-replace-form" method="get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>
-      <p><form id="same-origin-replace-form-submitter" method="get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin data-turbo-action=replace form</button></form></p>
+      <p><form id="same-origin-replace-form-get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>
+      <p><form id="same-origin-replace-form-submitter-get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin data-turbo-action=replace form</button></form></p>
       <p><a id="same-origin-false-link" href="/src/tests/fixtures/one.html" data-turbo="false">Same-origin data-turbo=false link</a></p>
       <p data-turbo="false"><a id="same-origin-unannotated-link-inside-false-container" href="/src/tests/fixtures/one.html">Same-origin unannotated link inside data-turbo=false container</a></p>
       <p data-turbo="false"><a id="same-origin-true-link-inside-false-container" href="/src/tests/fixtures/one.html" data-turbo="true">Same-origin data-turbo=true link inside data-turbo=false container</a></p>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -37,6 +37,14 @@
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>
       <p><form id="same-origin-replace-form-get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>
       <p><form id="same-origin-replace-form-submitter-get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin data-turbo-action=replace form</button></form></p>
+      <form id="same-origin-replace-form-post" method="post" action="/__turbo/redirect" data-turbo-action="replace">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <button>Same-origin form[method="post"][data-turbo-action="replace"]</button>
+      </form>
+      <form id="same-origin-replace-form-submitter-post" method="post" action="/__turbo/redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <button data-turbo-action="replace">Same-origin form[method="post"] button[data-turbo-action="replace"]</button>
+      </form>
       <p><a id="same-origin-false-link" href="/src/tests/fixtures/one.html" data-turbo="false">Same-origin data-turbo=false link</a></p>
       <p data-turbo="false"><a id="same-origin-unannotated-link-inside-false-container" href="/src/tests/fixtures/one.html">Same-origin unannotated link inside data-turbo=false container</a></p>
       <p data-turbo="false"><a id="same-origin-true-link-inside-false-container" href="/src/tests/fixtures/one.html" data-turbo="true">Same-origin data-turbo=true link inside data-turbo=false container</a></p>

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -77,6 +77,22 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.equal(await this.visitAction, "replace")
   }
 
+  async "test following a same-origin POST form[data-turbo-action=replace]"() {
+    this.clickSelector("#same-origin-replace-form-post button")
+    await this.nextBody
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+    this.assert.equal(await this.visitAction, "replace")
+  }
+
+  async "test following a same-origin POST form button[data-turbo-action=replace]"() {
+    this.clickSelector("#same-origin-replace-form-submitter-post button")
+    await this.nextBody
+
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
+    this.assert.equal(await this.visitAction, "replace")
+  }
+
   async "test following a same-origin data-turbo=false link"() {
     this.clickSelector("#same-origin-false-link")
     await this.nextBody

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -63,15 +63,15 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.equal(await this.visitAction, "replace")
   }
 
-  async "test following a same-origin data-turbo-action=replace form[method=GET]"() {
-    this.clickSelector("#same-origin-replace-form button")
+  async "test following a same-origin GET form[data-turbo-action=replace]"() {
+    this.clickSelector("#same-origin-replace-form-get button")
     await this.nextBody
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
     this.assert.equal(await this.visitAction, "replace")
   }
 
-  async "test following a same-origin form with button[data-turbo-action=replace]"() {
-    this.clickSelector("#same-origin-replace-form-submitter button")
+  async "test following a same-origin GET form button[data-turbo-action=replace]"() {
+    this.clickSelector("#same-origin-replace-form-submitter-get button")
     await this.nextBody
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
     this.assert.equal(await this.visitAction, "replace")


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo-ios/issues/44
Follow-up to https://github.com/hotwired/turbo/pull/231

---

This commit follows-up [#231][], which added `[data-turbo-action]`
support for idempotent form submissions to maintain parity with
`<a>`-initiated Visits.

These changes re-use the existent `Navigator.getActionForFormSubmission`
function to determine the value for the `VisitOptions.action` options.

[#231]: https://github.com/hotwired/turbo/pull/231