### PR TITLE
Contain `[aria-busy]` toggling within Frames

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -165,7 +165,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   requestStarted(request: FetchRequest) {
-    [ this.element, document.documentElement ].forEach(markAsBusy)
+    markAsBusy(this.element)
   }
 
   requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse) {
@@ -188,13 +188,13 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   requestFinished(request: FetchRequest) {
-    [ this.element, document.documentElement ].forEach(clearBusyState)
+    clearBusyState(this.element)
   }
 
   // Form submission delegate
 
   formSubmissionStarted({ formElement }: FormSubmission) {
-    [ formElement, this.findFrameElement(formElement), document.documentElement ].forEach(markAsBusy)
+    markAsBusy(formElement, this.findFrameElement(formElement))
   }
 
   formSubmissionSucceededWithResponse(formSubmission: FormSubmission, response: FetchResponse) {
@@ -214,7 +214,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   formSubmissionFinished({ formElement }: FormSubmission) {
-    [ formElement, this.findFrameElement(formElement), document.documentElement ].forEach(clearBusyState)
+    clearBusyState(formElement, this.findFrameElement(formElement))
   }
 
   // View delegate

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -439,10 +439,8 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), "", "sets [busy] on the #frame")
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "aria-busy"), "true", "sets [aria-busy] on the #frame")
-    this.assert.equal(await this.nextAttributeMutationNamed("html", "aria-busy"), "true", "sets [aria-busy] on the document element")
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), null, "removes [busy] from the #frame")
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "aria-busy"), null, "removes [aria-busy] from the #frame")
-    this.assert.equal(await this.nextAttributeMutationNamed("html", "aria-busy"), null, "removes [aria-busy] from the document element")
   }
 
   async "test frame form submission toggles the target frame's [aria-busy] attribute"() {

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -31,10 +31,8 @@ export class FrameTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), "", "sets [busy] on the #frame")
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "aria-busy"), "true", "sets [aria-busy=true] on the #frame")
-    this.assert.equal(await this.nextAttributeMutationNamed("html", "aria-busy"), "true", "sets [aria-busy=true] on the document element")
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "busy"), null, "removes [busy] on the #frame")
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "aria-busy"), null, "removes [aria-busy] from the #frame")
-    this.assert.equal(await this.nextAttributeMutationNamed("html", "aria-busy"), null, "removes [aria-busy] from the document element")
   }
 
   async "test following a link to a page without a matching frame results in an empty frame"() {

--- a/src/util.ts
+++ b/src/util.ts
@@ -64,17 +64,21 @@ export function getAttribute(attributeName: string, ...elements: (Element | unde
   return null
 }
 
-export function markAsBusy(element: Element) {
-  if (element.localName == "turbo-frame") {
-    element.setAttribute("busy", "")
+export function markAsBusy(...elements: Element[]) {
+  for (const element of elements) {
+    if (element.localName == "turbo-frame") {
+      element.setAttribute("busy", "")
+    }
+    element.setAttribute("aria-busy", "true")
   }
-  element.setAttribute("aria-busy", "true")
 }
 
-export function clearBusyState(element: Element) {
-  if (element.localName == "turbo-frame") {
-    element.removeAttribute("busy")
-  }
+export function clearBusyState(...elements: Element[]) {
+  for (const element of elements) {
+    if (element.localName == "turbo-frame") {
+      element.removeAttribute("busy")
+    }
 
-  element.removeAttribute("aria-busy")
+    element.removeAttribute("aria-busy")
+  }
 }


### PR DESCRIPTION
Setting `[aria-busy="true"]` on the `<html>` element during a
`<turbo-frame>` navigation might be too aggressive given the frame's
value proposition of a compartmentalized request-response cycle. If
applications style the page based on `html[aria-busy="true"]`, having
that toggled during (eager or lazy) Frame loading could lead to a
disorienting experience.

If that isn't the case for applications, they can synchronize the
attribute themselves with a `MutationObserver`:

```js
const observer = new MutationObserver(([ { target } ]) => {
  document.documentElement.setAttribute("aria-busy", target.busy)
}, { subtree: true, attributeFilter: ["busy"] })

observer.observe(document.body)
```