### PR TITLE
Support custom rendering in `turbo:before{-frame,}-render` events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,13 +40,6 @@ jobs:
     - name: Firefox Test
       run: yarn test:browser --project=firefox
 
-    - name: Upload test results
-      if: always()
-      uses: actions/upload-artifact@v2
-      with:
-        name: playwright-report
-        path: playwright-report
-
     - name: Publish dev build
       run: .github/scripts/publish-dev-build '${{ secrets.DEV_BUILD_GITHUB_TOKEN }}'
       if: ${{ github.event_name == 'push' }}

--- a/src/core/drive/error_renderer.ts
+++ b/src/core/drive/error_renderer.ts
@@ -2,15 +2,21 @@ import { PageSnapshot } from "./page_snapshot"
 import { Renderer } from "../renderer"
 
 export class ErrorRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
+  static renderElement(currentElement: HTMLBodyElement, newElement: HTMLBodyElement) {
+    const { documentElement, body } = document
+
+    documentElement.replaceChild(newElement, body)
+  }
+
   async render() {
     this.replaceHeadAndBody()
     this.activateScriptElements()
   }
 
   replaceHeadAndBody() {
-    const { documentElement, head, body } = document
+    const { documentElement, head } = document
     documentElement.replaceChild(this.newHead, head)
-    documentElement.replaceChild(this.newElement, body)
+    this.renderElement(this.currentElement, this.newElement)
   }
 
   activateScriptElements() {

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -3,6 +3,14 @@ import { PageSnapshot } from "./page_snapshot"
 import { ReloadReason } from "../native/browser_adapter"
 
 export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
+  static renderElement(currentElement: HTMLBodyElement, newElement: HTMLBodyElement) {
+    if (document.body && newElement instanceof HTMLBodyElement) {
+      document.body.replaceWith(newElement)
+    } else {
+      document.documentElement.appendChild(newElement)
+    }
+  }
+
   get shouldRender() {
     return this.newSnapshot.isVisitable && this.trackedElementsAreIdentical
   }
@@ -105,11 +113,7 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
   }
 
   assignNewBody() {
-    if (document.body && this.newElement instanceof HTMLBodyElement) {
-      document.body.replaceWith(this.newElement)
-    } else {
-      document.documentElement.appendChild(this.newElement)
-    }
+    this.renderElement(this.currentElement, this.newElement)
   }
 
   get newHeadStylesheetElements() {

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -1,10 +1,12 @@
 import { nextEventLoopTick } from "../../util"
-import { View, ViewDelegate } from "../view"
+import { View, ViewDelegate, ViewRenderOptions } from "../view"
 import { ErrorRenderer } from "./error_renderer"
 import { PageRenderer } from "./page_renderer"
 import { PageSnapshot } from "./page_snapshot"
 import { SnapshotCache } from "./snapshot_cache"
 import { Visit } from "./visit"
+
+export type PageViewRenderOptions = ViewRenderOptions
 
 export interface PageViewDelegate extends ViewDelegate<HTMLBodyElement, PageSnapshot> {
   viewWillCacheSnapshot(): void

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -6,7 +6,7 @@ import { PageSnapshot } from "./page_snapshot"
 import { SnapshotCache } from "./snapshot_cache"
 import { Visit } from "./visit"
 
-export type PageViewRenderOptions = ViewRenderOptions
+export type PageViewRenderOptions = ViewRenderOptions<HTMLBodyElement>
 
 export interface PageViewDelegate extends ViewDelegate<HTMLBodyElement, PageSnapshot> {
   viewWillCacheSnapshot(): void

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -6,19 +6,19 @@ import { PageSnapshot } from "./page_snapshot"
 import { SnapshotCache } from "./snapshot_cache"
 import { Visit } from "./visit"
 
-export interface PageViewDelegate extends ViewDelegate<PageSnapshot> {
+export interface PageViewDelegate extends ViewDelegate<HTMLBodyElement, PageSnapshot> {
   viewWillCacheSnapshot(): void
 }
 
 type PageViewRenderer = PageRenderer | ErrorRenderer
 
-export class PageView extends View<Element, PageSnapshot, PageViewRenderer, PageViewDelegate> {
+export class PageView extends View<HTMLBodyElement, PageSnapshot, PageViewRenderer, PageViewDelegate> {
   readonly snapshotCache = new SnapshotCache(10)
   lastRenderedLocation = new URL(location.href)
   forceReloaded = false
 
   renderPage(snapshot: PageSnapshot, isPreview = false, willRender = true, visit?: Visit) {
-    const renderer = new PageRenderer(this.snapshot, snapshot, isPreview, willRender)
+    const renderer = new PageRenderer(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)
     if (!renderer.shouldRender) {
       this.forceReloaded = true
     } else {
@@ -29,7 +29,7 @@ export class PageView extends View<Element, PageSnapshot, PageViewRenderer, Page
 
   renderError(snapshot: PageSnapshot, visit?: Visit) {
     visit?.changeHistory()
-    const renderer = new ErrorRenderer(this.snapshot, snapshot, false)
+    const renderer = new ErrorRenderer(this.snapshot, snapshot, ErrorRenderer.renderElement, false)
     return this.render(renderer)
   }
 

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -10,7 +10,7 @@ import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/
 import { clearBusyState, getAttribute, parseHTMLDocument, markAsBusy } from "../../util"
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
-import { ViewDelegate } from "../view"
+import { ViewDelegate, ViewRenderOptions } from "../view"
 import { getAction, expandURL, urlsAreEqual, locationIsVisitable } from "../url"
 import { FormInterceptor, FormInterceptorDelegate } from "./form_interceptor"
 import { FrameView } from "./frame_view"
@@ -259,7 +259,7 @@ export class FrameController
 
   // View delegate
 
-  allowsImmediateRender(_snapshot: Snapshot, _resume: (value: any) => void) {
+  allowsImmediateRender(_snapshot: Snapshot, _options: ViewRenderOptions) {
     return true
   }
 

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -259,7 +259,7 @@ export class FrameController
 
   // View delegate
 
-  allowsImmediateRender(_snapshot: Snapshot, _options: ViewRenderOptions) {
+  allowsImmediateRender(_snapshot: Snapshot, _options: ViewRenderOptions<FrameElement>) {
     return true
   }
 

--- a/src/core/frames/frame_view.ts
+++ b/src/core/frames/frame_view.ts
@@ -1,6 +1,8 @@
 import { FrameElement } from "../../elements"
 import { Snapshot } from "../snapshot"
-import { View } from "../view"
+import { View, ViewRenderOptions } from "../view"
+
+export type FrameViewRenderOptions = ViewRenderOptions<FrameElement>
 
 export class FrameView extends View<FrameElement> {
   invalidate() {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -8,20 +8,24 @@ type ResolvingFunctions<T = unknown> = {
   reject(reason?: any): void
 }
 
+export type Render<E> = (newElement: E, currentElement: E) => void
+
 export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapshot<E>> implements BardoDelegate {
   readonly currentSnapshot: S
   readonly newSnapshot: S
   readonly isPreview: boolean
   readonly willRender: boolean
   readonly promise: Promise<void>
+  renderElement: Render<E>
   private resolvingFunctions?: ResolvingFunctions<void>
   private activeElement: Element | null = null
 
-  constructor(currentSnapshot: S, newSnapshot: S, isPreview: boolean, willRender = true) {
+  constructor(currentSnapshot: S, newSnapshot: S, renderElement: Render<E>, isPreview: boolean, willRender = true) {
     this.currentSnapshot = currentSnapshot
     this.newSnapshot = newSnapshot
     this.isPreview = isPreview
     this.willRender = willRender
+    this.renderElement = renderElement
     this.promise = new Promise((resolve, reject) => (this.resolvingFunctions = { resolve, reject }))
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -23,7 +23,7 @@ import { Preloader, PreloaderDelegate } from "./drive/preloader"
 
 export type TimingData = unknown
 export type TurboBeforeCacheEvent = CustomEvent
-export type TurboBeforeRenderEvent = CustomEvent<{ newBody: HTMLBodyElement; resume: (value: any) => void }>
+export type TurboBeforeRenderEvent = CustomEvent<{ newBody: HTMLBodyElement } & PageViewRenderOptions>
 export type TurboBeforeVisitEvent = CustomEvent<{ url: string }>
 export type TurboClickEvent = CustomEvent<{ url: string; originalEvent: MouseEvent }>
 export type TurboFrameLoadEvent = CustomEvent
@@ -261,7 +261,16 @@ export class Session
 
   allowsImmediateRender({ element }: PageSnapshot, options: PageViewRenderOptions) {
     const event = this.notifyApplicationBeforeRender(element, options)
-    return !event.defaultPrevented
+    const {
+      defaultPrevented,
+      detail: { render },
+    } = event
+
+    if (this.view.renderer && render) {
+      this.view.renderer.renderElement = render
+    }
+
+    return !defaultPrevented
   }
 
   viewRenderedSnapshot(_snapshot: PageSnapshot, _isPreview: boolean) {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -46,7 +46,7 @@ export class Session
   readonly navigator = new Navigator(this)
   readonly history = new History(this)
   readonly preloader = new Preloader(this)
-  readonly view = new PageView(this, document.documentElement)
+  readonly view = new PageView(this, document.documentElement as HTMLBodyElement)
   adapter: Adapter = new BrowserAdapter(this)
 
   readonly pageObserver = new PageObserver(this)

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -18,6 +18,7 @@ import { PageView, PageViewDelegate, PageViewRenderOptions } from "./drive/page_
 import { Visit, VisitOptions } from "./drive/visit"
 import { PageSnapshot } from "./drive/page_snapshot"
 import { FrameElement } from "../elements/frame_element"
+import { FrameViewRenderOptions } from "./frames/frame_view"
 import { FetchResponse } from "../http/fetch_response"
 import { Preloader, PreloaderDelegate } from "./drive/preloader"
 
@@ -27,6 +28,7 @@ export type TurboBeforeRenderEvent = CustomEvent<{ newBody: HTMLBodyElement } & 
 export type TurboBeforeVisitEvent = CustomEvent<{ url: string }>
 export type TurboClickEvent = CustomEvent<{ url: string; originalEvent: MouseEvent }>
 export type TurboFrameLoadEvent = CustomEvent
+export type TurboBeforeFrameRenderEvent = CustomEvent<{ newFrame: FrameElement } & FrameViewRenderOptions>
 export type TurboFrameRenderEvent = CustomEvent<{ fetchResponse: FetchResponse }>
 export type TurboLoadEvent = CustomEvent<{ url: string; timing: TimingData }>
 export type TurboRenderEvent = CustomEvent

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -14,7 +14,7 @@ import { StreamMessage } from "./streams/stream_message"
 import { StreamObserver } from "../observers/stream_observer"
 import { Action, Position, StreamSource, isAction } from "./types"
 import { clearBusyState, dispatch, markAsBusy } from "../util"
-import { PageView, PageViewDelegate } from "./drive/page_view"
+import { PageView, PageViewDelegate, PageViewRenderOptions } from "./drive/page_view"
 import { Visit, VisitOptions } from "./drive/visit"
 import { PageSnapshot } from "./drive/page_snapshot"
 import { FrameElement } from "../elements/frame_element"
@@ -259,8 +259,8 @@ export class Session
     }
   }
 
-  allowsImmediateRender({ element }: PageSnapshot, resume: (value: any) => void) {
-    const event = this.notifyApplicationBeforeRender(element, resume)
+  allowsImmediateRender({ element }: PageSnapshot, options: PageViewRenderOptions) {
+    const event = this.notifyApplicationBeforeRender(element, options)
     return !event.defaultPrevented
   }
 
@@ -323,9 +323,9 @@ export class Session
     return dispatch<TurboBeforeCacheEvent>("turbo:before-cache")
   }
 
-  notifyApplicationBeforeRender(newBody: HTMLBodyElement, resume: (value: any) => void) {
+  notifyApplicationBeforeRender(newBody: HTMLBodyElement, options: PageViewRenderOptions) {
     return dispatch<TurboBeforeRenderEvent>("turbo:before-render", {
-      detail: { newBody, resume },
+      detail: { newBody, ...options },
       cancelable: true,
     })
   }

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -4,8 +4,12 @@ import { Snapshot } from "./snapshot"
 import { Position } from "./types"
 import { getAnchor } from "./url"
 
+export interface ViewRenderOptions {
+  resume: (value: any) => void
+}
+
 export interface ViewDelegate<E extends Element, S extends Snapshot<E>> {
-  allowsImmediateRender(snapshot: S, resume: (value: any) => void): boolean
+  allowsImmediateRender(snapshot: S, options: ViewRenderOptions): boolean
   preloadOnLoadLinksForView(element: Element): void
   viewRenderedSnapshot(snapshot: S, isPreview: boolean): void
   viewInvalidated(reason: ReloadReason): void
@@ -85,7 +89,8 @@ export abstract class View<
         this.prepareToRenderSnapshot(renderer)
 
         const renderInterception = new Promise((resolve) => (this.resolveInterceptionPromise = resolve))
-        const immediateRender = this.delegate.allowsImmediateRender(snapshot, this.resolveInterceptionPromise)
+        const options = { resume: this.resolveInterceptionPromise }
+        const immediateRender = this.delegate.allowsImmediateRender(snapshot, options)
         if (!immediateRender) await renderInterception
 
         await this.renderSnapshot(renderer)

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -4,7 +4,7 @@ import { Snapshot } from "./snapshot"
 import { Position } from "./types"
 import { getAnchor } from "./url"
 
-export interface ViewDelegate<S extends Snapshot> {
+export interface ViewDelegate<E extends Element, S extends Snapshot<E>> {
   allowsImmediateRender(snapshot: S, resume: (value: any) => void): boolean
   preloadOnLoadLinksForView(element: Element): void
   viewRenderedSnapshot(snapshot: S, isPreview: boolean): void
@@ -15,7 +15,7 @@ export abstract class View<
   E extends Element,
   S extends Snapshot<E> = Snapshot<E>,
   R extends Renderer<E, S> = Renderer<E, S>,
-  D extends ViewDelegate<S> = ViewDelegate<S>
+  D extends ViewDelegate<E, S> = ViewDelegate<E, S>
 > {
   readonly delegate: D
   readonly element: E

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -1,15 +1,16 @@
 import { ReloadReason } from "./native/browser_adapter"
-import { Renderer } from "./renderer"
+import { Renderer, Render } from "./renderer"
 import { Snapshot } from "./snapshot"
 import { Position } from "./types"
 import { getAnchor } from "./url"
 
-export interface ViewRenderOptions {
+export interface ViewRenderOptions<E> {
   resume: (value: any) => void
+  render: Render<E>
 }
 
 export interface ViewDelegate<E extends Element, S extends Snapshot<E>> {
-  allowsImmediateRender(snapshot: S, options: ViewRenderOptions): boolean
+  allowsImmediateRender(snapshot: S, options: ViewRenderOptions<E>): boolean
   preloadOnLoadLinksForView(element: Element): void
   viewRenderedSnapshot(snapshot: S, isPreview: boolean): void
   viewInvalidated(reason: ReloadReason): void
@@ -89,7 +90,7 @@ export abstract class View<
         this.prepareToRenderSnapshot(renderer)
 
         const renderInterception = new Promise((resolve) => (this.resolveInterceptionPromise = resolve))
-        const options = { resume: this.resolveInterceptionPromise }
+        const options = { resume: this.resolveInterceptionPromise, render: this.renderer.renderElement }
         const immediateRender = this.delegate.allowsImmediateRender(snapshot, options)
         if (!immediateRender) await renderInterception
 

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -309,7 +309,7 @@
     <form method="post" action="https://httpbin.org/post">
       <button id="submit-external">POST to https://httpbin.org/post</button>
     </form>
-     <a href="/__turbo/redirect?path=/src/tests/fixtures/frames/hello.html" data-turbo-method="post" data-turbo-frame="hello" id="turbo-method-post-to-targeted-frame">Turbo method post to targeted frame</a>
+     <a href="/__turbo/redirect?path=%2Fsrc%2Ftests%2Ffixtures%2Fframes%2Fhello.html" data-turbo-method="post" data-turbo-frame="hello" id="turbo-method-post-to-targeted-frame">Turbo method post to targeted frame</a>
     <turbo-frame id="hello"></turbo-frame>
     <hr>
 

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -62,6 +62,24 @@ test("test reloads when tracked elements change", async ({ page }) => {
   assert.equal(reason, "tracked_element_mismatch")
 })
 
+test("test before-render event supports custom render function", async ({ page }) => {
+  await page.evaluate(() =>
+    addEventListener("turbo:before-render", (event) => {
+      const { detail } = event as CustomEvent
+      const { render } = detail
+      detail.render = (currentElement: HTMLBodyElement, newElement: HTMLBodyElement) => {
+        newElement.insertAdjacentHTML("beforeend", `<span id="custom-rendered">Custom Rendered</span>`)
+        render(currentElement, newElement)
+      }
+    })
+  )
+  await page.click("#same-origin-link")
+  await nextBody(page)
+
+  const customRendered = await page.locator("#custom-rendered")
+  assert.equal(await customRendered.textContent(), "Custom Rendered", "renders with custom function")
+})
+
 test("test wont reload when tracked elements has a nonce", async ({ page }) => {
   await page.click("#tracked-nonce-tag-link")
   await nextBody(page)


### PR DESCRIPTION
Renderer: Extract `renderElement()`
===

For each renderer (`PageRenderer`, `ErrorRenderer`, `FrameRenderer`)
extract their rendering logic into a class-`static-` property named
`renderElement()`. That function accepts two arguments: the first is the
current version of the element being rendered, the second is the new
version of the element being rendered.

The `PageRenderer` and `ErrorRenderer` types are genericized to accept
`HTMLBodyElement` instances. The `FrameRenderer` generics accept a
`FrameElement` instance. This means that the `renderElement()` function
shares the same class-level generics.

Extract `ViewRenderOptions`
===

Introduce the `ViewRenderOptions<E extends Element>` to store the
`resume()` function dispatched with the `turbo:before-render` event.

Future commits will add additional properties to this option interface.

Support custom rendering from `turbo:before-render`
===

The problem
---

The rendering process during a page-wide navigation is opaque, and
cannot be extended. Proposals have been made to use third-party
rendering tools like [morphdom][], or other animation libraries.

Outside of the HTML manipulation, Turbo is also responsible for loading
script, transposing permanent elements, etc.

How might these tools integrate with Turbo in a way that's compliant
with permanent elements.

The solution
---

When publishing a `turbo:before-render` event, dispatch it with a
`render()` function property in addition to the `resume()`.

This way, consumer applications can override rendering:

```js
import morphdom from "morphdom"

addEventListener("turbo:before-render", ({ detail }) => {
  detail.render = (currentElement, newElement) => {
    morphdom(currentElement, newElement)
  }

  // or, more tersely
  detail.render = morphdom
})
```

Potentially Closes [hotwired/turbo#197][]
Potentially Closes [hotwired/turbo#378][]
Potentially Closes [hotwired/turbo#218][]

[morphdom]: https://github.com/patrick-steele-idem/morphdom
[hotwired/turbo#218]: https://github.com/hotwired/turbo/pull/218
[hotwired/turbo#378]: https://github.com/hotwired/turbo/issues/378
[hotwired/turbo#197]: https://github.com/hotwired/turbo/issues/197

Introduce `turbo:before-frame-render` event
===

The problem
---

Similar to `turbo:before-render` events and the `<body>` element,
rendering `<turbo-frame>` events is opaque and isn't extensible.

The solution
---

Publish a `turbo:before-frame-render` event, dispatch it with a
`render()` function property in addition to the `resume()`.

This way, consumer applications can override rendering in the same style
as `turbo:before-render` events.
