### PR TITLE
Resolve progress bar test suite failure

### DIFF
--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -2,6 +2,7 @@
 <html id="html">
   <head>
     <meta charset="utf-8">
+    <meta name="csp-nonce" content="123">
     <title>Turbo</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -2,7 +2,6 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <meta name="csp-nonce" content="123" />
     <title>Turbo</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -6,6 +6,10 @@ export class NavigationTests extends TurboDriveTestCase {
   }
 
   async "test navigating renders a progress bar"() {
+    const styleElement = await this.querySelector("style")
+
+    this.assert.equal(await styleElement.getProperty("nonce"), "123", "renders progress bar stylesheet inline with nonce")
+
     await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
     await this.clickSelector("#delayed-link")
 

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -17,13 +17,6 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert(await newBody.equals(await this.body))
   }
 
-  async "test progress bar inline style has nonce"() {
-    await this.remote.execute(() => window.Turbo.setProgressBarDelay(0))
-    await this.clickSelector("#delayed-link")
-
-    this.assert.ok(await this.hasSelector("script[nonce='123']"), "displays progress bar")
-  }
-
   async "test triggers before-render and render events for error pages"() {
     this.clickSelector("#nonexistent-link")
     const { newBody } = await this.nextEventNamed("turbo:before-render")


### PR DESCRIPTION
Merging [hotwired/turbo#501][] into `main` introduced a [consistent
failure to the test suite][ci-failure]:

```
× firefox on linux 5.11.0-1022-azure - RenderingTests - progress bar inline style has nonce (0.32s)
458
    AssertionError: displays progress bar: expected false to be truthy
459
      at RenderingTests.test progress bar inline style has nonce @ src/tests/functional/rendering_tests.ts:24:16
460
      at processTicksAndRejections @ internal/process/task_queues.js:97:5
461
      at async RenderingTests.runTest @ src/tests/helpers/intern_test_case.ts:43:6
```

This commit re-structures the test to make the same assertion (replacing
the [script][] tagname with [style][]).

[script]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/script
[style]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/style
[ci-failure]: https://github.com/hotwired/turbo/runs/4574673552?check_suite_focus=true#step:7:457
[hotwired/turbo#501]: https://github.com/hotwired/turbo/pull/501