### PR TITLE
Defensively create custom turbo elements

### DIFF
--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -7,5 +7,10 @@ FrameElement.delegateConstructor = FrameController
 export * from "./frame_element"
 export * from "./stream_element"
 
-customElements.define("turbo-frame", FrameElement)
-customElements.define("turbo-stream", StreamElement)
+if (customElements.get("turbo-frame") === undefined) {
+  customElements.define("turbo-frame", FrameElement)
+}
+
+if (customElements.get("turbo-stream") === undefined) {
+  customElements.define("turbo-stream", StreamElement)
+}


### PR DESCRIPTION
There are instances when turbo attempts to create the frame and stream
elements when they have already been registered. This is easily
reproducible in development when using webpacker by following these steps:

* Make a change to any file that webpacker compiles.
* Click a turbo enabled link.
* Boom.

When Turbo replaces the page it appears as if it reloads the Turbo
library and attempts to create the custom elements again. I have also
observed this behavior in my production app via my exception monitoring
service, but have been unable to reproduce this behavior in production
on my own.

This change simply checks for the existence of the custom element prior
to to attempting to define it. The `get` method used here explicitly
returns `undefined` when the element does not yet exist so it is safe to
use the strict equality operator here. Reference:
https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/get

Fixes #188