### PR TITLE
Ignore external `<form>` submissions

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -5,7 +5,7 @@ import { FormSubmitObserver, FormSubmitObserverDelegate } from "../observers/for
 import { FrameRedirector } from "./frames/frame_redirector"
 import { History, HistoryDelegate } from "./drive/history"
 import { LinkClickObserver, LinkClickObserverDelegate } from "../observers/link_click_observer"
-import { expandURL, locationIsVisitable, Locatable } from "./url"
+import { getAction, expandURL, locationIsVisitable, Locatable } from "./url"
 import { Navigator, NavigatorDelegate } from "./drive/navigator"
 import { PageObserver, PageObserverDelegate } from "../observers/page_observer"
 import { ScrollObserver } from "../observers/scroll_observer"
@@ -200,7 +200,11 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   // Form submit observer delegate
 
   willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {
-    return this.elementDriveEnabled(form) && (!submitter || this.elementDriveEnabled(submitter))
+    const action = getAction(form, submitter)
+
+    return this.elementDriveEnabled(form)
+      && (!submitter || this.elementDriveEnabled(submitter))
+      && locationIsVisitable(expandURL(action), this.snapshot.rootLocation)
   }
 
   formSubmitted(form: HTMLFormElement, submitter?: HTMLElement) {

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -13,6 +13,12 @@ export function getAnchor(url: URL) {
   }
 }
 
+export function getAction(form: HTMLFormElement, submitter?: HTMLElement) {
+  const action = submitter?.getAttribute("formaction") || form.getAttribute("action") || form.action
+
+  return expandURL(action)
+}
+
 export function getExtension(url: URL) {
   return (getLastPathComponent(url).match(/\.[^.]*$/) || [])[0] || ""
 }

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -249,6 +249,24 @@
       <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-within-form-outside-frame">Stream link within form outside frame</a>
     </form>
     <hr>
+    <form method="post" action="https://httpbin.org/post">
+      <button id="submit-external">POST to https://httpbin.org/post</button>
+    </form>
     <turbo-frame id="hello"></turbo-frame>
+    <hr>
+
+    <turbo-frame id="ignored">
+      <form method="post" action="https://httpbin.org/post">
+        <button id="submit-external-within-ignored">POST to https://httpbin.org/post within #hello</button>
+      </form>
+    </turbo-frame>
+
+    <form method="post" action="https://httpbin.org/post">
+      <button id="submit-external">POST to https://httpbin.org/post</button>
+    </form>
+
+    <form method="post" action="https://httpbin.org/post" data-turbo-frame="ignored">
+      <button id="submit-external-target-ignored">POST to https://httpbin.org/post targeting #hello</button>
+    </form>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -651,6 +651,30 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.ok(await this.nextEventOnTarget("form_one", "turbo:before-fetch-response"))
   }
 
+  async "test POST to external action ignored"() {
+    await this.clickSelector("#submit-external")
+    await this.noNextEventNamed("turbo:before-fetch-request")
+    await this.nextBody
+
+    this.assert.equal(await this.location, "https://httpbin.org/post")
+  }
+
+  async "test POST to external action within frame ignored"() {
+    await this.clickSelector("#submit-external-within-ignored")
+    await this.noNextEventNamed("turbo:before-fetch-request")
+    await this.nextBody
+
+    this.assert.equal(await this.location, "https://httpbin.org/post")
+  }
+
+  async "test POST to external action targetting frame ignored"() {
+    await this.clickSelector("#submit-external-target-ignored")
+    await this.noNextEventNamed("turbo:before-fetch-request")
+    await this.nextBody
+
+    this.assert.equal(await this.location, "https://httpbin.org/post")
+  }
+
   get formSubmitStarted(): Promise<boolean> {
     return this.hasSelector("html[data-form-submit-start]")
   }


### PR DESCRIPTION
Closes [#435][]

When observing `<form>` submissions (page-wide submissions, submissions
within a `<turbo-frame>`, or submissions targeting a `<turbo-frame>`),
ignore any with an `[action]` (or submitter `[formaction]`) attribute
that targets an external URL.

To determine whether or not a URL is "external", re-use the existing
`locationIsVisitable()` utility function used by the `Session` to
determine whether or not to navigate an `<a>` element.

The existing `locationIsVisitable()` calls depend on a "root" location
read from a `PageSnapshot` instance. The `FrameController` and
`FrameRedirector` do not have access to such an instance, so the `<meta
name="turbo-root" content="...">` element reading abstracted away by the
`PageSnapshot` is re-implemented across both call sites. When a
`turbo-root` "setting" does not exist, treat `/` as the root.

[#435]: https://github.com/hotwired/turbo/issues/435