### PR TITLE
`GET` Forms: fire `submit-start` and `submit-end`

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -44,11 +44,7 @@ export class Navigator {
     this.stop()
     this.formSubmission = new FormSubmission(this, form, submitter, true)
 
-    if (this.formSubmission.isIdempotent) {
-      this.proposeVisit(this.formSubmission.fetchRequest.url, { action: this.getActionForFormSubmission(this.formSubmission) })
-    } else {
-      this.formSubmission.start()
-    }
+    this.formSubmission.start()
   }
 
   stop() {
@@ -92,8 +88,9 @@ export class Navigator {
           this.view.clearSnapshotCache()
         }
 
-        const { statusCode } = fetchResponse
-        const visitOptions = { response: { statusCode, responseHTML } }
+        const { statusCode, redirected } = fetchResponse
+        const action = this.getActionForFormSubmission(formSubmission)
+        const visitOptions = { action, response: { statusCode, responseHTML, redirected } }
         this.proposeVisit(fetchResponse.location, visitOptions)
       }
     }

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -152,13 +152,9 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
 
     this.reloadable = false
     this.formSubmission = new FormSubmission(this, element, submitter)
-    if (this.formSubmission.fetchRequest.isIdempotent) {
-      this.navigateFrame(element, this.formSubmission.fetchRequest.url.href, submitter)
-    } else {
-      const { fetchRequest } = this.formSubmission
-      this.prepareHeadersForRequest(fetchRequest.headers, fetchRequest)
-      this.formSubmission.start()
-    }
+    const { fetchRequest } = this.formSubmission
+    this.prepareHeadersForRequest(fetchRequest.headers, fetchRequest)
+    this.formSubmission.start()
   }
 
   // Fetch request delegate

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -36,7 +36,7 @@ export class FormSubmitObserver {
       const submitter = event.submitter || undefined
 
       if (form) {
-        const method = submitter?.getAttribute("formmethod") || form.method
+        const method = submitter?.getAttribute("formmethod") || form.getAttribute("method")
 
         if (method != "dialog" && this.delegate.willSubmitForm(form, submitter)) {
           event.preventDefault()

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -18,7 +18,12 @@
       <form action="/__turbo/redirect" method="post" class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
         <input type="hidden" name="greeting" value="Hello from a redirect">
-        <input type="submit">
+        <input id="standard-post-form-submit" type="submit" value="form[method=post]">
+      </form>
+      <form action="/__turbo/redirect" method="get" class="redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
+        <input type="hidden" name="greeting" value="Hello from a redirect">
+        <input id="standard-get-form-submit" type="submit" value="form[method=get]">
       </form>
       <form action="/__turbo/messages" method="post" class="created">
         <input type="hidden" name="content" value="Hello!">
@@ -153,6 +158,16 @@
       <form id="form_one" action="/__turbo/redirect" method="post" data-turbo-frame="frame" class="one">
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
         <button type="submit">Submit</button>
+      </form>
+
+      <form action="/__turbo/redirect" method="post" data-turbo-frame="frame">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+        <button id="targets-frame-post-form-submit" type="submit">targets-frame form[method=post]</button>
+      </form>
+
+      <form action="/__turbo/redirect" method="get" data-turbo-frame="frame">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+        <button id="targets-frame-get-form-submit" type="submit">targets-frame form[method=get]</button>
       </form>
 
       <form action="/__turbo/redirect" method="post" data-turbo-frame="frame" class="frame">


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/pull/421
Closes https://github.com/hotwired/turbo/issues/122

---

Fire the same sequence of events for  `<form method="get">` submissions
as for `<form method="post">` submissions.

The [FormSubmission.prepareHeadersForRequest][] already accounts for
`[method="get"]` forms by omitting the `Accept:` header with the custom
`turbo-stream` MIME type.

Visit actions
---

Prior to this change, a `<form method="get">` would _always_ result in
two Visits: the first with `{ action: "advance" }`, then a second with
`{ action: "replace" }`.

Since the response to a `<form method="get">` has the potential to be a
[200 OK][] or a [201 Created][], this commit also modifies the `Visit`
class to skip the `followRedirect()` call when the request is idempotent
and the response is not a redirect.

Test changes
---

The `eventLogs` mechanisms we have in place declared in
`src/tests/fixutres/test.js` cannot properly serialize `Element`
instances, so adding `turbo:submit-start` and `turbo:submit-end`
listeners to serialize events for our test suite isn't possible in the
current configuration. To that end, this commit adds assertions for
`<form>` submit event sequences for all events except those two. In
their place, the suite adds listeners to set `[data-form-submit-start]`
and `[data-form-submit-end]` to the `<html>` element when they fire.

[FormSubmission.prepareHeadersForRequest]: https://github.com/hotwired/turbo/blob/58d2261274533a80a2c5efda7da211b3f20efcbb/src/core/drive/form_submission.ts#L136-L144
[200 OK]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/200
[201 Created]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/201
