### PR TITLE
Adds append_unless_duplicate and prepend_unless_duplicate

### DIFF
--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -10,12 +10,26 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
     this.targetElements.forEach(e => e.append(this.templateContent))
   },
 
+  append_unless_duplicate() {
+    if (this.hasDuplicateChildren) {
+      return
+    }
+    this.targetElements.forEach(e => e.append(this.templateContent))
+  },
+
   before() {
     this.targetElements.forEach(e => e.parentElement?.insertBefore(this.templateContent, e))
   },
 
   prepend() {
     this.removeDuplicateTargetChildren()
+    this.targetElements.forEach(e => e.prepend(this.templateContent))
+  },
+
+  prepend_unless_duplicate() {
+    if (this.hasDuplicateChildren) {
+      return
+    }
     this.targetElements.forEach(e => e.prepend(this.templateContent))
   },
 

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -9,7 +9,9 @@ import { nextAnimationFrame } from "../util"
  * Using the `action` attribute, this can be configured one of four ways:
  *
  * - `append` - appends the result to the container
+ * - `append_unless_duplicate` - appends the result to the container only if there are no duplicate children
  * - `prepend` - prepends the result to the container
+ * - `prepend_unless_duplicate` - prepends the result to the container only if there are no duplicate children
  * - `replace` - replaces the contents of the container
  * - `remove` - removes the container
  * - `before` - inserts the result before the target
@@ -64,6 +66,13 @@ export class StreamElement extends HTMLElement {
     const newChildrenIds   = [...this.templateContent?.children].filter(c => !!c.id).map(c => c.id)
   
     return existingChildren.filter(c => newChildrenIds.includes(c.id))
+  }
+
+  /**
+   * Checks for any duplicate children (i.e. those with the same ID)
+   */
+  get hasDuplicateChildren() {
+    return !!this.duplicateChildren.length
   }
   
 

--- a/src/tests/unit/stream_element_tests.ts
+++ b/src/tests/unit/stream_element_tests.ts
@@ -43,6 +43,42 @@ export class StreamElementTests extends DOMTestCase {
     this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo  tail1 New First Second tail2 ')
   }
 
+  async "test action=append_unless_duplicate"() {
+    const element = createStreamElement("append_unless_duplicate", "hello", createTemplateElement("<span> Streams</span>"))
+    const element2 = createStreamElement("append_unless_duplicate", "hello", createTemplateElement("<span> and more</span>"))
+
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo Streams")
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo Streams and more")
+    this.assert.isNull(element2.parentElement)
+  }
+
+  async "test action=append_unless_duplicate with children ID already present in target"() {
+    const element = createStreamElement("append_unless_duplicate", "hello", createTemplateElement(' <div id="child_1">First</div> tail1 '))
+    const element2 = createStreamElement("append_unless_duplicate", "hello", createTemplateElement('<div id="child_1">New First</div> <div id="child_2">Second</div> tail2 '))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo First tail1 ')
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'Hello Turbo First tail1 ')
+  }
+
   async "test action=prepend"() {
     const element = createStreamElement("prepend", "hello", createTemplateElement("<span>Streams </span>"))
     const element2 = createStreamElement("prepend", "hello", createTemplateElement("<span>and more </span>"))
@@ -76,6 +112,41 @@ export class StreamElementTests extends DOMTestCase {
     await nextAnimationFrame()
 
     this.assert.equal(this.find("#hello")?.textContent, 'New First Second tail2  tail1 Hello Turbo')
+  }
+
+  async "test action=prepend_unless_duplicate"() {
+    const element = createStreamElement("prepend_unless_duplicate", "hello", createTemplateElement("<span>Streams </span>"))
+    const element2 = createStreamElement("prepend_unless_duplicate", "hello", createTemplateElement("<span>and more </span>"))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, "Streams Hello Turbo")
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, "and more Streams Hello Turbo")
+    this.assert.isNull(element.parentElement)
+  }
+
+  async "test action=prepend_unless_duplicate with children ID already present in target"() {
+    const element = createStreamElement("prepend_unless_duplicate", "hello", createTemplateElement('<div id="child_1">First</div> tail1 '))
+    const element2 = createStreamElement("prepend_unless_duplicate", "hello", createTemplateElement('<div id="child_1">New First</div> <div id="child_2">Second</div> tail2 '))
+    this.assert.equal(this.find("#hello")?.textContent, "Hello Turbo")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'First tail1 Hello Turbo')
+    this.assert.isNull(element.parentElement)
+
+    this.append(element2)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.textContent, 'First tail1 Hello Turbo')
   }
 
   async "test action=remove"() {


### PR DESCRIPTION
When appending or prepending content we want to control what
the action should do if there are already matching elements
on the page.
This is especially true when responding and broadcasting streams
contain the same data.

Additional actions added to skip the action if elements are
already present. In this case it would be recommended to use
the `replace` action.