### PR TITLE
Await for confirm method results

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -51,8 +51,8 @@ export class FormSubmission {
   state = FormSubmissionState.initialized
   result?: FormSubmissionResult
 
-  static confirmMethod(message: string, _element: HTMLFormElement): boolean {
-    return confirm(message)
+  static confirmMethod(message: string, _element: HTMLFormElement): Promise<boolean> {
+    return Promise.resolve(confirm(message))
   }
 
   constructor(
@@ -121,7 +121,7 @@ export class FormSubmission {
     const { initialized, requesting } = FormSubmissionState
 
     if (this.needsConfirmation) {
-      const answer = FormSubmission.confirmMethod(this.confirmationMessage!, this.formElement)
+      const answer = await FormSubmission.confirmMethod(this.confirmationMessage!, this.formElement)
       if (!answer) {
         return
       }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -99,6 +99,6 @@ export function setProgressBarDelay(delay: number) {
   session.setProgressBarDelay(delay)
 }
 
-export function setConfirmMethod(confirmMethod: (message: string, element: HTMLFormElement) => boolean) {
+export function setConfirmMethod(confirmMethod: (message: string, element: HTMLFormElement) => Promise<boolean>) {
   FormSubmission.confirmMethod = confirmMethod
 }

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -57,7 +57,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
   }
 
   async "test from submission with confirmation overriden"() {
-    await this.remote.execute(() => window.Turbo.setConfirmMethod(() => confirm("Overriden message")))
+    await this.remote.execute(() => window.Turbo.setConfirmMethod(() => Promise.resolve(confirm("Overriden message"))))
 
     await this.clickSelector("#standard form.confirm input[type=submit]")
 


### PR DESCRIPTION
The browser's `confirm` is synchronous and waits for a boolean. This is really convenient, but makes it painful to implement a custom confirm modal in Boostrap, Tailwind, etc.

This PR adds `await` so a custom `confirm` can return a promise that waits until the user confirms or cancels the operation.

The overridden confirm method simply needs to return a Promise that resolves to `true` or `false.
```js

Turbo.setConfirmMethod(() => {
  return new Promise((resolve, reject) => {
    // show modal
    // on confirm, resolve(true)
    // on cancel, resolve(false)
  })
})

```

Closes #522


Example of it in action:
https://user-images.githubusercontent.com/67093/151271318-5034bbff-6b24-462f-89f7-8e6e3f8d0466.mp4
