### PR TITLE
Autofocus avoids inert elements

### DIFF
--- a/src/tests/fixtures/autofocus-inert.html
+++ b/src/tests/fixtures/autofocus-inert.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Autofocus</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Autofocus With Inert Elements</h1>
+    <dialog>
+      <button autofocus id="first-autofocus-element" type="button">First [autofocus]</button>
+    </dialog>
+    <div hidden>
+      <button autofocus id="second-autofocus-element" type="button">Second [autofocus]</button>
+    </div>
+    <button autofocus id="third-autofocus-element" type="button">Third [autofocus]</button>
+  </body>
+</html>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -59,6 +59,7 @@
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
       <p><a id="link-to-disabled-frame" href="/src/tests/fixtures/frames/hello.html" data-turbo-frame="hello">Disabled turbo-frame</a></p>
       <p><a id="autofocus-link" href="/src/tests/fixtures/autofocus.html">autofocus.html link</a></p>
+      <p><a id="autofocus-inert-link" href="/src/tests/fixtures/autofocus-inert.html">autofocus-inert.html link</a></p>
       <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/one.html">Redirection link</a></p>
       <p><a id="headers-link" href="/__turbo/headers">Headers link</a></p>
       <p><custom-link-element id="custom-link-element" link="/src/tests/fixtures/one.html" text="Same-origin unannotated custom element link"></custom-link-element></p>

--- a/src/tests/functional/autofocus_tests.ts
+++ b/src/tests/functional/autofocus_tests.ts
@@ -20,6 +20,16 @@ export class AutofocusTests extends TurboDriveTestCase {
     this.assert.notOk(await this.hasSelector("#second-autofocus-element:focus"), "focuses the first [autofocus] element on the page")
   }
 
+  async "test autofocus third [autofocus] element on visit with inert elements"() {
+    await this.goToLocation("/src/tests/fixtures/navigation.html")
+    await this.clickSelector("#autofocus-inert-link")
+    await this.sleep(500)
+
+    this.assert.notOk(await this.hasSelector("#first-autofocus-element:focus"), "first autofocus element is hidden in a closed dialog")
+    this.assert.notOk(await this.hasSelector("#second-autofocus-element:focus"), "second autofocus element is hidden in a hidden div")
+    this.assert.ok(await this.hasSelector("third-autofocus-element:focus"), "focuses the third [autofocus] element on the page")
+  }
+
   async "test navigating a frame with a descendant link autofocuses [autofocus]:first-of-type"() {
     await this.clickSelector("#frame-inner-link")
     await this.nextBeat


### PR DESCRIPTION
When loading a page containing `<dialog>` elements or `<div hidden>` elements, which themselves contain `autofocus` elements, the browser is able to determine the first "active" `autofocus` element, and focus that.

Right now Turbo does not do the same thing. As a reduced test case, consider the following two pages:


```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="UTF-8">
    <script type="module" src="https://cdn.skypack.dev/@hotwired/turbo@7.1.0"></script>
  </head>
  <body>
    <a href="/two.html">Click</a>
  </body>
</html>
```

```html
<!DOCTYPE html>
<html>
  <head>
    <meta charset="UTF-8">
    <script type="module" src="https://cdn.skypack.dev/@hotwired/turbo@7.1.0"></script>
  </head>
  <body>
    <dialog> <!-- this could be also <div hidden> -->
      <input autofocus>
    </dialog>
    <input autofocus>
  </body>
</html>
```

Navigating to the second page with `Turbo.session.drive = false` will result in the `<input autofocus>` _outside_ of the dialog to be focussed. Refreshing the page will also cause the outer `<input autofocus>` to be focussed. However with Turbo drive on, the element does not autofocus.