### PR TITLE
Preserve page state while promoting Frame-to-Visit

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -133,10 +133,6 @@ export class Navigator {
     this.delegate.visitCompleted(visit)
   }
 
-  visitCachedSnapshot(visit: Visit) {
-    this.delegate.visitCachedSnapshot(visit)
-  }
-
   locationWithActionIsSamePage(location: URL, action?: Action): boolean {
     const anchor = getAnchor(location)
     const currentAnchor = getAnchor(this.view.lastRenderedLocation)

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -11,7 +11,9 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
   }
 
   async render() {
-    this.replaceBody()
+    if (this.willRender) {
+      this.replaceBody()
+    }
   }
 
   finishRendering() {

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -15,8 +15,8 @@ export class PageView extends View<Element, PageSnapshot, PageViewRenderer, Page
   readonly snapshotCache = new SnapshotCache(10)
   lastRenderedLocation = new URL(location.href)
 
-  renderPage(snapshot: PageSnapshot, isPreview = false) {
-    const renderer = new PageRenderer(this.snapshot, snapshot, isPreview)
+  renderPage(snapshot: PageSnapshot, isPreview = false, willRender = true) {
+    const renderer = new PageRenderer(this.snapshot, snapshot, isPreview, willRender)
     return this.render(renderer)
   }
 
@@ -34,7 +34,9 @@ export class PageView extends View<Element, PageSnapshot, PageViewRenderer, Page
       this.delegate.viewWillCacheSnapshot()
       const { snapshot, lastRenderedLocation: location } = this
       await nextEventLoopTick()
-      this.snapshotCache.put(location, snapshot.clone())
+      const cachedSnapshot = snapshot.clone()
+      this.snapshotCache.put(location, cachedSnapshot)
+      return cachedSnapshot
     }
   }
 

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -4,7 +4,6 @@ import { FetchResponse } from "../../http/fetch_response"
 import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/appearance_observer"
 import { clearBusyState, getAttribute, parseHTMLDocument, markAsBusy } from "../../util"
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
-import { Visit, VisitDelegate } from "../drive/visit"
 import { Snapshot } from "../snapshot"
 import { ViewDelegate } from "../view"
 import { getAction, expandURL, urlsAreEqual, locationIsVisitable, Locatable } from "../url"
@@ -23,6 +22,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   readonly formInterceptor: FormInterceptor
   currentURL?: string | null
   formSubmission?: FormSubmission
+  fetchResponseLoaded = (fetchResponse: FetchResponse) => {}
   private currentFetchRequest: FetchRequest | null = null
   private resolveVisitPromise = () => {}
   private connected = false
@@ -108,15 +108,18 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
       if (html) {
         const { body } = parseHTMLDocument(html)
         const snapshot = new Snapshot(await this.extractForeignFrameElement(body))
-        const renderer = new FrameRenderer(this.view.snapshot, snapshot, false)
+        const renderer = new FrameRenderer(this.view.snapshot, snapshot, false, false)
         if (this.view.renderPromise) await this.view.renderPromise
         await this.view.render(renderer)
         session.frameRendered(fetchResponse, this.element)
         session.frameLoaded(this.element)
+        this.fetchResponseLoaded(fetchResponse)
       }
     } catch (error) {
       console.error(error)
       this.view.invalidate()
+    } finally {
+      this.fetchResponseLoaded = () => {}
     }
   }
 
@@ -261,19 +264,16 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
     const action = getAttribute("data-turbo-action", submitter, element, frame)
 
     if (isAction(action)) {
-      const delegate = new SnapshotSubstitution(frame)
-      const proposeVisit = (event: Event) => {
-        const { target, detail: { fetchResponse } } = event as CustomEvent
-        if (target instanceof FrameElement && target.src) {
+      const { visitCachedSnapshot } = new SnapshotSubstitution(frame)
+      frame.delegate.fetchResponseLoaded = (fetchResponse: FetchResponse) => {
+        if (frame.src) {
           const { statusCode, redirected } = fetchResponse
-          const responseHTML = target.ownerDocument.documentElement.outerHTML
+          const responseHTML = frame.ownerDocument.documentElement.outerHTML
           const response = { statusCode, redirected, responseHTML }
 
-          session.visit(target.src, { action, response, delegate })
+          session.visit(frame.src, { action, response, visitCachedSnapshot, willRender: false })
         }
       }
-
-      frame.addEventListener("turbo:frame-render", proposeVisit , { once: true })
     }
   }
 
@@ -395,26 +395,19 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 }
 
-class SnapshotSubstitution implements Partial<VisitDelegate> {
+class SnapshotSubstitution {
   private readonly clone: Node
   private readonly id: string
-  private snapshot?: Snapshot
 
   constructor(element: FrameElement) {
     this.clone = element.cloneNode(true)
     this.id = element.id
   }
 
-  visitStarted(visit: Visit) {
-    this.snapshot = visit.view.snapshot
-  }
+  visitCachedSnapshot = ({ element }: Snapshot) => {
+    const { id, clone } = this
 
-  visitCachedSnapshot() {
-    const { snapshot, id, clone } = this
-
-    if (snapshot) {
-      snapshot.element.querySelector("#" + id)?.replaceWith(clone)
-    }
+    element.querySelector("#" + id)?.replaceWith(clone)
   }
 }
 

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -10,13 +10,15 @@ export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapsh
   readonly currentSnapshot: S
   readonly newSnapshot: S
   readonly isPreview: boolean
+  readonly willRender: boolean
   readonly promise: Promise<void>
   private resolvingFunctions?: ResolvingFunctions<void>
 
-  constructor(currentSnapshot: S, newSnapshot: S, isPreview: boolean) {
+  constructor(currentSnapshot: S, newSnapshot: S, isPreview: boolean, willRender = true) {
     this.currentSnapshot = currentSnapshot
     this.newSnapshot = newSnapshot
     this.isPreview = isPreview
+    this.willRender = willRender
     this.promise = new Promise((resolve, reject) => this.resolvingFunctions = { resolve, reject })
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -189,9 +189,6 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     this.notifyApplicationAfterPageLoad(visit.getTimingMetrics())
   }
 
-  visitCachedSnapshot(visit: Visit) {
-  }
-
   locationWithActionIsSamePage(location: URL, action?: Action): boolean {
     return this.navigator.locationWithActionIsSamePage(location, action)
   }

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -11,6 +11,7 @@ export interface FrameElementDelegate {
   formSubmissionIntercepted(element: HTMLFormElement, submitter?: HTMLElement): void
   linkClickIntercepted(element: Element, url: string): void
   loadResponse(response: FetchResponse): void
+  fetchResponseLoaded: (fetchResponse: FetchResponse) => void
   isLoading: boolean
 }
 

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="html">
+<html id="html" data-skip-event-details="turbo:before-render">
   <head>
     <meta charset="utf-8">
     <title>Frame</title>
@@ -9,9 +9,14 @@
       addEventListener("click", ({ target }) => {
         if (target.id == "add-turbo-action-to-frame") {
           target.closest("turbo-frame")?.setAttribute("data-turbo-action", "advance")
+        } else if (target.id == "remove-target-from-hello") {
+          document.getElementById("hello").removeAttribute("target")
         }
       })
     </script>
+    <style>
+      .push-off-screen { margin-top: 1000px; }
+    </style>
   </head>
   <body>
     <h1>Frames</h1>
@@ -45,7 +50,11 @@
       <h2>Frames: #hello</h2>
 
       <a href="/src/tests/fixtures/frames/frame.html">Load #frame</a>
+      <button type="button" id="remove-target-from-hello">Remove #hello[target]</button>
+
     </turbo-frame>
+
+    <a id="link-hello-advance" href="/src/tests/fixtures/frames/hello.html" data-turbo-frame="hello" data-turbo-action="advance">advance #hello</a>
 
     <turbo-frame id="nested-root" target="frame">
       <h2>Frames: #nested-root</h2>
@@ -104,5 +113,9 @@
     <form data-turbo-frame="frame" method="get" action="/src/tests/fixtures/frames/frame.html">
       <input id="outer-frame-submit" type="submit" value="Outer form submit">
     </form>
+
+    <hr class="push-off-screen">
+    <input id="below-the-fold-input">
+    <a id="below-the-fold-link-frame-action" data-turbo-action="advance" data-turbo-frame="frame" href="/src/tests/fixtures/frames/frame.html">Navigate #frame</a>
   </body>
 </html>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -7,7 +7,9 @@
   }
 
   function eventListener(event) {
-    eventLogs.push([event.type, event.detail, event.target.id])
+    const skipped = document.documentElement.getAttribute("data-skip-event-details") || ""
+
+    eventLogs.push([event.type, skipped.includes(event.type) ? {} : event.detail, event.target.id])
   }
   window.mutationLogs = []
 

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -288,13 +288,13 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.equal(await this.nextAttributeMutationNamed("frame", "aria-busy"), "true", "sets aria-busy on the <turbo-frame>")
     await this.nextEventOnTarget("frame", "turbo:before-fetch-request")
     await this.nextEventOnTarget("frame", "turbo:before-fetch-response")
-    await this.nextEventOnTarget("html", "turbo:before-visit")
-    await this.nextEventOnTarget("html", "turbo:visit")
     await this.nextEventOnTarget("frame", "turbo:frame-render")
     await this.nextEventOnTarget("frame", "turbo:frame-load")
     this.assert.notOk(await this.nextAttributeMutationNamed("frame", "aria-busy"), "removes aria-busy from the <turbo-frame>")
 
     this.assert.equal(await this.nextAttributeMutationNamed("html", "aria-busy"), "true", "sets aria-busy on the <html>")
+    await this.nextEventOnTarget("html", "turbo:before-visit")
+    await this.nextEventOnTarget("html", "turbo:visit")
     await this.nextEventOnTarget("html", "turbo:before-cache")
     await this.nextEventOnTarget("html", "turbo:before-render")
     await this.nextEventOnTarget("html", "turbo:render")
@@ -305,7 +305,7 @@ export class FrameTests extends TurboDriveTestCase {
   async "test navigating turbo-frame[data-turbo-action=advance] from within pushes URL state"() {
     await this.clickSelector("#add-turbo-action-to-frame")
     await this.clickSelector("#link-frame")
-    await this.nextBeat
+    await this.nextEventNamed("turbo:load")
 
     const title = await this.querySelector("h1")
     const frameTitle = await this.querySelector("#frame h2")
@@ -315,9 +315,59 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/frame.html")
   }
 
+  async "test navigating turbo-frame[data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state"() {
+    await this.clickSelector("#link-outside-frame-action-advance")
+    await this.nextEventNamed("turbo:load")
+    await this.clickSelector("#link-outside-frame-action-advance")
+    await this.nextEventNamed("turbo:load")
+    await this.clickSelector("#link-outside-frame-action-advance")
+    await this.nextEventNamed("turbo:load")
+
+    this.assert.equal(await this.attributeForSelector("#frame", "aria-busy"), null, "clears turbo-frame[aria-busy]")
+    this.assert.equal(await this.attributeForSelector("#html", "aria-busy"), null, "clears html[aria-busy]")
+    this.assert.equal(await this.attributeForSelector("#html", "data-turbo-preview"), null, "clears html[aria-busy]")
+  }
+
+  async "test navigating a turbo-frame with an a[data-turbo-action=advance] preserves page state"() {
+    await this.scrollToSelector("#below-the-fold-input")
+    await this.fillInSelector("#below-the-fold-input", "a value")
+    await this.clickSelector("#below-the-fold-link-frame-action")
+    await this.nextEventNamed("turbo:load")
+
+    const title = await this.querySelector("h1")
+    const frameTitle = await this.querySelector("#frame h2")
+    const src = await this.attributeForSelector("#frame", "src") ?? ""
+
+    this.assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+    this.assert.equal(await title.getVisibleText(), "Frames")
+    this.assert.equal(await frameTitle.getVisibleText(), "Frame: Loaded")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/frame.html")
+    this.assert.equal(await this.propertyForSelector("#below-the-fold-input", "value"), "a value", "preserves page state")
+
+    const { y } = await this.scrollPosition
+    this.assert.notEqual(y, 0, "preserves Y scroll position")
+  }
+
+  async "test a turbo-frame that has been driven by a[data-turbo-action] can be navigated normally"() {
+    await this.clickSelector("#remove-target-from-hello")
+    await this.clickSelector("#link-hello-advance")
+    await this.nextEventNamed("turbo:load")
+
+    this.assert.equal(await (await this.querySelector("h1")).getVisibleText(), "Frames")
+    this.assert.equal(await (await this.querySelector("#hello h2")).getVisibleText(), "Hello from a frame")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/hello.html")
+
+    await this.clickSelector("#hello a")
+    await this.nextEventOnTarget("hello", "turbo:frame-load")
+    await this.noNextEventNamed("turbo:load")
+
+    this.assert.equal(await (await this.querySelector("#hello h2")).getVisibleText(), "Frames: #hello")
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/hello.html")
+  }
+
   async "test navigating turbo-frame from within with a[data-turbo-action=advance] pushes URL state"() {
     await this.clickSelector("#link-nested-frame-action-advance")
-    await this.nextBeat
+    await this.nextEventNamed("turbo:load")
 
     const title = await this.querySelector("h1")
     const frameTitle = await this.querySelector("#frame h2")
@@ -329,7 +379,7 @@ export class FrameTests extends TurboDriveTestCase {
 
   async "test navigating frame with a[data-turbo-action=advance] pushes URL state"() {
     await this.clickSelector("#link-outside-frame-action-advance")
-    await this.nextBeat
+    await this.nextEventNamed("turbo:load")
 
     const title = await this.querySelector("h1")
     const frameTitle = await this.querySelector("#frame h2")
@@ -341,7 +391,7 @@ export class FrameTests extends TurboDriveTestCase {
 
   async "test navigating frame with form[method=get][data-turbo-action=advance] pushes URL state"() {
     await this.clickSelector("#form-get-frame-action-advance button")
-    await this.nextBeat
+    await this.nextEventNamed("turbo:load")
 
     const title = await this.querySelector("h1")
     const frameTitle = await this.querySelector("#frame h2")
@@ -349,11 +399,24 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.equal(await title.getVisibleText(), "Frames")
     this.assert.equal(await frameTitle.getVisibleText(), "Frame: Loaded")
     this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/frame.html")
+  }
+
+  async "test navigating frame with form[method=get][data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state"() {
+    await this.clickSelector("#form-get-frame-action-advance button")
+    await this.nextEventNamed("turbo:load")
+    await this.clickSelector("#form-get-frame-action-advance button")
+    await this.nextEventNamed("turbo:load")
+    await this.clickSelector("#form-get-frame-action-advance button")
+    await this.nextEventNamed("turbo:load")
+
+    this.assert.equal(await this.attributeForSelector("#frame", "aria-busy"), null, "clears turbo-frame[aria-busy]")
+    this.assert.equal(await this.attributeForSelector("#html", "aria-busy"), null, "clears html[aria-busy]")
+    this.assert.equal(await this.attributeForSelector("#html", "data-turbo-preview"), null, "clears html[aria-busy]")
   }
 
   async "test navigating frame with form[method=post][data-turbo-action=advance] pushes URL state"() {
     await this.clickSelector("#form-post-frame-action-advance button")
-    await this.nextBeat
+    await this.nextEventNamed("turbo:load")
 
     const title = await this.querySelector("h1")
     const frameTitle = await this.querySelector("#frame h2")
@@ -363,9 +426,22 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/frames/frame.html")
   }
 
+  async "test navigating frame with form[method=post][data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state"() {
+    await this.clickSelector("#form-post-frame-action-advance button")
+    await this.nextEventNamed("turbo:load")
+    await this.clickSelector("#form-post-frame-action-advance button")
+    await this.nextEventNamed("turbo:load")
+    await this.clickSelector("#form-post-frame-action-advance button")
+    await this.nextEventNamed("turbo:load")
+
+    this.assert.equal(await this.attributeForSelector("#frame", "aria-busy"), null, "clears turbo-frame[aria-busy]")
+    this.assert.equal(await this.attributeForSelector("#html", "aria-busy"), null, "clears html[aria-busy]")
+    this.assert.equal(await this.attributeForSelector("#html", "data-turbo-preview"), null, "clears html[aria-busy]")
+  }
+
   async "test navigating frame with button[data-turbo-action=advance] pushes URL state"() {
     await this.clickSelector("#button-frame-action-advance")
-    await this.nextBeat
+    await this.nextEventNamed("turbo:load")
 
     const title = await this.querySelector("h1")
     const frameTitle = await this.querySelector("#frame h2")
@@ -380,7 +456,7 @@ export class FrameTests extends TurboDriveTestCase {
     await this.clickSelector("#link-frame")
     await this.nextEventNamed("turbo:load")
     await this.goBack()
-    await this.nextBody
+    await this.nextEventNamed("turbo:load")
 
     const title = await this.querySelector("h1")
     const frameTitle = await this.querySelector("#frame h2")
@@ -395,9 +471,9 @@ export class FrameTests extends TurboDriveTestCase {
     await this.clickSelector("#link-frame")
     await this.nextEventNamed("turbo:load")
     await this.goBack()
-    await this.nextBody
+    await this.nextEventNamed("turbo:load")
     await this.goForward()
-    await this.nextBody
+    await this.nextEventNamed("turbo:load")
 
     const title = await this.querySelector("h1")
     const frameTitle = await this.querySelector("#frame h2")
@@ -415,6 +491,14 @@ export class FrameTests extends TurboDriveTestCase {
   async "test turbo:before-fetch-response fires on the frame element"() {
     await this.clickSelector("#hello a")
     this.assert.ok(await this.nextEventOnTarget("frame", "turbo:before-fetch-response"))
+  }
+
+  async fillInSelector(selector: string, value: string) {
+    const element = await this.querySelector(selector)
+
+    await element.click()
+
+    return element.type(value)
   }
 
   get frameScriptEvaluationCount(): Promise<number | undefined> {


### PR DESCRIPTION
The problem
---

The changes made in [444][] removed the `willRender:` Visit option in
favor of allowing Frame-to-Visit navigations to participate in the
entire Visit Rendering, Snapshot Caching, and History navigating
pipeline.

The way that the `willRender:` guard clause was removed caused new
issues in how Frame-to-Visit navigations were treated. Removing the
outer conditional without replacing it with matching checks elsewhere
has caused Frame-to-Visit navigations to re-render the entire page,
and losing the current contextual state like scroll, focus or anything
else that exists outside the `<turbo-frame>` element.

Similarly, the nature of the
`FrameController.proposeVisitIfNavigatedWithAction()` helper resulted in
an out-of-order dispatching of `turbo:` and `turbo:frame-` events, and
resulted in `turbo:before-visit` and `turbo:visit` events firing before
`turbo:frame-render` and `turbo:frame-load` events.

The solution
---

To resolve the rendering issues, this commit re-introduces the
`willRender:` option (originally introduced in [398][] and removed in
[444][]). The option is captured in the `Visit` constructor and passed
along the constructed `PageRenderer`. This commit adds the `willRender:`
property to the `PageRenderer` class, which defaults to `true` unless
specified as an argument. During `PageRenderer.render()` calls, the
`replaceBody()` call is only made if `willRender == true`.

To integrate with caching, this commit invokes the
`VisitDelegate.visitCachedSnapshot()` callback with the `Snapshot`
instance that is written to the `PageView.snapshotCache` so that the
`FrameController` can manage the before- and after-navigation HTML to
enable integration with navigating back and forward through the
browser's history.

To re-order the events, this commit replaces the
`frame.addEventListener("turbo:frame-render")` attachment with a one-off
`fetchResponseLoaded(FetchResponse)` callback that is assigned and reset
during the frame navigation. When present, that callback is invoked
_after_ the `turbo:load` event fires, which results in a much more
expected event order: `turbo:before-fetch-request`,
`turbo:before-fetch-response`, and `turbo:frame-` events fire first,
then the rest of the Visit's events fire.

The `fetchResponseLoaded(FetchResponse)` callback is an improvement, but
is still an awkward way to coordinate between the
`formSubmissionIntercepted()` and `linkClickIntercepted()` delegate
methods, the `FrameController` instance, and the `Session` instance.
It's functional for now, and we'll likely have a change to improve it
with work like what's proposed in [430][] (which we can take on while
developing `7.2.0`).

To ensure this behavior, this commit adds several new types of tests,
including coverage to make sure that the frame navigations can be
transformed into page Visits without lasting consequences to the
`<turbo-frame>` element. Similarly, another test ensures the
preservation of scroll state and input text state after a Frame-to-Visit
navigation.

There is one quirk worth highlighting: the `FrameTests` seem incapable
of using Selenium to serialize the `{ detail: { newBody: <body> } }`
value out of the driven Browser's environment and into the Test harness
environment. The event itself fires, but references a detached element
or instance that results in a [Stale Element Reference][]. To work
around that issue while delivering the bug fixes, this commit alters the
`frame.html` page's `<html>` to opt-out of serializing those events'
`event.detail` object (handled in
[src/tests/fixtures/test.js](./src/tests/fixtures/test.js)). All other
tests that assert about `turbo:` events (with `this.nextEventNamed` or
`this.nextEventOnTarget`) will continue to behave as normal, the
`FrameTests` is the sole exception.

[398]: https://github.com/hotwired/turbo/pull/398
[430]: https://github.com/hotwired/turbo/pull/430
[441]: https://github.com/hotwired/turbo/pull/441
[444]: https://github.com/hotwired/turbo/pull/444
[Stale Element Reference]: https://developer.mozilla.org/en-US/docs/Web/WebDriver/Errors/StaleElementReference