### PR TITLE
Fix links with a `data-turbo-method` specified and Turbo.session.drive set to false

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -147,6 +147,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
       form.method = linkMethod
       form.action = link.getAttribute("href") || "undefined"
       form.hidden = true
+      form.setAttribute("data-turbo", "true")
 
       if (link.hasAttribute("data-turbo-confirm")) {
         form.setAttribute("data-turbo-confirm", link.getAttribute("data-turbo-confirm")!)


### PR DESCRIPTION
If a user has `Turbo.session.drive` set to `false`, then using `data-turbo-method` on a link will not work, because the form injected by Turbo will not be handled by turbo because the form does not have a `data-turbo="true"` attribute.

This bug has existed for a while, but I didn't run into until #341 was merged. Usually I will enable turbo for a section of the DOM with a `data-turbo="true"` attribute on a nearby parent element. This worked fine because the form that was created was injected adjacent to the link and so they shared a common parent with the `data-turbo="true"` attribute. But since #341, the form now gets injected at the bottom of the body so that links with a data-turbo-method will still work even if they are inside a `<form>` element. But they now no longer share a common ancestor chain and so won't have the same turbo enabled state.

This PR assumes that if turbo is handling the link, then it should also handle the form, which I think is a reasonable assumption. As a user of Turbo, I don't really want to think about or need to be aware of the fact that a form has been created and is the thing submitting the request.