### PR TITLE
set turbo-progress-bar z-index to max value

### DIFF
--- a/src/core/drive/progress_bar.ts
+++ b/src/core/drive/progress_bar.ts
@@ -12,7 +12,7 @@ export class ProgressBar {
         left: 0;
         height: 3px;
         background: #0076ff;
-        z-index: 9999;
+        z-index: 2147483647;
         transition:
           width ${ProgressBar.animationDuration}ms ease-out,
           opacity ${ProgressBar.animationDuration / 2}ms ${ProgressBar.animationDuration / 2}ms ease-in;


### PR DESCRIPTION
Many websites use z-index to display top bars, headers, staff bars, etc. 

When I tried to use Turbo on a site, I noticed this exact problem. Some developer somewhere had made a staff bar which has z-index set to `9999`. The Turbo progress bar wasn't visible. 

I considered changing this to `99999` (5 nines) to up the ante and make sure Turbo won this particular battle, but it doesn't win the war. Setting `z-index` to some arbitrarily high value is common practice, and often times is set to some N number of 9s value, such as `9999` or `99999` or `999999999`. It's hard to enforce a rule for developers to use some maximum value, and the usual response to something not working is just to tack another 9 on.

I propose we go nuclear, and set z-index to `2147483647` which I believe to be the highest z-index value possible in the CSS spec. No one can beat this number. Turbo Progress Bar will remain the boss of z-index, and tacking more 9s onto other elements will not mean Turbo's Progress Bar has to live under the shadow of other elements that wish to claim its title.