### PR TITLE
Bug: `getUserMedia` doesn't work reliably with Turbo on some iOS versions

### DIFF
--- a/src/tests/fixtures/page_with_webcam.html
+++ b/src/tests/fixtures/page_with_webcam.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Page with webcam</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="test" content="foo">
+  </head>
+  <body>
+    <h1>Page with webcam</h1>
+
+    <video autoplay muted playsinline id="video"></video>
+
+    <script>
+      window.navigator.mediaDevices
+        .getUserMedia({ video: true })
+        .then((stream) => {
+          document.getElementById("video").srcObject = stream
+        })
+    </script>
+  </body>
+</html>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -30,6 +30,7 @@
     <section>
       <h1>Rendering</h1>
       <p><a id="same-origin-link" href="/src/tests/fixtures/one.html">Same-origin link</a></p>
+      <p><a id="link-to-page-with-webcam" href="/src/tests/fixtures/page_with_webcam.html">Page with webcam</a></p>
       <p><a id="tracked-asset-change-link" href="/src/tests/fixtures/tracked_asset_change.html">Tracked asset change</a></p>
       <p><a id="tracked-nonce-tag-link" href="/src/tests/fixtures/tracked_nonce_tag.html">Tracked nonce tag</a></p>
       <p><a id="additional-assets-link" href="/src/tests/fixtures/additional_assets.html">Additional assets</a></p>


### PR DESCRIPTION
I haven't figured out exactly how to write a test for this. But pushing this as a replication example.

To replicate:

- [Run the test server](https://github.com/hotwired/turbo/blob/main/CONTRIBUTING.md)
- Use a tool like `ngrok` to make the test server accessible over the internet
- On your iPhone, using Safari, go to the test server at `<ngrok URL>/src/tests/fixtures/rendering.html`
- Tap on "Page with webcam"
- On the next page, you'll get a prompt to permit access to the camera
- Tap "approve"
- On some iOS versions, you won't see a camera feed. On some you will.

On iOS 14.4.2 you don't see a camera feed (or at least, I don't). On iOS 15.0.2 you do (or at least, I do).

I'm not sure this is is a Turbo issue, but I am creating it here because the issue doesn't exist without Turbo:

- If you navigate to `src/tests/fixtures/page_with_webcam.html` then the video feed shows, on every browser I've tested. It only breaks (on some phones) when you get there via a link.
- Using `data-turbo=false` on the link makes the issue go away too.

Here's a video of the issue: https://drive.google.com/file/d/1Jl0epNA4Xe35yjiC-KEwc10BHavqwZct/view?usp=sharing. The first time I tap the link (with Turbo), nothing shows. When I refresh (ie. load without Turbo), the video feed shows.

Hopefully someone's come across this before and/or has an idea for how to fix it!