### PR TITLE
Custom Actions: Export `StreamActions` module

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -30,6 +30,8 @@ export { TurboSubmitStartEvent, TurboSubmitEndEvent } from "./drive/form_submiss
 export { TurboBeforeFetchRequestEvent, TurboBeforeFetchResponseEvent } from "../http/fetch_request"
 export { TurboBeforeStreamRenderEvent } from "../elements/stream_element"
 
+export { StreamActions } from "./streams/stream_actions"
+
 /**
  * Starts the main session.
  * This initialises any necessary observers such as those to monitor

--- a/src/tests/functional/stream_tests.ts
+++ b/src/tests/functional/stream_tests.ts
@@ -33,6 +33,24 @@ test("test receiving a stream message with css selector target", async ({ page }
   assert.equal(await element[1], "Hello CSS!")
 })
 
+test("test overriding with custom StreamActions", async ({ page }) => {
+  const html = "Rendered with Custom Action"
+
+  await page.evaluate((html) => {
+    window.Turbo.StreamActions.customUpdate = function () {
+      for (const target of this.targetElements) target.innerHTML = html
+    }
+    document.body.insertAdjacentHTML(
+      "afterbegin",
+      `<turbo-stream action="customUpdate" target="messages">
+        <template></template>
+      </turbo-stream>`
+    )
+  }, html)
+
+  assert.equal(await page.textContent("#messages"), html, "evaluates custom StreamAction")
+})
+
 test("test receiving a stream message asynchronously", async ({ page }) => {
   let messages = await page.locator("#messages > *").allTextContents()
 


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/pull/478
Closes https://github.com/hotwired/turbo/pull/477

As an alternative to continuing to introduce support for more varied and
specialized `<turbo-stream action="...">` values, this commit exports
the `StreamActions` module from the root-module in order to provide
applications with direct access.

Applications can add new actions or override existing actions, so long
as they adhere to the `StreamAction` interface: a function whose `this`
context is an instance of `StreamElement`.