### PR TITLE
Add a `turbo:reload` event that returns the reason why turbo needed to do a hard reload.

### DIFF
--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -6,6 +6,18 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
     return this.newSnapshot.isVisitable && this.trackedElementsAreIdentical
   }
 
+  get reloadReason() {
+    if (!this.newSnapshot.isVisitable) {
+      return "Page snapshot is not visitable."
+    }
+
+    if (!this.trackedElementsAreIdentical) {
+      return "Tracked element was different."
+    }
+
+    return ""
+  }
+
   prepareToRender() {
     this.mergeHead()
   }

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -1,21 +1,24 @@
 import { Renderer } from "../renderer"
 import { PageSnapshot } from "./page_snapshot"
+import { ReloadReason } from "../native/browser_adapter"
 
 export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
   get shouldRender() {
     return this.newSnapshot.isVisitable && this.trackedElementsAreIdentical
   }
 
-  get reloadReason() {
+  get reloadReason(): ReloadReason {
     if (!this.newSnapshot.isVisitable) {
-      return "Page snapshot is not visitable."
+      return {
+        reason: "turbo_visit_control_is_reload"
+      }
     }
 
     if (!this.trackedElementsAreIdentical) {
-      return "A tracked element was different."
+      return {
+        reason: "tracked_element_mismatch"
+      }
     }
-
-    return ""
   }
 
   prepareToRender() {

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -12,7 +12,7 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
     }
 
     if (!this.trackedElementsAreIdentical) {
-      return "Tracked element was different."
+      return "A tracked element was different."
     }
 
     return ""

--- a/src/core/native/adapter.ts
+++ b/src/core/native/adapter.ts
@@ -1,5 +1,6 @@
 import { Visit, VisitOptions } from "../drive/visit"
 import { FormSubmission } from "../drive/form_submission"
+import { ReloadReason } from "./browser_adapter"
 
 export interface Adapter {
   visitProposedToLocation(location: URL, options?: Partial<VisitOptions>): void
@@ -13,5 +14,5 @@ export interface Adapter {
   visitRendered(visit: Visit): void
   formSubmissionStarted?(formSubmission: FormSubmission): void
   formSubmissionFinished?(formSubmission: FormSubmission): void
-  pageInvalidated(reason: string): void
+  pageInvalidated(reason: ReloadReason): void
 }

--- a/src/core/native/adapter.ts
+++ b/src/core/native/adapter.ts
@@ -13,5 +13,5 @@ export interface Adapter {
   visitRendered(visit: Visit): void
   formSubmissionStarted?(formSubmission: FormSubmission): void
   formSubmissionFinished?(formSubmission: FormSubmission): void
-  pageInvalidated(): void
+  pageInvalidated(reason: string): void
 }

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -3,7 +3,7 @@ import { ProgressBar } from "../drive/progress_bar"
 import { SystemStatusCode, Visit, VisitOptions } from "../drive/visit"
 import { FormSubmission } from "../drive/form_submission"
 import { Session } from "../session"
-import { uuid } from "../../util"
+import { uuid, dispatch } from "../../util"
 
 export class BrowserAdapter implements Adapter {
   readonly session: Session
@@ -45,7 +45,7 @@ export class BrowserAdapter implements Adapter {
       case SystemStatusCode.networkFailure:
       case SystemStatusCode.timeoutFailure:
       case SystemStatusCode.contentTypeMismatch:
-        return this.reload()
+        return this.reload(`Request failed with status code ${statusCode}`)
       default:
         return visit.loadResponse()
     }
@@ -60,8 +60,8 @@ export class BrowserAdapter implements Adapter {
 
   }
 
-  pageInvalidated() {
-    this.reload()
+  pageInvalidated(reason: string) {
+    this.reload(reason)
   }
 
   visitFailed(visit: Visit) {
@@ -114,7 +114,8 @@ export class BrowserAdapter implements Adapter {
     this.progressBar.show()
   }
 
-  reload() {
+  reload(reason: string) {
+    dispatch("turbo:reload", { detail: { reason} })
     window.location.reload()
   }
 

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -5,6 +5,12 @@ import { FormSubmission } from "../drive/form_submission"
 import { Session } from "../session"
 import { uuid, dispatch } from "../../util"
 
+export type ReloadReason = StructuredReason | undefined
+interface StructuredReason {
+  reason: string
+  context?: {[key: string]: any}
+}
+
 export class BrowserAdapter implements Adapter {
   readonly session: Session
   readonly progressBar = new ProgressBar
@@ -45,7 +51,12 @@ export class BrowserAdapter implements Adapter {
       case SystemStatusCode.networkFailure:
       case SystemStatusCode.timeoutFailure:
       case SystemStatusCode.contentTypeMismatch:
-        return this.reload(`Request failed with status code ${statusCode}`)
+        return this.reload({
+          reason: 'request_failed',
+          context: {
+            statusCode
+          }
+        })
       default:
         return visit.loadResponse()
     }
@@ -60,7 +71,7 @@ export class BrowserAdapter implements Adapter {
 
   }
 
-  pageInvalidated(reason: string) {
+  pageInvalidated(reason: ReloadReason) {
     this.reload(reason)
   }
 
@@ -114,8 +125,8 @@ export class BrowserAdapter implements Adapter {
     this.progressBar.show()
   }
 
-  reload(reason: string) {
-    dispatch("turbo:reload", { detail: { reason} })
+  reload(reason: ReloadReason) {
+    dispatch("turbo:reload", { detail: reason })
     window.location.reload()
   }
 

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -52,7 +52,7 @@ export class BrowserAdapter implements Adapter {
       case SystemStatusCode.timeoutFailure:
       case SystemStatusCode.contentTypeMismatch:
         return this.reload({
-          reason: 'request_failed',
+          reason: "request_failed",
           context: {
             statusCode
           }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -26,6 +26,10 @@ export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapsh
     return true
   }
 
+  get reloadReason() {
+    return ""
+  }
+
   prepareToRender() {
     return
   }

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,5 +1,6 @@
 import { Bardo } from "./bardo"
 import { Snapshot } from "./snapshot"
+import { ReloadReason } from "./native/browser_adapter"
 
 type ResolvingFunctions<T = unknown> = {
   resolve(value: T | PromiseLike<T>): void
@@ -26,8 +27,8 @@ export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapsh
     return true
   }
 
-  get reloadReason() {
-    return ""
+  get reloadReason(): ReloadReason {
+    return
   }
 
   prepareToRender() {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -116,7 +116,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     if (this.enabled) {
       this.navigator.startVisit(location, restorationIdentifier, { action: "restore", historyChanged: true })
     } else {
-      this.adapter.pageInvalidated()
+      this.adapter.pageInvalidated("historyPoppedToLocationWithRestorationIdentifier")
     }
   }
 
@@ -250,8 +250,8 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     this.notifyApplicationAfterRender()
   }
 
-  viewInvalidated() {
-    this.adapter.pageInvalidated()
+  viewInvalidated(reason: string) {
+    this.adapter.pageInvalidated(reason)
   }
 
   // Frame element

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -1,5 +1,5 @@
 import { Adapter } from "./native/adapter"
-import { BrowserAdapter } from "./native/browser_adapter"
+import { BrowserAdapter, ReloadReason } from "./native/browser_adapter"
 import { CacheObserver } from "../observers/cache_observer"
 import { FormSubmitObserver, FormSubmitObserverDelegate } from "../observers/form_submit_observer"
 import { FrameRedirector } from "./frames/frame_redirector"
@@ -116,7 +116,9 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     if (this.enabled) {
       this.navigator.startVisit(location, restorationIdentifier, { action: "restore", historyChanged: true })
     } else {
-      this.adapter.pageInvalidated("Turbo is disabled.")
+      this.adapter.pageInvalidated({
+        reason: "turbo_disabled"
+      })
     }
   }
 
@@ -250,7 +252,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     this.notifyApplicationAfterRender()
   }
 
-  viewInvalidated(reason: string) {
+  viewInvalidated(reason: ReloadReason) {
     this.adapter.pageInvalidated(reason)
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -116,7 +116,7 @@ export class Session implements FormSubmitObserverDelegate, HistoryDelegate, Lin
     if (this.enabled) {
       this.navigator.startVisit(location, restorationIdentifier, { action: "restore", historyChanged: true })
     } else {
-      this.adapter.pageInvalidated("historyPoppedToLocationWithRestorationIdentifier")
+      this.adapter.pageInvalidated("Turbo is disabled.")
     }
   }
 

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -6,7 +6,7 @@ import { getAnchor } from "./url"
 export interface ViewDelegate<S extends Snapshot> {
   allowsImmediateRender(snapshot: S, resume: (value: any) => void): boolean
   viewRenderedSnapshot(snapshot: S, isPreview: boolean): void
-  viewInvalidated(): void
+  viewInvalidated(reason: string): void
 }
 
 export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E>, R extends Renderer<E, S> = Renderer<E, S>, D extends ViewDelegate<S> = ViewDelegate<S>> {
@@ -90,12 +90,12 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
         delete this.renderPromise
       }
     } else {
-      this.invalidate()
+      this.invalidate(renderer.reloadReason)
     }
   }
 
-  invalidate() {
-    this.delegate.viewInvalidated()
+  invalidate(reason: string) {
+    this.delegate.viewInvalidated(reason)
   }
 
   prepareToRenderSnapshot(renderer: R) {

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -1,3 +1,4 @@
+import { ReloadReason } from "./native/browser_adapter"
 import { Renderer } from "./renderer"
 import { Snapshot } from "./snapshot"
 import { Position } from "./types"
@@ -6,7 +7,7 @@ import { getAnchor } from "./url"
 export interface ViewDelegate<S extends Snapshot> {
   allowsImmediateRender(snapshot: S, resume: (value: any) => void): boolean
   viewRenderedSnapshot(snapshot: S, isPreview: boolean): void
-  viewInvalidated(reason: string): void
+  viewInvalidated(reason: ReloadReason): void
 }
 
 export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E>, R extends Renderer<E, S> = Renderer<E, S>, D extends ViewDelegate<S> = ViewDelegate<S>> {
@@ -94,7 +95,7 @@ export abstract class View<E extends Element, S extends Snapshot<E> = Snapshot<E
     }
   }
 
-  invalidate(reason: string) {
+  invalidate(reason: ReloadReason) {
     this.delegate.viewInvalidated(reason)
   }
 

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -31,4 +31,5 @@
   "turbo:visit",
   "turbo:frame-load",
   "turbo:frame-render",
+  "turbo:reload"
 ])

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -41,14 +41,14 @@ export class RenderingTests extends TurboDriveTestCase {
   async "test reloads when tracked elements change"() {
     await this.remote.execute(() =>
       window.addEventListener("turbo:reload", (e: any) => {
-        localStorage.setItem('reloadReason', e.detail.reason)
+        localStorage.setItem("reloadReason", e.detail.reason)
       })
     )
 
     this.clickSelector("#tracked-asset-change-link")
     await this.nextBody
 
-    const reason = await this.remote.execute(() => localStorage.getItem('reloadReason'))
+    const reason = await this.remote.execute(() => localStorage.getItem("reloadReason"))
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/tracked_asset_change.html")
     this.assert.equal(await this.visitAction, "load")
@@ -65,14 +65,14 @@ export class RenderingTests extends TurboDriveTestCase {
   async "test reloads when turbo-visit-control setting is reload"() {
     await this.remote.execute(() =>
       window.addEventListener("turbo:reload", (e: any) => {
-        localStorage.setItem('reloadReason', e.detail.reason)
+        localStorage.setItem("reloadReason", e.detail.reason)
       })
     )
 
     this.clickSelector("#visit-control-reload-link")
     await this.nextBody
 
-    const reason = await this.remote.execute(() => localStorage.getItem('reloadReason'))
+    const reason = await this.remote.execute(() => localStorage.getItem("reloadReason"))
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/visit_control_reload.html")
     this.assert.equal(await this.visitAction, "load")

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -63,10 +63,20 @@ export class RenderingTests extends TurboDriveTestCase {
   }
 
   async "test reloads when turbo-visit-control setting is reload"() {
+    await this.remote.execute(() =>
+      window.addEventListener("turbo:reload", (e: any) => {
+        localStorage.setItem('reloadReason', e.detail.reason)
+      })
+    )
+
     this.clickSelector("#visit-control-reload-link")
     await this.nextBody
+
+    const reason = await this.remote.execute(() => localStorage.getItem('reloadReason'))
+
     this.assert.equal(await this.pathname, "/src/tests/fixtures/visit_control_reload.html")
     this.assert.equal(await this.visitAction, "load")
+    this.assert.equal(reason, "Page snapshot is not visitable.")
   }
 
   async "test accumulates asset elements in head"() {

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -52,7 +52,7 @@ export class RenderingTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/tracked_asset_change.html")
     this.assert.equal(await this.visitAction, "load")
-    this.assert.equal(reason, "A tracked element was different.")
+    this.assert.equal(reason, "tracked_element_mismatch")
   }
 
   async "test wont reload when tracked elements has a nonce"() {
@@ -76,7 +76,7 @@ export class RenderingTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/visit_control_reload.html")
     this.assert.equal(await this.visitAction, "load")
-    this.assert.equal(reason, "Page snapshot is not visitable.")
+    this.assert.equal(reason, "turbo_visit_control_is_reload")
   }
 
   async "test accumulates asset elements in head"() {

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -271,10 +271,6 @@ export class RenderingTests extends TurboDriveTestCase {
     return this.evaluate(() => getComputedStyle(document.body).getPropertyValue("--black-if-noscript-evaluated").trim() === "black")
   }
 
-  get reloadFired(): Promise<boolean> {
-    return this.hasSelector("html[data-reload-fired]")
-  }
-
   async modifyBodyBeforeCaching() {
     return this.remote.execute(() => addEventListener("turbo:before-cache", function eventListener(event) {
       removeEventListener("turbo:before-cache", eventListener, false)


### PR DESCRIPTION
I feel like we are missing an event fired when the page is going to be hard reloaded. With `turbo:reload` users will be able to listen to **why** their Turbo navigations are causing reloads instead of soft-navigation. That will help users track the data and improve their apps.