### PR TITLE
Extract `FrameVisit` to drive `FrameController`

### DIFF
--- a/src/core/frames/frame_visit.js
+++ b/src/core/frames/frame_visit.js
@@ -1,0 +1,152 @@
+import { expandURL } from "../url"
+import { clearBusyState, getVisitAction, markAsBusy } from "../../util"
+import { FetchMethod, FetchRequest } from "../../http/fetch_request"
+import { FormSubmission } from "../drive/form_submission"
+import { PageSnapshot } from "../drive/page_snapshot"
+import { StreamMessage } from "../streams/stream_message"
+
+export class FrameVisit {
+  isFormSubmission = false
+  #resolveVisitPromise = () => {}
+
+  static optionsForClick(element, url) {
+    const action = getVisitAction(element)
+    const acceptsStreamResponse = element.hasAttribute("data-turbo-stream")
+
+    return { acceptsStreamResponse, action, url }
+  }
+
+  static optionsForSubmit(form, submitter) {
+    const action = getVisitAction(form, submitter)
+
+    return { action, submit: { form, submitter } }
+  }
+
+  constructor(delegate, frameElement, options) {
+    this.delegate = delegate
+    this.frameElement = frameElement
+    this.previousURL = this.frameElement.src
+
+    const { acceptsStreamResponse, action, url, submit } = (this.options = options)
+
+    this.acceptsStreamResponse = acceptsStreamResponse || false
+    this.action = action || getVisitAction(this.frameElement)
+
+    if (submit) {
+      const { fetchRequest } = (this.formSubmission = new FormSubmission(this, submit.form, submit.submitter))
+      this.prepareRequest(fetchRequest)
+      this.isFormSubmission = true
+      this.isSafe = this.formSubmission.isSafe
+    } else if (url) {
+      this.fetchRequest = new FetchRequest(this, FetchMethod.get, expandURL(url), new URLSearchParams(), this.frameElement)
+      this.isSafe = true
+    } else {
+      throw new Error("FrameVisit must be constructed with either a url: or submit: option")
+    }
+  }
+
+  async start() {
+    if (this.delegate.shouldVisitFrame(this)) {
+      if (this.action) {
+        this.snapshot = PageSnapshot.fromElement(this.frameElement).clone()
+      }
+
+      if (this.formSubmission) {
+        await this.formSubmission.start()
+      } else {
+        await this.#performRequest()
+      }
+
+      return this.frameElement.loaded
+    } else {
+      return Promise.resolve()
+    }
+  }
+
+  stop() {
+    this.fetchRequest?.cancel()
+    this.formSubmission?.stop()
+  }
+
+  // Fetch request delegate
+
+  prepareRequest(fetchRequest) {
+    fetchRequest.headers["Turbo-Frame"] = this.frameElement.id
+
+    if (this.acceptsStreamResponse || this.isFormSubmission) {
+      fetchRequest.acceptResponseType(StreamMessage.contentType)
+    }
+  }
+
+  requestStarted(fetchRequest) {
+    this.delegate.frameVisitStarted(this)
+
+    if (fetchRequest.target instanceof HTMLFormElement) {
+      markAsBusy(fetchRequest.target)
+    }
+
+    markAsBusy(this.frameElement)
+  }
+
+  requestPreventedHandlingResponse(_fetchRequest, _fetchResponse) {
+    this.#resolveVisitPromise()
+  }
+
+  requestFinished(fetchRequest) {
+    clearBusyState(this.frameElement)
+
+    if (fetchRequest.target instanceof HTMLFormElement) {
+      clearBusyState(fetchRequest.target)
+    }
+
+    this.delegate.frameVisitCompleted(this)
+  }
+
+  async requestSucceededWithResponse(_fetchRequest, fetchResponse) {
+    await this.delegate.frameVisitSucceededWithResponse(this, fetchResponse)
+    this.#resolveVisitPromise()
+  }
+
+  async requestFailedWithResponse(_fetchRequest, fetchResponse) {
+    console.error(fetchResponse)
+    await this.delegate.frameVisitFailedWithResponse(this, fetchResponse)
+    this.#resolveVisitPromise()
+  }
+
+  requestErrored(fetchRequest, error) {
+    this.delegate.frameVisitErrored(this, fetchRequest, error)
+    this.#resolveVisitPromise()
+  }
+
+  // Form submission delegate
+
+  formSubmissionStarted(formSubmission) {
+    this.requestStarted(formSubmission.fetchRequest)
+  }
+
+  async formSubmissionSucceededWithResponse(formSubmission, fetchResponse) {
+    await this.requestSucceededWithResponse(formSubmission.fetchRequest, fetchResponse)
+  }
+
+  async formSubmissionFailedWithResponse(formSubmission, fetchResponse) {
+    await this.requestFailedWithResponse(formSubmission.fetchRequest, fetchResponse)
+  }
+
+  formSubmissionErrored(formSubmission, error) {
+    this.requestErrored(formSubmission.fetchRequest, error)
+  }
+
+  formSubmissionFinished(formSubmission) {
+    this.requestFinished(formSubmission.fetchRequest)
+  }
+
+  #performRequest() {
+    this.frameElement.loaded = new Promise((resolve) => {
+      this.#resolveVisitPromise = () => {
+        this.#resolveVisitPromise = () => {}
+        resolve()
+      }
+      this.fetchRequest?.perform()
+    })
+  }
+}

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -98,10 +98,10 @@ export class Session {
     const frameElement = options.frame ? document.getElementById(options.frame) : null
 
     if (frameElement instanceof FrameElement) {
-      const action = options.action || getVisitAction(frameElement)
-
-      frameElement.delegate.proposeVisitIfNavigatedWithAction(frameElement, action)
-      frameElement.src = location.toString()
+      frameElement.delegate.visit({
+        url: location.toString(),
+        action: options.action || getVisitAction(frameElement)
+      })
     } else {
       this.navigator.proposeVisit(expandURL(location), options)
     }

--- a/src/tests/fixtures/tabs/three.html
+++ b/src/tests/fixtures/tabs/three.html
@@ -2,11 +2,13 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Frame</title>
+    <title>Tabs: Three</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
+    <h1>Tabs: Three</h1>
+
     <turbo-frame id="tab-frame" data-turbo-action="advance">
       <div>
         <a id="tab-1" href="/src/tests/fixtures/tabs.html">Tab 1</a>

--- a/src/tests/fixtures/tabs/two.html
+++ b/src/tests/fixtures/tabs/two.html
@@ -7,6 +7,8 @@
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
+    <h1>Tabs: Two</h1>
+
     <turbo-frame id="tab-frame" data-turbo-action="advance">
       <div>
         <a id="tab-1" href="/src/tests/fixtures/tabs.html">Tab 1</a>

--- a/src/tests/functional/frame_navigation_tests.js
+++ b/src/tests/functional/frame_navigation_tests.js
@@ -1,5 +1,5 @@
 import { test } from "@playwright/test"
-import { getFromLocalStorage, nextBeat, nextEventNamed, nextEventOnTarget, pathname, scrollToSelector } from "../helpers/page"
+import { getFromLocalStorage, nextBeat, nextEventNamed, nextEventOnTarget, pathname, scrollToSelector, sleep } from "../helpers/page"
 import { assert } from "chai"
 
 test("frame navigation with descendant link", async ({ page }) => {
@@ -49,6 +49,90 @@ test("frame navigation emits fetch-request-error event when offline", async ({ p
   await page.context().setOffline(true)
   await page.click("#tab-2")
   await nextEventOnTarget(page, "tab-frame", "turbo:fetch-request-error")
+})
+
+test("promoted frame submits a single request per navigation", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/tabs.html")
+  await nextEventNamed(page, "turbo:load")
+
+  const requestedPathnames = await capturingRequestPathnames(page, async () => {
+    await page.click("#tab-2")
+    await nextEventNamed(page, "turbo:load")
+    await page.click("#tab-3")
+    await nextEventNamed(page, "turbo:load")
+  })
+
+  assert.deepEqual(requestedPathnames, ["/src/tests/fixtures/tabs/two.html", "/src/tests/fixtures/tabs/three.html"])
+})
+
+test("promoted frames do not submit requests when navigating back and forward with history", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/tabs.html")
+  await nextEventNamed(page, "turbo:load")
+  await page.click("#tab-2")
+  await nextEventNamed(page, "turbo:load")
+  await page.click("#tab-3")
+  await nextEventNamed(page, "turbo:load")
+
+  const requestedPathnames = await capturingRequestPathnames(page, async () => {
+    await page.goBack()
+    await nextEventNamed(page, "turbo:load")
+    await page.goForward()
+    await nextEventNamed(page, "turbo:load")
+  })
+
+  assert.deepEqual(requestedPathnames, [])
+})
+
+test("navigating back when frame navigation has been canceled does not submit a request", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/tabs/three.html")
+  await nextEventNamed(page, "turbo:load")
+  await delayResponseForLink(page, "#tab-2", 2000)
+  page.click("#tab-2")
+  await page.click("#tab-1")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal("/src/tests/fixtures/tabs.html", pathname(page.url()))
+
+  const requestedPathnames = await capturingRequestPathnames(page, async () => {
+    await page.goBack()
+    await nextEventNamed(page, "turbo:load")
+  })
+
+  assert.deepEqual([], requestedPathnames)
+})
+
+test("canceling frame requests don't mutate the history", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/tabs.html")
+  await page.click("#tab-2")
+  await nextEventOnTarget(page, "tab-frame", "turbo:frame-load")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("#tab-content"), "Two")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "sets [complete]")
+
+  // This request will be canceled
+  await delayResponseForLink(page, "#tab-1", 2000)
+  page.click("#tab-1")
+  await page.click("#tab-3")
+
+  await nextEventOnTarget(page, "tab-frame", "turbo:frame-load")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("#tab-content"), "Three")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/three.html")
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("#tab-content"), "Two")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
+
+  // Make sure the frame is not mutated after some time.
+  await nextBeat()
+
+  assert.equal(await page.textContent("#tab-content"), "Two")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
 })
 
 test("lazy-loaded frame promotes navigation", async ({ page }) => {
@@ -118,3 +202,24 @@ test("promoted frame navigations are cached", async ({ page }) => {
   assert.equal(await page.getAttribute("#tab-frame", "src"), null, "caches one.html without #tab-frame[src]")
   assert.equal(await page.getAttribute("#tab-frame", "complete"), null, "caches one.html without [complete]")
 })
+
+async function capturingRequestPathnames(page, callback) {
+  const requestedPathnames = []
+
+  page.on("request", (request) => requestedPathnames.push(pathname(request.url())))
+
+  await callback()
+
+  return requestedPathnames
+}
+
+async function delayResponseForLink(page, selector, delayInMilliseconds) {
+  const href = await page.locator(selector).evaluate((link) => link.href)
+
+  await page.route(href, async (route) => {
+    await sleep(delayInMilliseconds)
+    route.continue()
+  })
+
+  return page
+}


### PR DESCRIPTION
Might close https://github.com/hotwired/turbo/pull/793

The problem
---

Programmatically driving a `<turbo-frame>` element when its `[src]`
attribute changes is a suitable end-user experience in consumer
applications. It's a fitting black-box interface for the outside world:
change the value of the attribute and let Turbo handle the rest.

However, internally, it's a lossy abstraction.

For example, when the `FrameRedirector` class listens for page-wide
`click` and `submit` events, it determines if their targets are meant to
drive a `<turbo-frame>` element by:

1. finding an element that matches a clicked `<a>` element's `[data-turbo-frame]` attribute
2. finding an element that matches a submitted `<form>` element's `[data-turbo-frame]` attribute
3. finding an element that matches a submitted `<form>` element's
   _submitter's_ `[data-turbo-frame]` attribute
4. finding the closest `<turbo-frame>` ancestor to the `<a>` or `<form>`

Once it finds the matching frame element, it disposes of all that
additional context and navigates the `<turbo-frame>` by updating its
`[src]` attribute. This makes it impossible to control various aspects
of the frame navigation (like its "rendering" explored in
[hotwired/turbo#146][]) outside of its destination URL.

Similarly, since a `<form>` and submitter pairing have an impact on
which `<turbo-frame>` is navigated, the `FrameController` implementation
passes around a `HTMLFormElement` and `HTMLSubmitter?` data clump and
constantly re-fetches a matching `<turbo-frame>` instance.

Outside of frames, page-wide navigation is driven by a `Visit` instance
that manages the HTTP life cycle and delegates along the way to a
`Visit` delegate. It also pairs calls to visit with an option object to
capture additional context.

The proposal
---

This commit introduces the `FrameVisit` class. It serves as an
encapsulation of the `FetchRequest` and `FormSubmission` lifecycle
events involved in navigating a frame.

It's implementation draws inspiration from the `Visit` class's delegate
and option structures. Since the `FrameVisit` knows how to unify
both `FetchRequest` and `FormSubmission` hooks, the resulting callbacks
fired from within the `FrameController` are flat and consistent.

Extra benefits
---

The biggest benefit is the introduction of a DRY abstraction to
manage the behind the scenes HTTP calls necessary to drive a
`<turbo-frame>`.

With the introduction of the `FrameVisit` concept, we can also declare a
`visit()` and `submit()` method for `FrameElement` delegate
implementations in the place of other implementation-specific methods
like `loadResponse()` and `formSubmissionIntercepted()`.

In addition, these changes have the potential to close
[hotwired/turbo#326][], since we can consistently invoke
`loadResponse()` across `<a>`-click-initiated and
`<form>`-submission-initiated visits. To ensure that's the case, this
commit adds test coverage for navigating a `<turbo-frame>` by making a
`GET` request to an endpoint that responds with a `500` status.

[hotwired/turbo#146]: https://github.com/hotwired/turbo/pull/146
[hotwired/turbo#326]: https://github.com/hotwired/turbo/issues/326

