### PR TITLE
Clear cache on non-GET form submit

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -87,7 +87,8 @@ export class Navigator {
     if (formSubmission == this.formSubmission) {
       const responseHTML = await fetchResponse.responseHTML
       if (responseHTML) {
-        if (formSubmission.method != FetchMethod.get) {
+        const shouldCacheSnapshot = (formSubmission.method == FetchMethod.get)
+        if (!shouldCacheSnapshot) {
           this.view.clearSnapshotCache()
         }
 
@@ -95,6 +96,7 @@ export class Navigator {
         const action = this.getActionForFormSubmission(formSubmission)
         const visitOptions = {
           action,
+          shouldCacheSnapshot,
           response: { statusCode, responseHTML, redirected },
         }
         this.proposeVisit(fetchResponse.location, visitOptions)

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -87,7 +87,7 @@ export class Navigator {
     if (formSubmission == this.formSubmission) {
       const responseHTML = await fetchResponse.responseHTML
       if (responseHTML) {
-        const shouldCacheSnapshot = (formSubmission.method == FetchMethod.get)
+        const shouldCacheSnapshot = formSubmission.method == FetchMethod.get
         if (!shouldCacheSnapshot) {
           this.view.clearSnapshotCache()
         }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -102,7 +102,16 @@ export class Visit implements FetchRequestDelegate {
     this.location = location
     this.restorationIdentifier = restorationIdentifier || uuid()
 
-    const { action, historyChanged, referrer, snapshotHTML, response, visitCachedSnapshot, willRender, shouldCacheSnapshot } = {
+    const {
+      action,
+      historyChanged,
+      referrer,
+      snapshotHTML,
+      response,
+      visitCachedSnapshot,
+      willRender,
+      shouldCacheSnapshot,
+    } = {
       ...defaultOptions,
       ...options,
     }

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -47,6 +47,10 @@
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
         <button data-turbo-action="replace">Same-origin form[method="post"] button[data-turbo-action="replace"]</button>
       </form>
+      <form id="form-post" method="post" action="/__turbo/redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="submit" id="form-post-submit" value="Submit"/>
+      </form>
       <p><a id="same-origin-false-link" href="/src/tests/fixtures/one.html" data-turbo="false">Same-origin data-turbo=false link</a></p>
       <p data-turbo="false"><a id="same-origin-unannotated-link-inside-false-container" href="/src/tests/fixtures/one.html">Same-origin unannotated link inside data-turbo=false container</a></p>
       <p data-turbo="false"><a id="same-origin-true-link-inside-false-container" href="/src/tests/fixtures/one.html" data-turbo="true">Same-origin data-turbo=true link inside data-turbo=false container</a></p>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -146,7 +146,6 @@ test("test standard POST form submission events", async ({ page }) => {
 
   await nextEventNamed(page, "turbo:before-visit")
   await nextEventNamed(page, "turbo:visit")
-  await nextEventNamed(page, "turbo:before-cache")
   await nextEventNamed(page, "turbo:before-render")
   await nextEventNamed(page, "turbo:render")
   await nextEventNamed(page, "turbo:load")

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -136,7 +136,7 @@ test("test following a same-origin POST form button[data-turbo-action=replace]",
   assert.equal(await visitAction(page), "replace")
 })
 
-test("test following a POST form clears cache", async({ page }) => {
+test("test following a POST form clears cache", async ({ page }) => {
   await page.evaluate(() => {
     const cachedElement = document.createElement("some-cached-element")
     document.body.appendChild(cachedElement)

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -136,6 +136,19 @@ test("test following a same-origin POST form button[data-turbo-action=replace]",
   assert.equal(await visitAction(page), "replace")
 })
 
+test("test following a POST form clears cache", async({ page }) => {
+  await page.evaluate(() => {
+    const cachedElement = document.createElement("some-cached-element")
+    document.body.appendChild(cachedElement)
+  })
+
+  page.click("#form-post-submit")
+  await nextBeat // 301 redirect response
+  await nextBeat // 200 response
+  await page.goBack()
+  assert.notOk(await hasSelector(page, "some-cached-element"))
+})
+
 test("test following a same-origin data-turbo=false link", async ({ page }) => {
   page.click("#same-origin-false-link")
   await nextBody(page)

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -142,9 +142,9 @@ test("test following a POST form clears cache", async ({ page }) => {
     document.body.appendChild(cachedElement)
   })
 
-  page.click("#form-post-submit")
-  await nextBeat // 301 redirect response
-  await nextBeat // 200 response
+  await page.click("#form-post-submit")
+  await nextBeat() // 301 redirect response
+  await nextBeat() // 200 response
   await page.goBack()
   assert.notOk(await hasSelector(page, "some-cached-element"))
 })


### PR DESCRIPTION
Closes #193

When handling a form submission, turbo clears cache but then re-creates a cache of the current page before navigating to the new page.

```javascript
  async formSubmissionSucceededWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse) {
    if (formSubmission == this.formSubmission) {
      ///...
      if (responseHTML) {
        if (formSubmission.method != FetchMethod.get) {
          this.view.clearSnapshotCache() //<= clear cache
        }

        ///...
        this.proposeVisit(fetchResponse.location, visitOptions) //<= recreates cache
      }
    }
  }
```