### PR TITLE
Persisting the snapshots

### DIFF
--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -27,6 +27,10 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
     return new PageSnapshot(this.element.cloneNode(true), this.headSnapshot)
   }
 
+  toString() {
+    return this.element.outerHTML
+  }
+
   get headElement() {
     return this.headSnapshot.element
   }

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -1,51 +1,60 @@
 export class Snapshot<E extends Element = Element> {
-  readonly element: E
+  readonly element: E;
 
   constructor(element: E) {
-    this.element = element
+    this.element = element;
   }
 
   get children() {
-    return [ ...this.element.children ]
+    return [...this.element.children];
   }
 
   hasAnchor(anchor: string | undefined) {
-    return this.getElementForAnchor(anchor) != null
+    return this.getElementForAnchor(anchor) != null;
   }
 
   getElementForAnchor(anchor: string | undefined) {
-    return anchor ? this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`) : null
+    return anchor
+      ? this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`)
+      : null;
   }
 
   get isConnected() {
-    return this.element.isConnected
+    return this.element.isConnected;
   }
 
   get firstAutofocusableElement() {
-    return this.element.querySelector("[autofocus]")
+    return this.element.querySelector("[autofocus]");
   }
 
   get permanentElements() {
-    return [ ...this.element.querySelectorAll("[id][data-turbo-permanent]") ]
+    return [...this.element.querySelectorAll("[id][data-turbo-permanent]")];
   }
 
   getPermanentElementById(id: string) {
-    return this.element.querySelector(`#${id}[data-turbo-permanent]`)
+    return this.element.querySelector(`#${id}[data-turbo-permanent]`);
   }
 
   getPermanentElementMapForSnapshot(snapshot: Snapshot) {
-    const permanentElementMap: PermanentElementMap = {}
+    const permanentElementMap: PermanentElementMap = {};
 
     for (const currentPermanentElement of this.permanentElements) {
-      const { id } = currentPermanentElement
-      const newPermanentElement = snapshot.getPermanentElementById(id)
+      const { id } = currentPermanentElement;
+      const newPermanentElement = snapshot.getPermanentElementById(id);
       if (newPermanentElement) {
-        permanentElementMap[id] = [ currentPermanentElement, newPermanentElement ]
+        permanentElementMap[id] = [
+          currentPermanentElement,
+          newPermanentElement,
+        ];
       }
     }
 
-    return permanentElementMap
+    return permanentElementMap;
+  }
+
+  toString() {
+    return this.element.outerHTML;
   }
 }
 
-export type PermanentElementMap = Record<string, [Element, Element]>
+export type PermanentElementMap = Record<string, [Element, Element]>;


### PR DESCRIPTION
Persisting the snapshots opens up the following use cases:
- Offline browsing
- Faster page loads across browser or mobile app sessions

However, I am not sure about the best way to design this and how well can this perform.

- Should we use indexeddb with websql and localStorage fallbacks? `localForage` library is the standard for this behaviour, but that adds a dependency
- Is it better to expose some sort of `persist` and `hydrate` callbacks so that the actual persistence doesn't have to be part of the library?