### PR TITLE
Add before callback to form link

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -98,6 +98,12 @@ export function setProgressBarDelay(delay: number) {
   session.setProgressBarDelay(delay)
 }
 
+export function setLinkToFormBeforeCallback(
+  callback: (element: HTMLFormElement) => void
+) {
+  session.setLinkToFormBeforeCallback(callback);
+}
+
 export function setConfirmMethod(confirmMethod: (message: string, element: HTMLFormElement)=>boolean) {
   FormSubmission.confirmMethod = confirmMethod
 }

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -40,6 +40,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
   enabled = true
   progressBarDelay = 500
   started = false
+  linkToFormBeforeCallback: null | ((formElement: HTMLFormElement) => void) = null;
 
   start() {
     if (!this.started) {
@@ -102,6 +103,10 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     this.progressBarDelay = delay
   }
 
+  setLinkToFormBeforeCallback(callback: (formElement: HTMLFormElement) => void) {
+    this.linkToFormBeforeCallback = callback;
+  }
+
   get location() {
     return this.history.location
   }
@@ -147,6 +152,10 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
       form.method = linkMethod
       form.action = link.getAttribute("href") || "undefined"
       form.hidden = true
+
+      if (this.linkToFormBeforeCallback) {
+        this.linkToFormBeforeCallback(form);
+      }
 
       if (link.hasAttribute("data-turbo-confirm")) {
         form.setAttribute("data-turbo-confirm", link.getAttribute("data-turbo-confirm")!)

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -277,6 +277,7 @@
       <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-within-form-outside-frame">Method link within form outside frame</a><br />
       <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-within-form-outside-frame">Stream link within form outside frame</a>
     </form>
+    <a href="/__turbo/redirect" data-turbo-method="delete" id="delete-link-method">Delete something</a>
     <hr>
     <form method="post" action="https://httpbin.org/post">
       <button id="submit-external">POST to https://httpbin.org/post</button>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -777,6 +777,25 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await message.getVisibleText(), "Link!")
   }
 
+  async "test form link with before callback"() {
+    await this.remote.execute(() => window.Turbo.setLinkToFormBeforeCallback((form) => {
+      if (form.getAttribute('method') !== 'delete') return;
+
+      const input = document.createElement("input");
+      input.setAttribute("name", "_method")
+      input.setAttribute("type", "hidden")
+      input.setAttribute("value", "delete")
+
+      form.method = 'post'
+      form.appendChild(input)
+    }))
+
+    await this.clickSelector("#delete-link-method")
+    await this.nextBody
+
+    this.assert.equal(await this.getSearchParam("_method"), "delete")
+  }
+
   async "test turbo:before-fetch-request fires on the form element"() {
     await this.clickSelector('#targets-frame form.one [type="submit"]')
     this.assert.ok(await this.nextEventOnTarget("form_one", "turbo:before-fetch-request"))


### PR DESCRIPTION
This pr adds a callback to the form link that is executed in `convertLinkWithMethodClickToFormSubmission`.

With this callback we could add some custom behavior like this:
```js
Turbo.setLinkToFormBeforeCallback((form) => {
  if (form.getAttribute('method') !== 'delete') return;
  
  const input = document.createElement("input");
  input.setAttribute("name", "_method")
  input.setAttribute("type", "hidden")
  input.setAttribute("value", "delete")
  
  form.method = 'post'
  form.appendChild(input)
})
``` 
This little script converts the links with the `delete` method to `post` and also adds a `_method` field with a `delete` value in the form link.

Notes: 
1. We also could add this script to turbo-rails in order to fix this https://github.com/hotwired/turbo-rails/issues/259
2. I'm open to suggestions to find a better name 😅 


 
