### PR TITLE
Frames: Ignore already cancelled `submit` events

### DIFF
--- a/src/core/frames/form_interceptor.ts
+++ b/src/core/frames/form_interceptor.ts
@@ -22,7 +22,7 @@ export class FormInterceptor {
 
   submitBubbled = <EventListener>((event: SubmitEvent) => {
     const form = event.target
-    if (form instanceof HTMLFormElement && form.closest("turbo-frame, html") == this.element) {
+    if (!event.defaultPrevented && form instanceof HTMLFormElement && form.closest("turbo-frame, html") == this.element) {
       const submitter = event.submitter || undefined
       const method = submitter?.getAttribute("formmethod") || form.method
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -564,6 +564,15 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.notOk(await this.formSubmitStarted)
   }
 
+  async "test frame form submission ignores submissions with their defaultPrevented"() {
+    await this.evaluate(() => document.addEventListener("submit", (event) => event.preventDefault(), true))
+    await this.clickSelector("#frame .redirect [type=submit]")
+    await this.nextBeat
+
+    this.assert.equal(await (await this.querySelector("#frame h2")).getVisibleText(), "Frame: Form")
+    this.assert.equal(await this.attributeForSelector("#frame", "src"), null, "does not navigate frame")
+  }
+
   async "test form submission with [data-turbo=false] on the form"() {
     await this.clickSelector('#turbo-false form[data-turbo="false"] input[type=submit]')
     await this.nextBody


### PR DESCRIPTION
Closes [hotwired/turbo#243][]

In tandem with [rails/rails#41960][] (which shipped as part of
`7.0.0.alpha2`), this commit modifies the `FormInterceptor` to ignore
`submit` events that have been cancelled.

Although it doesn't test the integration directly, the cancellation of
the `submit` event is what powers the ActiveStorage.js direct upload
asynchrony. Following a direct upload, ActiveStorage dispatches a
synthetic `submit` event, which the `FormInterceptor` will then respond
to.

[hotwired/turbo#243]: https://github.com/hotwired/turbo/issues/243
[rails/rails#41960]: https://github.com/rails/rails/pull/41960