### PR TITLE
Terribly, weakly support use as a git dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,9 @@
     "start": "node src/tests/runner.js serveOnly",
     "test": "NODE_OPTIONS=--inspect node src/tests/runner.js",
     "test:win": "SET NODE_OPTIONS=--inspect & node src/tests/runner.js",
-    "prerelease": "yarn build && git --no-pager diff && echo && npm pack --dry-run && echo && read -n 1 -p \"Look OK? Press any key to publish and commit v$npm_package_version\" && echo",
+    "prepare": "[ -d dist ] || yarn build",
+    "prepack": "yarn install",
+    "prerelease": "npm pack --dry-run && echo && git --no-pager diff && echo \"Look OK? Run `yarn release` to publish and commit v$npm_package_version\" && echo",
     "release": "npm publish && git commit -am \"$npm_package_name v$npm_package_version\" && git push"
   }
 }


### PR DESCRIPTION
Just a proof of concept to share in case anyone else wants to package from a specific git version without having to republish the package, vendor it, or proxy it. Not to be recommended, or merged. 😂

Add as a git dependency. Be sure to use the full git URL or else Yarn will install using a tarball and bypass the prepare script.
```bash
yarn add @hotwired/turbo@https://github.com/basecamp/turbo#build-from-git
```

Now the `prepare` script is triggered before install, including devDependencies, so we can use it to build IF we detect we're installing from git vs an npm package (based on the presence of the `dist/` dir). Hence, won't work on Windows because this assumes having a shell available; would have to wrap that up in a prepare.js instead.

Also note that Yarn has a history of [funky bugs](https://github.com/yarnpkg/yarn/issues/6312) with concurrent invocations like this, so you may need to pass `--network-concurrency 1` to your `yarn install` in CI and Dockerfiles and such.

Worse, Yarn and npm have diverged significantly with which scripts run and when, whether prepack or prepare. The whole thing is a regrettable morass. I apologize for sharing this, but figure someone will duck-duck-go for "yarn git dependency build" or some nonsense and need somewhere puzzling to land.

💀