### PR TITLE
Update <html> element attributes when navigating

### DIFF
--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -49,7 +49,9 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
 
   updateHtmlElementAttributes() {
     for(const attr of document.documentElement.attributes) {
-      document.documentElement.removeAttribute(attr.nodeName)
+      if (!this.newElement.hasAttribute(attr.nodeName)) {
+        document.documentElement.removeAttribute(attr.nodeName)
+      }
     }
 
     for(const attr of this.newHtmlElement.attributes) {

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -1,6 +1,8 @@
 import { Renderer } from "../renderer"
 import { PageSnapshot } from "./page_snapshot"
 
+const INTERNAL_ATTRIBUTES = ["aria-busy", "data-turbo-preview"]
+
 export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
   get shouldRender() {
     return this.newSnapshot.isVisitable && this.trackedElementsAreIdentical
@@ -49,7 +51,7 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
 
   updateHtmlElementAttributes() {
     for(const attr of document.documentElement.attributes) {
-      if (!this.newElement.hasAttribute(attr.nodeName)) {
+      if (!this.newElement.hasAttribute(attr.nodeName) && !INTERNAL_ATTRIBUTES.includes(attr.nodeName)) {
         document.documentElement.removeAttribute(attr.nodeName)
       }
     }

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -55,7 +55,7 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
     }
 
     for(const attr of this.newHtmlElement.attributes) {
-      document.documentElement.setAttribute(attr.nodeName, attr.nodeValue as string)
+      document.documentElement.setAttribute(attr.nodeName, attr.nodeValue!)
     }
   }
 

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -8,6 +8,7 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
 
   prepareToRender() {
     this.mergeHead()
+    this.updateHtmlElementAttributes()
   }
 
   async render() {
@@ -35,11 +36,25 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
     return this.newSnapshot.element
   }
 
+  get newHtmlElement() {
+    return this.newSnapshot.htmlElement
+  }
+
   mergeHead() {
     this.copyNewHeadStylesheetElements()
     this.copyNewHeadScriptElements()
     this.removeCurrentHeadProvisionalElements()
     this.copyNewHeadProvisionalElements()
+  }
+
+  updateHtmlElementAttributes() {
+    for(const attr of document.documentElement.attributes) {
+      document.documentElement.removeAttribute(attr.nodeName)
+    }
+
+    for(const attr of this.newHtmlElement.attributes) {
+      document.documentElement.setAttribute(attr.nodeName, attr.nodeValue as string)
+    }
   }
 
   replaceBody() {

--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -12,19 +12,21 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
     return this.fromDocument(element.ownerDocument)
   }
 
-  static fromDocument({ head, body }: Document) {
-    return new this(body as HTMLBodyElement, new HeadSnapshot(head))
+  static fromDocument({ head, body, documentElement }: Document) {
+    return new this(body as HTMLBodyElement, new HeadSnapshot(head), documentElement as HTMLHtmlElement)
   }
 
   readonly headSnapshot: HeadSnapshot
+  readonly htmlElement: HTMLHtmlElement
 
-  constructor(element: HTMLBodyElement, headSnapshot: HeadSnapshot) {
+  constructor(element: HTMLBodyElement, headSnapshot: HeadSnapshot, htmlElement: HTMLHtmlElement) {
     super(element)
     this.headSnapshot = headSnapshot
+    this.htmlElement = htmlElement
   }
 
   clone() {
-    return new PageSnapshot(this.element.cloneNode(true), this.headSnapshot)
+    return new PageSnapshot(this.element.cloneNode(true), this.headSnapshot, this.htmlElement)
   }
 
   get headElement() {

--- a/src/tests/fixtures/html_attributes.html
+++ b/src/tests/fixtures/html_attributes.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html data-attribute="attr" class="html-attributes">
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Attributes</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="test" content="foo">
+  </head>
+  <body>
+    <h1>HTML Attributes</h1>
+
+    <p><a id="link" href="/src/tests/fixtures/html_attributes_two.html">Link</a></p>
+  </body>
+</html>

--- a/src/tests/fixtures/html_attributes_two.html
+++ b/src/tests/fixtures/html_attributes_two.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html data-other-attribute="other-attr" class="html-attributes-two">
+  <head>
+    <meta charset="utf-8">
+    <title>HTML Attributes Two</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="test" content="foo">
+  </head>
+  <body>
+    <h1>HTML Attributes Two</h1>
+
+    <p><a id="link" href="/src/tests/fixtures/html_attributes.html">Link</a></p>
+  </body>
+</html>

--- a/src/tests/fixtures/html_attributes_two.html
+++ b/src/tests/fixtures/html_attributes_two.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-other-attribute="other-attr" class="html-attributes-two">
+<html data-attribute="attr-two" data-other-attribute="other-attr" class="html-attributes-two">
   <head>
     <meta charset="utf-8">
     <title>HTML Attributes Two</title>

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -14,7 +14,6 @@
     <a name="named-anchor"></a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
     <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/visit.html">Redirection link</a></p>
-    <p><a id="link-without-redirection" href="/src/tests/fixtures/two.html">Link without redirection</a></p>
 
     <turbo-frame id="navigate-top">
       Replaced only the frame

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="one">
+<html>
   <head>
     <meta charset="utf-8">
     <title>One</title>

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="one">
   <head>
     <meta charset="utf-8">
     <title>One</title>
@@ -14,6 +14,7 @@
     <a name="named-anchor"></a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
     <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/visit.html">Redirection link</a></p>
+    <p><a id="link-without-redirection" href="/src/tests/fixtures/two.html">Link without redirection</a></p>
 
     <turbo-frame id="navigate-top">
       Replaced only the frame

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html id="one">
   <head>
     <meta charset="utf-8">
     <title>One</title>

--- a/src/tests/fixtures/two.html
+++ b/src/tests/fixtures/two.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html class="two">
+<html>
   <head>
     <meta charset="utf-8">
     <title>Two</title>

--- a/src/tests/fixtures/two.html
+++ b/src/tests/fixtures/two.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html class="two">
   <head>
     <meta charset="utf-8">
     <title>Two</title>

--- a/src/tests/functional/drive_disabled_tests.ts
+++ b/src/tests/functional/drive_disabled_tests.ts
@@ -22,19 +22,14 @@ export class DriveDisabledTests extends TurboDriveTestCase {
   }
 
   async "test drive disabled by default; submit form inside data-turbo='true'"() {
-    await this.remote.execute(() => {
-      addEventListener("turbo:submit-start", () => document.documentElement.setAttribute("data-form-submitted", ""), { once: true })
-    })
+    await this.setLocalStorageFromEvent("turbo:submit-start", "formSubmitted", "true")
+
     this.clickSelector("#no_submitter_drive_enabled a#requestSubmit")
     await this.nextBody
-    this.assert.ok(await this.formSubmitted)
+    this.assert.ok(await this.getFromLocalStorage("formSubmitted"))
     this.assert.equal(await this.pathname, "/src/tests/fixtures/form.html")
     this.assert.equal(await this.visitAction, "advance")
     this.assert.equal(await this.getSearchParam("greeting"), "Hello from a redirect")
-  }
-
-  get formSubmitted(): Promise<boolean> {
-    return this.hasSelector("html[data-form-submitted]")
   }
 }
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -3,10 +3,8 @@ import { TurboDriveTestCase } from "../helpers/turbo_drive_test_case"
 export class FormSubmissionTests extends TurboDriveTestCase {
   async setup() {
     await this.goToLocation("/src/tests/fixtures/form.html")
-    await this.remote.execute(() => {
-      addEventListener("turbo:submit-start", () => document.documentElement.setAttribute("data-form-submit-start", ""), { once: true })
-      addEventListener("turbo:submit-end", () => document.documentElement.setAttribute("data-form-submit-end", ""), { once: true })
-    })
+    await this.setLocalStorageFromEvent("turbo:submit-start", "formSubmitStarted", "true")
+    await this.setLocalStorageFromEvent("turbo:submit-end", "formSubmitEnded", "true")
   }
 
   async "test standard form submission renders a progress bar"() {
@@ -811,12 +809,12 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await this.location, "https://httpbin.org/post")
   }
 
-  get formSubmitStarted(): Promise<boolean> {
-    return this.hasSelector("html[data-form-submit-start]")
+  get formSubmitStarted() {
+    return this.getFromLocalStorage("formSubmitStarted")
   }
 
-  get formSubmitEnded(): Promise<boolean> {
-    return this.hasSelector("html[data-form-submit-end]")
+  get formSubmitEnded() {
+    return this.getFromLocalStorage("formSubmitEnded")
   }
 }
 

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -40,7 +40,7 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
     this.assert.equal(await this.visitAction, "advance")
     this.assert.equal(await this.nextAttributeMutationNamed("html", "aria-busy"), "true", "sets [aria-busy] on the document element")
-    this.assert.equal(await this.nextAttributeMutationNamed("html", "aria-busy"), null, "removes [aria-busy] from the document element")
+    this.assert.equal(await this.nextAttributeMutationNamed("one", "aria-busy"), null, "removes [aria-busy] from the updated document element")
   }
 
   async "test following a same-origin unannotated custom element link"() {

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -121,20 +121,21 @@ export class VisitTests extends TurboDriveTestCase {
   }
 
   async "test updates HTML element classes"() {
-    await this.visitLocation("/src/tests/fixtures/one.html")
+    await this.visitLocation("/src/tests/fixtures/html_attributes.html")
+    await this.nextBeat
 
-    await this.remote.execute(() => {
-      this.assert.include(document.documentElement.className, "one")
-    })
+    this.assert.equal(await this.remote.execute(() => document.documentElement.className), "html-attributes")
+    this.assert.equal(await this.remote.execute(() => document.documentElement.getAttribute("data-attribute")), "attr")
+    this.assert.equal(await this.remote.execute(() => document.documentElement.getAttribute("data-other-attribute")), null)
 
-    this.clickSelector("#link-without-redirection")
+    this.clickSelector("#link")
+    await this.nextBeat
 
-    await this.nextBeat // 200 response
+    const classes = await this.remote.execute(() => document.documentElement.className)
+    this.assert.equal(classes, "html-attributes-two")
 
-    await this.remote.execute(() => {
-      this.assert.notInclude(document.documentElement.className, "one")
-      this.assert.include(document.documentElement.className, "visit")
-    })
+    this.assert.equal(await this.remote.execute(() => document.documentElement.getAttribute("data-attribute")), null)
+    this.assert.equal(await this.remote.execute(() => document.documentElement.getAttribute("data-other-attribute")), "other-attr")
   }
 
   async visitLocation(location: string) {

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -131,10 +131,8 @@ export class VisitTests extends TurboDriveTestCase {
     this.clickSelector("#link")
     await this.nextBeat
 
-    const classes = await this.remote.execute(() => document.documentElement.className)
-    this.assert.equal(classes, "html-attributes-two")
-
-    this.assert.equal(await this.remote.execute(() => document.documentElement.getAttribute("data-attribute")), null)
+    this.assert.equal(await this.remote.execute(() => document.documentElement.className), "html-attributes-two")
+    this.assert.equal(await this.remote.execute(() => document.documentElement.getAttribute("data-attribute")), "attr-two")
     this.assert.equal(await this.remote.execute(() => document.documentElement.getAttribute("data-other-attribute")), "other-attr")
   }
 

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -120,6 +120,23 @@ export class VisitTests extends TurboDriveTestCase {
     this.assert.notOk(await this.hasSelector("some-cached-element"))
   }
 
+  async "test updates HTML element classes"() {
+    await this.visitLocation("/src/tests/fixtures/one.html")
+
+    await this.remote.execute(() => {
+      this.assert.include(document.documentElement.className, "one")
+    })
+
+    this.clickSelector("#link-without-redirection")
+
+    await this.nextBeat // 200 response
+
+    await this.remote.execute(() => {
+      this.assert.notInclude(document.documentElement.className, "one")
+      this.assert.include(document.documentElement.className, "visit")
+    })
+  }
+
   async visitLocation(location: string) {
     this.remote.execute((location: string) => window.Turbo.visit(location), [location])
   }

--- a/src/tests/helpers/turbo_drive_test_case.ts
+++ b/src/tests/helpers/turbo_drive_test_case.ts
@@ -11,12 +11,9 @@ export class TurboDriveTestCase extends FunctionalTestCase {
   lastBody?: Element
 
   async beforeTest() {
+    await this.clearLocalStorage()
     await this.drainEventLog()
     this.lastBody = await this.body
-  }
-
-  async afterTest() {
-    await this.remote.execute(() => localStorage.clear())
   }
 
   get nextWindowHandle(): Promise<string> {
@@ -103,5 +100,9 @@ export class TurboDriveTestCase extends FunctionalTestCase {
 
   drainEventLog() {
     return this.eventLogChannel.drain()
+  }
+
+  clearLocalStorage() {
+    this.remote.execute(() => localStorage.clear())
   }
 }

--- a/src/tests/helpers/turbo_drive_test_case.ts
+++ b/src/tests/helpers/turbo_drive_test_case.ts
@@ -63,10 +63,10 @@ export class TurboDriveTestCase extends FunctionalTestCase {
     return attributeValue
   }
 
-  async setLocalStorageFromEvent(eventName: string, key: string, value: string) {
-    return this.remote.execute((storageKey: string, storageValue: string) => {
+  async setLocalStorageFromEvent(event: string, key: string, value: string) {
+    return this.remote.execute((eventName: string, storageKey: string, storageValue: string) => {
       addEventListener(eventName, () => localStorage.setItem(storageKey, storageValue))
-    }, [key, value])
+    }, [event, key, value])
   }
 
   getFromLocalStorage(key: string) {

--- a/src/tests/helpers/turbo_drive_test_case.ts
+++ b/src/tests/helpers/turbo_drive_test_case.ts
@@ -15,6 +15,10 @@ export class TurboDriveTestCase extends FunctionalTestCase {
     this.lastBody = await this.body
   }
 
+  async afterTest() {
+    await this.remote.execute(() => localStorage.clear())
+  }
+
   get nextWindowHandle(): Promise<string> {
     return (async (nextHandle?: string) => {
       do {
@@ -57,6 +61,16 @@ export class TurboDriveTestCase extends FunctionalTestCase {
     }
     const attributeValue = record[2]
     return attributeValue
+  }
+
+  async setLocalStorageFromEvent(eventName: string, key: string, value: string) {
+    return this.remote.execute((storageKey: string, storageValue: string) => {
+      addEventListener(eventName, () => localStorage.setItem(storageKey, storageValue))
+    }, [key, value])
+  }
+
+  getFromLocalStorage(key: string) {
+    return this.remote.execute((storageKey: string) => localStorage.getItem(storageKey), [key])
   }
 
   get nextBody(): Promise<Element> {


### PR DESCRIPTION
Turbo only replaces the `<body>` and updates the `<head>` when navigating, ignoring possible changes to the `<html>` element, like classes or `data-*` attributes.
With this change, Turbo will update the `<html>` when navigating through pages.