### PR TITLE
Progress Bar Won't Render if CSP is Turned On

### DIFF
--- a/src/core/drive/progress_bar.ts
+++ b/src/core/drive/progress_bar.ts
@@ -110,6 +110,9 @@ export class ProgressBar {
     const element = document.createElement("style")
     element.type = "text/css"
     element.textContent = ProgressBar.defaultCSS
+    if (this.cspNonce) {
+      element.nonce = this.cspNonce
+    }
     return element
   }
 
@@ -117,5 +120,9 @@ export class ProgressBar {
     const element = document.createElement("div")
     element.className = "turbo-progress-bar"
     return element
+  }
+
+  get cspNonce() {
+    return document.head.querySelector('meta[name="csp-nonce"]')?.getAttribute("content")
   }
 }

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="csp-nonce" content="123" />
     <title>Turbo</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -40,6 +40,7 @@
       <p><a id="permanent-element-link" href="/src/tests/fixtures/permanent_element.html">Permanent element</a></p>
       <p><a id="permanent-in-frame-element-link" href="/src/tests/fixtures/permanent_element.html" data-turbo-frame="frame">Permanent element in frame</a></p>
       <p><a id="permanent-in-frame-without-layout-element-link" href="/src/tests/fixtures/frames/without_layout.html" data-turbo-frame="frame">Permanent element in frame without layout</a></p>
+      <p><a id="delayed-link" href="/__turbo/delayed_response">Delayed link</a></p>
     </section>
     <div id="permanent" data-turbo-permanent>Rendering</div>
 

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -17,6 +17,14 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert(await newBody.equals(await this.body))
   }
 
+  async "test progress bar inline style has nonce"() {
+    await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
+    await this.clickSelector("#delayed-link")
+
+    await this.waitUntilSelector(".turbo-progress-bar")
+    this.assert.ok(await this.hasSelector(".turbo-progress-bar[nonce=123]"), "displays progress bar")
+  }
+
   async "test triggers before-render and render events for error pages"() {
     this.clickSelector("#nonexistent-link")
     const { newBody } = await this.nextEventNamed("turbo:before-render")

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -21,8 +21,7 @@ export class RenderingTests extends TurboDriveTestCase {
     await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
     await this.clickSelector("#delayed-link")
 
-    await this.waitUntilSelector(".turbo-progress-bar")
-    this.assert.ok(await this.hasSelector(".turbo-progress-bar[nonce=123]"), "displays progress bar")
+    this.assert.ok(await this.hasSelector("script[nonce='123']"), "displays progress bar")
   }
 
   async "test triggers before-render and render events for error pages"() {


### PR DESCRIPTION
Progress Bar injects inline `<style />` element to page. However, when Content Security Policy is turned on and `nonce` is generated - Progress Bar element ignores that.

This PR fixes that and checks if `csp-nonce` is set in `meta` tags. Then it uses it to create inline style.

Update: I don't know why test is failing and is generating `<style />` without `nonce` being set. However, when testing manually - this fix works. I might need some help here from someone more experienced in writing JS tests.