### PR TITLE
Add Turbo Stream actions to add and remove CSS classes

### DIFF
--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -32,5 +32,17 @@ export const StreamActions: { [action: string]: (this: StreamElement) => void } 
       e.innerHTML = ""
       e.append(this.templateContent)
     })
+  },
+
+  "add-class"() {
+    this.targetElements.forEach(e => {
+      this.templateElement.classList.forEach(c => e.classList.add(c))
+    })
+  },
+
+  "remove-class"() {
+    this.targetElements.forEach(e => {
+      this.templateElement.classList.forEach(c => e.classList.remove(c))
+    })
   }
 }

--- a/src/tests/unit/stream_element_tests.ts
+++ b/src/tests/unit/stream_element_tests.ts
@@ -4,7 +4,7 @@ import { DOMTestCase } from "../helpers/dom_test_case"
 
 export class StreamElementTests extends DOMTestCase {
   async beforeTest() {
-    this.fixtureHTML = `<div><div id="hello">Hello Turbo</div></div>`
+    this.fixtureHTML = `<div><div id="hello" class="hello1 hello2">Hello Turbo</div></div>`
   }
 
   async "test action=append"() {
@@ -139,6 +139,26 @@ export class StreamElementTests extends DOMTestCase {
     this.assert.ok(this.find("h1#before"))
     this.assert.isNull(element.parentElement)
   }
+
+  async "test action=add-class"() {
+    const element = createStreamElement("add-class", "hello", createTemplateElement("", "hello2 hello3"))
+    this.assert.equal(this.find("#hello")?.getAttribute("class"), "hello1 hello2")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.getAttribute("class"), "hello1 hello2 hello3")
+  }
+
+  async "test action=remove-class"() {
+    const element = createStreamElement("remove-class", "hello", createTemplateElement("", "hello2 hello3"))
+    this.assert.equal(this.find("#hello")?.getAttribute("class"), "hello1 hello2")
+
+    this.append(element)
+    await nextAnimationFrame()
+
+    this.assert.equal(this.find("#hello")?.getAttribute("class"), "hello1")
+  }
 }
 
 function createStreamElement(action: string | null, target: string | null, templateElement?: HTMLTemplateElement) {
@@ -149,9 +169,10 @@ function createStreamElement(action: string | null, target: string | null, templ
   return element
 }
 
-function createTemplateElement(html: string) {
+function createTemplateElement(html: string, classes?: string) {
   const element = document.createElement("template")
   element.innerHTML = html
+  if (classes) element.setAttribute("class", classes)
   return element
 }
 


### PR DESCRIPTION
A common UI pattern is to indicate whether a field is valid or invalid by adding a CSS class to invalid fields to turn them red. Another is to submit the input as the user enters the text rather than waiting for them to press a button to submit the form. Combining the two requires us to add or remove fields from a field as the user continues to type into it.  For example, the following field in our application is validated to be exactly 8 digits:
![An example of a field which validates as the user types.  The field is initially red to show that it is invalid, but goes blue when the text reaches the required 8 digits.  When more text is entered, it goes back to red.](https://user-images.githubusercontent.com/301674/155208675-173dd0f1-e5d4-493a-8b16-5c4de078806f.gif)

This is difficult to implement using Turbo Streams, because the only action that can change the CSS class of an element on a page is `update`, which removes the existing element and replaces it with a new one.  This interrupts the user's input and is likely to discard their latest changes.

It is possible to work around this, for example by updating a hidden element with [a Stimulus controller that adds or removes the class when it connects](https://gist.github.com/percysnoodle/aa843cb942f8be1b4fd51ec36bba8e8a) (as in the above example) or perhaps doing something with sibling selectors; but this is bespoke and unwieldy.

The Turbo handbook says that...

> Turbo Streams consciously restricts you to seven actions [...in order to...] keep you from turning individual responses in a jumble of behaviors that cannot be reused and which make the app hard to follow

...but I feel that the omission of an action which enables this behaviour has pushed us in that direction instead of away from it.

So, to enable these sorts of update using Turbo Streams out of the box, this PR adds two new stream actions: `add-class`, which adds the template's classes to the targets; and `remove-class`, which removes them.

Since it's also fairly common to enable and disable elements, I did consider adding more generic actions to handle element attributes, but since disabling a field would also interrupt user input I think it is sufficiently covered by existing actions, and so it's not worth the extra complexity.