### PR TITLE
Perform scrolling prior to Visit completion

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -258,6 +258,7 @@ export class Visit implements FetchRequestDelegate {
         if (this.view.renderPromise) await this.view.renderPromise
         if (isSuccessful(statusCode) && responseHTML != null) {
           await this.view.renderPage(PageSnapshot.fromHTMLString(responseHTML), false, this.willRender, this)
+          this.performScroll()
           this.adapter.visitRendered(this)
           this.complete()
         } else {
@@ -300,6 +301,7 @@ export class Visit implements FetchRequestDelegate {
         } else {
           if (this.view.renderPromise) await this.view.renderPromise
           await this.view.renderPage(snapshot, isPreview, this.willRender, this)
+          this.performScroll()
           this.adapter.visitRendered(this)
           if (!isPreview) {
             this.complete()
@@ -324,6 +326,7 @@ export class Visit implements FetchRequestDelegate {
     if (this.isSamePage) {
       this.render(async () => {
         this.cacheSnapshot()
+        this.performScroll()
         this.adapter.visitRendered(this)
       })
     }
@@ -378,7 +381,7 @@ export class Visit implements FetchRequestDelegate {
   // Scrolling
 
   performScroll() {
-    if (!this.scrolled) {
+    if (!this.scrolled && !this.view.forceReloaded) {
       if (this.action == "restore") {
         this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()
       } else {
@@ -458,9 +461,6 @@ export class Visit implements FetchRequestDelegate {
     })
     await callback()
     delete this.frame
-    if (!this.view.forceReloaded) {
-      this.performScroll()
-    }
   }
 
   cancelRender() {

--- a/src/tests/fixtures/scroll/one.html
+++ b/src/tests/fixtures/scroll/one.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Scroll: One</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <style>
+      html { scroll-behavior: smooth; }
+      .push-below-fold { margin-top: 100vh; }
+    </style>
+  </head>
+  <body>
+    <h1>Scroll: One</h1>
+    <hr class="push-below-fold">
+    <a id="one-below-fold" href="/src/tests/fixtures/scroll/two.html#two-below-fold">two.html#two-below-fold</a>
+    <hr class="push-below-fold">
+  </body>
+</html>

--- a/src/tests/fixtures/scroll/two.html
+++ b/src/tests/fixtures/scroll/two.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Scroll: Two</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <style>
+      html { scroll-behavior: smooth; }
+      .push-below-fold { margin-top: 100vh; }
+    </style>
+  </head>
+  <body>
+    <h1>Scroll: Two</h1>
+    <hr class="push-below-fold">
+    <a id="two-below-fold" href="/src/tests/fixtures/scroll/one.html#one-below-fold">one.html#one-below-fold</a>
+    <hr class="push-below-fold">
+  </body>
+</html>

--- a/src/tests/fixtures/visit.html
+++ b/src/tests/fixtures/visit.html
@@ -5,6 +5,9 @@
     <title>Turbo</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
+    <style>
+      .push-below-fold { margin-top: 100vh; }
+    </style>
   </head>
   <body>
     <section>
@@ -12,6 +15,10 @@
       <p><a id="same-origin-link" href="/src/tests/fixtures/one.html">Same-origin link</a></p>
       <p><a id="same-origin-link-search-params" href="/src/tests/fixtures/one.html?key=value">Same-origin link with ?key=value</a></p>
       <p><a id="sample-response" href="/src/tests/fixtures/one.html">Sample response</a></p>
+      <p><a id="same-page-link" href="/src/tests/fixtures/visit.html">Same page link</a></p>
+      <hr class="push-below-fold">
+      <p><a id="below-the-fold-link" href="/src/tests/fixtures/one.html">one.html</a></p>
+      <hr class="push-below-fold">
     </section>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -592,7 +592,7 @@ test("test frame form submission with redirect response", async ({ page }) => {
 
   const button = await page.locator("#frame form.redirect input[type=submit]")
   await button.click()
-  await nextBeat()
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
   const message = await page.locator("#frame div.message")
   assert.notOk(await hasSelector(page, "#frame form.redirect"))


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/400

When processing a `Visit`, invoke `Visit.performScroll()` while loading
a response, loading a Snapshot, or executing a same-page anchor
navigation. After in-lining those calls to more appropriate points in
the Visit lifecycle, this commit removes the `performScroll()` call from
the `Visit.render()` method.
