### PR TITLE
Expose FormSubmission and FetchRequest

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -4,12 +4,13 @@ import { Locatable } from "./url"
 import { StreamMessage } from "./streams/stream_message"
 import { StreamSource } from "./types"
 import { VisitOptions } from "./drive/visit"
+import { FormSubmission } from "./drive/form_submission"
 import { PageRenderer } from "./drive/page_renderer"
 import { PageSnapshot } from "./drive/page_snapshot"
 
 const session = new Session
 const { navigator } = session
-export { navigator, session, PageRenderer, PageSnapshot }
+export { navigator, session, PageRenderer, PageSnapshot, FormSubmission }
 
 /**
  * Starts the main session.

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ window.Turbo = Turbo
 Turbo.start()
 
 export * from "./core"
+export { FetchRequest } from "./http/fetch_request"


### PR DESCRIPTION
I'm working to add Hotwire support for [Shoelace](https://shoelace.style/), a Web Component-based design system. One challenge wth integrating custom elements is that the normal `<form>` tag fires a `submit` event with all the form controls automatically captured while form inputs in a shadow DOM would be excluded from it.

Thankfully, both Hotwire and Shoelace are built in a very standardized way, and I was able to get them working well with these classes exposed in Hotwire. It would be great if these two constants could be exposed for reusability.