### PR TITLE
Do not declare global types/constants

### DIFF
--- a/src/polyfills/submit-event.ts
+++ b/src/polyfills/submit-event.ts
@@ -41,3 +41,6 @@ function clickCaptured(event: Event) {
     }
   })
 })()
+
+// Ensure TypeScript parses this file as a module
+export {}


### PR DESCRIPTION
The submit-event polyfill was being interpreted by TSC as a script and not a module.

This caused all the declarations there to be treated as global in the exported types.

Fixes #523 