### PR TITLE
Fire `turbo:click` event when submitting `<form method="get">`

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -40,15 +40,10 @@ export class Navigator {
     this.currentVisit.start()
   }
 
-  submitForm(form: HTMLFormElement, submitter?: HTMLElement) {
+  submitForm(formSubmission: FormSubmission) {
     this.stop()
-    this.formSubmission = new FormSubmission(this, form, submitter, true)
-
-    if (this.formSubmission.isIdempotent) {
-      this.proposeVisit(this.formSubmission.fetchRequest.url, { action: this.getActionForFormSubmission(this.formSubmission) })
-    } else {
-      this.formSubmission.start()
-    }
+    this.formSubmission = formSubmission
+    this.formSubmission.start()
   }
 
   stop() {

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -33,10 +33,11 @@
     <section id="main" style="height: 200vh">
       <h1>Navigation</h1>
       <p><a id="same-origin-unannotated-link" href="/src/tests/fixtures/one.html">Same-origin unannotated link</a></p>
-      <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button>Same-origin unannotated form</button></form></p>
+      <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button id="same-origin-unannotated-submitter">Same-origin unannotated form</button></form></p>
+      <p><form id="same-origin-unannotated-form-no-action"><button id="same-origin-submitter-formaction" formaction="/src/tests/fixtures/one.html">Same-origin unannotated form formaction</button></form></p>
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>
-      <p><form id="same-origin-replace-form" method="get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>
-      <p><form id="same-origin-replace-form-submitter" method="get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin data-turbo-action=replace form</button></form></p>
+      <p><form id="same-origin-replace-form" method="get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin form[data-turbo-action=replace]</button></form></p>
+      <p><form id="same-origin-replace-form-submitter" method="get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin form button[data-turbo-action=replace]</button></form></p>
       <p><a id="same-origin-false-link" href="/src/tests/fixtures/one.html" data-turbo="false">Same-origin data-turbo=false link</a></p>
       <p data-turbo="false"><a id="same-origin-unannotated-link-inside-false-container" href="/src/tests/fixtures/one.html">Same-origin unannotated link inside data-turbo=false container</a></p>
       <p data-turbo="false"><a id="same-origin-true-link-inside-false-container" href="/src/tests/fixtures/one.html" data-turbo="true">Same-origin data-turbo=true link inside data-turbo=false container</a></p>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -19,6 +19,7 @@
      }
    }).observe(document, { subtree: true, childList: true, attributes: true })
 })([
+  "turbo:click",
   "turbo:before-cache",
   "turbo:before-render",
   "turbo:before-visit",

--- a/src/tests/helpers/functional_test_case.ts
+++ b/src/tests/helpers/functional_test_case.ts
@@ -121,8 +121,16 @@ export class FunctionalTestCase extends InternTestCase {
     return await this.remote.execute(callback, args)
   }
 
+  async expandURL(pathname: string | null | undefined) {
+    return await this.evaluate((pathname) => new URL(pathname || "", document.baseURI), [pathname])
+  }
+
   get head(): Promise<Element> {
     return this.evaluate(() => document.head as any)
+  }
+
+  get url(): Promise<URL> {
+    return this.evaluate(() => new URL(location.href))
   }
 
   get body(): Promise<Element> {

--- a/src/tests/helpers/turbo_drive_test_case.ts
+++ b/src/tests/helpers/turbo_drive_test_case.ts
@@ -26,6 +26,14 @@ export class TurboDriveTestCase extends FunctionalTestCase {
     })()
   }
 
+  async nextEvent(): Promise<EventLog> {
+    let record: EventLog | undefined
+    while (!record) {
+      [ record ] = await this.eventLogChannel.read(1)
+    }
+    return record
+  }
+
   async nextEventNamed(eventName: string): Promise<any> {
     let record: EventLog | undefined
     while (!record) {


### PR DESCRIPTION
Prior to this change, navigating a page via an `<a>` element and
navigating a page via a `<form method="get">` element both resulted in
`turbo:visit` events.

However, clicking an `<a>` fired a `turbo:click` event, whereas
submitting a `<form method="get">` by clicking its `<input
type="submit">` or `<button>` element _did not_ fire the click for the
submitter.

This commit adds support for firing `turbo:click` events for a
`<form method="get">` element's submitter.