### PR TITLE
fix: allow programmatic visits to go cross-origin

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -2,7 +2,7 @@ import { Action, isAction } from "../types"
 import { FetchMethod } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { FormSubmission } from "./form_submission"
-import { expandURL, getAnchor, getRequestURL, Locatable, isPrefixedBy, isHTML } from "../url"
+import { expandURL, getAnchor, getRequestURL, Locatable, locationIsVisitable } from "../url"
 import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
@@ -23,7 +23,7 @@ export class Navigator {
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
     if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
-      if (isPrefixedBy(location, this.view.snapshot.rootLocation) && isHTML(location)) {
+      if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
         this.delegate.visitProposedToLocation(location, options)
       } else {
         window.location.href = location.toString()

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -2,7 +2,7 @@ import { Action, isAction } from "../types"
 import { FetchMethod } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { FormSubmission } from "./form_submission"
-import { expandURL, getAnchor, getRequestURL, Locatable } from "../url"
+import { expandURL, getAnchor, getRequestURL, Locatable, isPrefixedBy, isHTML } from "../url"
 import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
@@ -23,7 +23,11 @@ export class Navigator {
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
     if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
-      this.delegate.visitProposedToLocation(location, options)
+      if (isPrefixedBy(location, this.view.snapshot.rootLocation) && isHTML(location)) {
+        this.delegate.visitProposedToLocation(location, options)
+      } else {
+        window.location.href = location.toString()
+      }
     }
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -130,7 +130,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
 
   willFollowLinkToLocation(link: Element, location: URL) {
     return this.elementDriveEnabled(link)
-      && this.locationIsVisitable(location, this.snapshot.rootLocation)
+      && locationIsVisitable(location, this.snapshot.rootLocation)
       && this.applicationAllowsFollowingLinkToLocation(link, location)
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -5,7 +5,7 @@ import { FormSubmitObserver, FormSubmitObserverDelegate } from "../observers/for
 import { FrameRedirector } from "./frames/frame_redirector"
 import { History, HistoryDelegate } from "./drive/history"
 import { LinkClickObserver, LinkClickObserverDelegate } from "../observers/link_click_observer"
-import { expandURL, isPrefixedBy, isHTML, Locatable } from "./url"
+import { expandURL, locationIsVisitable, Locatable } from "./url"
 import { Navigator, NavigatorDelegate } from "./drive/navigator"
 import { PageObserver, PageObserverDelegate } from "../observers/page_observer"
 import { ScrollObserver } from "../observers/scroll_observer"
@@ -130,7 +130,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
 
   willFollowLinkToLocation(link: Element, location: URL) {
     return this.elementDriveEnabled(link)
-      && this.locationIsVisitable(location)
+      && this.locationIsVisitable(location, this.snapshot.rootLocation)
       && this.applicationAllowsFollowingLinkToLocation(link, location)
   }
 
@@ -329,10 +329,6 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   getActionForLink(link: Element): Action {
     const action = link.getAttribute("data-turbo-action")
     return isAction(action) ? action : "advance"
-  }
-
-  locationIsVisitable(location: URL) {
-    return isPrefixedBy(location, this.snapshot.rootLocation) && isHTML(location)
   }
 
   get snapshot() {

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -26,6 +26,10 @@ export function isPrefixedBy(baseURL: URL, url: URL) {
   return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
 }
 
+export function locationIsVisitable(location: URL, rootLocation: string) {
+  return isPrefixedBy(location, rootLocation) && isHTML(location)
+}
+
 export function getRequestURL(url: URL) {
   const anchor = getAnchor(url)
   return anchor != null

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -26,7 +26,7 @@ export function isPrefixedBy(baseURL: URL, url: URL) {
   return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
 }
 
-export function locationIsVisitable(location: URL, rootLocation: string) {
+export function locationIsVisitable(location: URL, rootLocation: URL) {
   return isPrefixedBy(location, rootLocation) && isHTML(location)
 }
 

--- a/src/tests/fixtures/drive.html
+++ b/src/tests/fixtures/drive.html
@@ -11,6 +11,7 @@
 
     <div>
       <a id="drive_enabled" href="/src/tests/fixtures/drive.html">Drive enabled link</a>
+      <a id="drive_enabled_external" href="https://example.com">Drive enabled external link</a>
     </div>
 
     <div data-turbo="false">

--- a/src/tests/functional/drive_tests.ts
+++ b/src/tests/functional/drive_tests.ts
@@ -14,6 +14,14 @@ export class DriveTests extends TurboDriveTestCase {
     this.assert.equal(await this.visitAction, "advance")
   }
 
+  async "test drive to external link"() {
+    this.clickSelector("#drive_enabled_external")
+    await this.nextBody
+    this.assert.equal(
+      await this.remote.execute(() => window.location.href), "https://example.com/"
+    )
+  }
+
   async "test drive enabled by default; click link inside data-turbo='false'"() {
     this.clickSelector("#drive_disabled")
     await this.nextBody


### PR DESCRIPTION
Currently, when calling `Turbo.visit("https://example.com", { action: "advance" })` , the site will not navigate to the `https://example.com` and in addition a number of errors pop up here:

<img width="978" alt="Screen Shot 2021-09-27 at 6 04 09 PM" src="https://user-images.githubusercontent.com/26425882/135015762-c8b2d180-40be-40ce-b604-525588afb9fe.png">

Most of these errors have to do with trying to fetch cross-origin as well as adding history for a cross-origin url. This PR takes previous art from Turbolinks here:

https://github.com/turbolinks/turbolinks/blob/80cd172ed5b3a35eda85c58e428de9f1f1d06fc8/src/controller.ts#L70-L80

and uses previous art from Turbo's own link delegator here:

https://github.com/hotwired/turbo/blob/5982a679f19f9c745c51e85885e99069cf3d0c4a/src/core/session.ts#L334-L336

Unfortunately, I ran into multiple issues trying to get tests for this due to my chromedriver only supporting up to v92 and chrome itself being v94. I tried manually installing and upgrading both and was unsuccessful. Regardless, I think drawing on prior art and having done some manual testing as well, all appears to be well.

### Video Before:

https://user-images.githubusercontent.com/26425882/135016268-da859358-d0ce-4b75-aa54-e74b3aa3345f.mov

### Video After:

https://user-images.githubusercontent.com/26425882/135016032-0d5be5d0-be6f-455e-80a6-a0b70e9142ae.mov