### PR TITLE
Fire `turbo:frame-load` event during form submission

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -88,7 +88,6 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
           this.appearanceObserver.stop()
           await this.element.loaded
           this.hasBeenLoaded = true
-          session.frameLoaded(this.element)
         } catch (error) {
           this.currentURL = previousURL
           throw error
@@ -110,7 +109,8 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
         const renderer = new FrameRenderer(this.view.snapshot, snapshot, false)
         if (this.view.renderPromise) await this.view.renderPromise
         await this.view.render(renderer)
-        session.frameRendered(fetchResponse, this.element);
+        session.frameRendered(fetchResponse, this.element)
+        session.frameLoaded(this.element)
       }
     } catch (error) {
       console.error(error)

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -339,6 +339,10 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(await this.formSubmitEnded, "fires turbo:submit-end")
 
     await this.nextEventNamed("turbo:frame-render")
+    await this.nextEventNamed("turbo:frame-load")
+
+    const otherEvents = await this.eventLogChannel.read()
+    this.assert.equal(otherEvents.length, 0, "no more events")
   }
 
   async "test frame GET form targetting frame submission"() {
@@ -356,6 +360,10 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(await this.formSubmitEnded, "fires turbo:submit-end")
 
     await this.nextEventNamed("turbo:frame-render")
+    await this.nextEventNamed("turbo:frame-load")
+
+    const otherEvents = await this.eventLogChannel.read()
+    this.assert.equal(otherEvents.length, 0, "no more events")
   }
 
   async "test frame form GET submission from submitter referencing another frame"() {
@@ -444,7 +452,16 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
   async "test invalid frame form submission with unprocessable entity status"() {
     await this.clickSelector("#frame form.unprocessable_entity input[type=submit]")
-    await this.nextBeat
+
+    this.assert.ok(await this.formSubmitStarted, "fires turbo:submit-start")
+    await this.nextEventNamed("turbo:before-fetch-request")
+    await this.nextEventNamed("turbo:before-fetch-response")
+    this.assert.ok(await this.formSubmitEnded, "fires turbo:submit-end")
+    await this.nextEventNamed("turbo:frame-render")
+    await this.nextEventNamed("turbo:frame-load")
+
+    const otherEvents = await this.eventLogChannel.read()
+    this.assert.equal(otherEvents.length, 0, "no more events")
 
     const title = await this.querySelector("#frame h2")
     this.assert.ok(await this.hasSelector("#reject form"), "only replaces frame")
@@ -453,7 +470,16 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
   async "test invalid frame form submission with internal server errror status"() {
     await this.clickSelector("#frame form.internal_server_error input[type=submit]")
-    await this.nextBeat
+
+    this.assert.ok(await this.formSubmitStarted, "fires turbo:submit-start")
+    await this.nextEventNamed("turbo:before-fetch-request")
+    await this.nextEventNamed("turbo:before-fetch-response")
+    this.assert.ok(await this.formSubmitEnded, "fires turbo:submit-end")
+    await this.nextEventNamed("turbo:frame-render")
+    await this.nextEventNamed("turbo:frame-load")
+
+    const otherEvents = await this.eventLogChannel.read()
+    this.assert.equal(otherEvents.length, 0, "no more events")
 
     const title = await this.querySelector("#frame h2")
     this.assert.ok(await this.hasSelector("#reject form"), "only replaces frame")

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -19,6 +19,7 @@ export class FrameTests extends TurboDriveTestCase {
   async "test a frame whose src references itself does not infinitely loop"() {
     await this.clickSelector("#frame-self")
 
+    await this.nextEventOnTarget("frame", "turbo:frame-render")
     await this.nextEventOnTarget("frame", "turbo:frame-load")
 
     const otherEvents = await this.eventLogChannel.read()
@@ -203,6 +204,18 @@ export class FrameTests extends TurboDriveTestCase {
     const { fetchResponse } = await this.nextEventNamed("turbo:frame-render")
 
     this.assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/part.html")
+  }
+
+  async "test navigating a frame fires events"() {
+    await this.clickSelector("#outside-frame-form")
+
+    const { fetchResponse } = await this.nextEventOnTarget("frame", "turbo:frame-render")
+    this.assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/form.html")
+
+    await this.nextEventOnTarget("frame", "turbo:frame-load")
+
+    const otherEvents = await this.eventLogChannel.read()
+    this.assert.equal(otherEvents.length, 0, "no more events")
   }
 
    async "test following inner link reloads frame on every click"() {


### PR DESCRIPTION
Prior to this change, whenever a `<form>` submission drove a
`<turbo-frame>` element, `turbo:frame-render` events would fire but
`turbo:frame-load` events would not. The implementation to handle
navigations initiated by `[src]`-based attribute changes diverges from
the code paths that handle form submissions and `4xx` response
rendering.

Regardless of any plans to re-structure those code paths, it's important to ensure that
`turbo:frame-load` events fire regardless of how the `<turbo-frame>` was
navigated.