### PR TITLE
Remove isHTML

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -2,13 +2,14 @@ import { Action, isAction } from "../types"
 import { FetchMethod } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { FormSubmission } from "./form_submission"
-import { expandURL, getAnchor, getRequestURL, Locatable, locationIsVisitable } from "../url"
+import { expandURL, getAnchor, getRequestURL, Locatable } from "../url"
 import { getAttribute } from "../../util"
 import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
   allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
+  locationIsVisitable(location: URL, rootLocation: URL): boolean
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>): void
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
@@ -25,7 +26,7 @@ export class Navigator {
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
     if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
-      if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
+      if (this.delegate.locationIsVisitable(location, this.view.snapshot.rootLocation)) {
         this.delegate.visitProposedToLocation(location, options)
       } else {
         window.location.href = location.toString()

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -20,7 +20,7 @@ import {
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
 import { ViewDelegate, ViewRenderOptions } from "../view"
-import { Locatable, getAction, expandURL, urlsAreEqual, locationIsVisitable } from "../url"
+import { Locatable, getAction, expandURL, urlsAreEqual } from "../url"
 import { FormSubmitObserver, FormSubmitObserverDelegate } from "../../observers/form_submit_observer"
 import { FrameView } from "./frame_view"
 import { LinkClickObserver, LinkClickObserverDelegate } from "../../observers/link_click_observer"
@@ -459,7 +459,7 @@ export class FrameController
   private formActionIsVisitable(form: HTMLFormElement, submitter?: HTMLElement) {
     const action = getAction(form, submitter)
 
-    return locationIsVisitable(expandURL(action), this.rootLocation)
+    return session.locationIsVisitable(expandURL(action), this.rootLocation)
   }
 
   private shouldInterceptNavigation(element: Element, submitter?: HTMLElement) {

--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -1,6 +1,6 @@
 import { FormSubmitObserver, FormSubmitObserverDelegate } from "../../observers/form_submit_observer"
 import { FrameElement } from "../../elements/frame_element"
-import { expandURL, getAction, locationIsVisitable } from "../url"
+import { expandURL, getAction } from "../url"
 import { LinkClickObserver, LinkClickObserverDelegate } from "../../observers/link_click_observer"
 import { Session, TurboClickEvent } from "../session"
 import { dispatch } from "../../util"
@@ -69,7 +69,7 @@ export class FrameRedirector implements LinkClickObserverDelegate, FormSubmitObs
     const meta = this.element.ownerDocument.querySelector<HTMLMetaElement>(`meta[name="turbo-root"]`)
     const rootLocation = expandURL(meta?.content ?? "/")
 
-    return this.shouldRedirect(form, submitter) && locationIsVisitable(action, rootLocation)
+    return this.shouldRedirect(form, submitter) && this.session.locationIsVisitable(action, rootLocation)
   }
 
   private shouldRedirect(element: Element, submitter?: HTMLElement) {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -6,7 +6,7 @@ import { FrameRedirector } from "./frames/frame_redirector"
 import { History, HistoryDelegate } from "./drive/history"
 import { LinkClickObserver, LinkClickObserverDelegate } from "../observers/link_click_observer"
 import { FormLinkClickObserver, FormLinkClickObserverDelegate } from "../observers/form_link_click_observer"
-import { getAction, expandURL, locationIsVisitable, Locatable } from "./url"
+import { getAction, getExtension, expandURL, isPrefixedBy, Locatable } from "./url"
 import { Navigator, NavigatorDelegate } from "./drive/navigator"
 import { PageObserver, PageObserverDelegate } from "../observers/page_observer"
 import { ScrollObserver } from "../observers/scroll_observer"
@@ -136,6 +136,14 @@ export class Session
     this.view.clearSnapshotCache()
   }
 
+  isVisitable(url: URL) {
+    return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml|php))$/)
+  }
+
+  locationIsVisitable(location: URL, rootLocation: URL) {
+    return isPrefixedBy(location, rootLocation) && this.isVisitable(location)
+  }
+
   setProgressBarDelay(delay: number) {
     this.progressBarDelay = delay
   }
@@ -176,7 +184,7 @@ export class Session
   // Form click observer delegate
 
   willSubmitFormLinkToLocation(link: Element, location: URL): boolean {
-    return this.elementIsNavigatable(link) && locationIsVisitable(location, this.snapshot.rootLocation)
+    return this.elementIsNavigatable(link) && this.locationIsVisitable(location, this.snapshot.rootLocation)
   }
 
   submittedFormLinkToLocation() {}
@@ -186,7 +194,7 @@ export class Session
   willFollowLinkToLocation(link: Element, location: URL, event: MouseEvent) {
     return (
       this.elementIsNavigatable(link) &&
-      locationIsVisitable(location, this.snapshot.rootLocation) &&
+      this.locationIsVisitable(location, this.snapshot.rootLocation) &&
       this.applicationAllowsFollowingLinkToLocation(link, location, event)
     )
   }
@@ -239,7 +247,7 @@ export class Session
 
     return (
       this.submissionIsNavigatable(form, submitter) &&
-      locationIsVisitable(expandURL(action), this.snapshot.rootLocation)
+      this.locationIsVisitable(expandURL(action), this.snapshot.rootLocation)
     )
   }
 

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -24,17 +24,9 @@ export function getExtension(url: URL) {
   return (getLastPathComponent(url).match(/\.[^.]*$/) || [])[0] || ""
 }
 
-export function isHTML(url: URL) {
-  return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml|php))$/)
-}
-
 export function isPrefixedBy(baseURL: URL, url: URL) {
   const prefix = getPrefix(url)
   return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
-}
-
-export function locationIsVisitable(location: URL, rootLocation: URL) {
-  return isPrefixedBy(location, rootLocation) && isHTML(location)
 }
 
 export function getRequestURL(url: URL) {

--- a/src/tests/fixtures/visitable.html
+++ b/src/tests/fixtures/visitable.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Visitable</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Visitable</h1>
+
+    <div>
+      <a id="link" href="/src/tests/fixtures/visitable.html">link</a>
+    </div>
+  </body>
+</html>

--- a/src/tests/functional/visitable_tests.ts
+++ b/src/tests/functional/visitable_tests.ts
@@ -1,0 +1,31 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBody, pathname, visitAction } from "../helpers/page"
+
+const path = "/src/tests/fixtures/visitable.html"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(path)
+})
+
+test("test user-defined visitable URL", async ({ page }) => {
+  await page.evaluate(() => {
+    window.Turbo.session.isVisitable = (_url) => true
+  })
+
+  page.click("#link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), path)
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test user-defined unvisitable URL", async ({ page }) => {
+  await page.evaluate(() => {
+    window.Turbo.session.isVisitable = (_url) => false
+  })
+
+  page.click("#link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), path)
+  assert.equal(await visitAction(page), "load")
+})


### PR DESCRIPTION
Hello,

Before **Turbo** will make a request it checks URL against regexp. The check passes for URLs without a file extension and those ending with `.htm`, `.html` and `.xhtml`. On success request is made using **Turbo** and on failure whole page is replaced.

I would like to propose removing `isHTML` function. Results of `isHTML` call are highly dubious and should not be trusted.

*Example 1*: Lets say there is a `download` action that maps to `/download` URL path. Response type of it would be `application/octet-stream` but **Turbo** will assume that it is HTML. 

*Example 2*: For URLs like `https://github.com/hotwired/turbo/blob/main/README.md` where parameter is part of path **Turbo** will fail to recognize browsable URL.

I believe a better approach would be to try to open everything by default and require to explicitly mark unbrowsable links with `data-turbo=”false”`. That would remove a bunch of unobvious URL problems like these mentioned above.

Moreover, currently its impossible to force **Turbo** visit as setting `data-turbo` to `true` triggers default behavior (that calls `isHTML`) and normal request instead of **Turbo** request is made (if `isHTML` will return `false`).

The change is a breaking one because it requires unbrowsable links to have `data-turbo=”false”` attribute added (not the case currently) but I believe it would result in more predictable less error prone behaviour in general.

Also after removing `isHTML` `locationIsVisitable` is reduced to return just the value of `isPrefixedBy` and is somewhat obsolete. So I replaced calls to `locationIsVisitable` with `isPrefixedBy`.

There are some disscussions regarding `isHTML` probems already open: #185, #385, #480.

Cheers
🍷 