### PR TITLE
Add test coverage for event listener leaking

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -439,6 +439,7 @@ function activateElement(element: Element | null, currentURL?: string | null) {
 
     if (element instanceof FrameElement) {
       element.connectedCallback()
+      element.disconnectedCallback()
       return element
     }
   }

--- a/src/core/frames/frame_renderer.ts
+++ b/src/core/frames/frame_renderer.ts
@@ -29,7 +29,6 @@ export class FrameRenderer extends Renderer<FrameElement> {
     if (sourceRange) {
       sourceRange.selectNodeContents(frameElement)
       this.currentElement.appendChild(sourceRange.extractContents())
-      frameElement.disconnectedCallback()
     }
   }
 


### PR DESCRIPTION
Add test coverage for event listener leaking
===

Add test coverage to [hotwired/turbo#454][]. While the original fix was
important to ship, it was unclear how to guard against re-introducing
the leaks.

This commit introduces the `withoutChangingEventListenersCount()` test
helper to wrap a block within the test harness. While executing within
the block, the driven page's `document.addEventListener` and
`document.removeEventListener` functions are replaced with decorated
functions that increment and decrement a counter. At the start of the
block, capture and return how many times `addEventListener` has been
invoked without a matching `removeEventListener`. At the end, capture
and return the differential.

[hotwired/turbo#454]: https://github.com/hotwired/turbo/pull/454

Move the `disconnectedCallback()` call
===

The fix introduced in [hotwired/turbo#454][] resolved the issue, but
introduced a matching `disconnectedCallback()` far-off in the
`FrameRenderer`.

This commit moves that call to occur _immediately_ after it's paired
`element.connectedCallback()`.

[hotwired/turbo#454]: https://github.com/hotwired/turbo/pull/454
