### PR TITLE
Raise turbo:error event on error

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -1,4 +1,5 @@
 import { Action, isAction } from "../types"
+import { reportError } from "../../util"
 import { FetchMethod } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { FormSubmission } from "./form_submission"
@@ -113,7 +114,7 @@ export class Navigator {
   }
 
   formSubmissionErrored(formSubmission: FormSubmission, error: Error) {
-    console.error(error)
+    reportError(error)
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -8,6 +8,7 @@ import { PageSnapshot } from "./page_snapshot"
 import { Action } from "../types"
 import { uuid } from "../../util"
 import { PageView } from "./page_view"
+import { reportError } from "../../util"
 
 export interface VisitDelegate {
   readonly adapter: Adapter
@@ -221,6 +222,7 @@ export class Visit implements FetchRequestDelegate {
           this.adapter.visitRendered(this)
           this.complete()
         } else {
+          reportError(this.response)
           await this.view.renderError(PageSnapshot.fromHTMLString(responseHTML))
           this.adapter.visitRendered(this)
           this.fail()

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -187,7 +187,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   requestErrored(request: FetchRequest, error: Error) {
-    console.error(error)
+    reportError(error)
     this.resolveVisitPromise()
   }
 
@@ -214,7 +214,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   formSubmissionErrored(formSubmission: FormSubmission, error: Error) {
-    console.error(error)
+    reportError(error)
   }
 
   formSubmissionFinished({ formElement }: FormSubmission) {
@@ -296,9 +296,9 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
         return await this.extractForeignFrameElement(element)
       }
 
-      console.error(`Response has no matching <turbo-frame id="${id}"> element`)
+      reportError(`Response has no matching <turbo-frame id="${id}"> element`)
     } catch (error) {
-      console.error(error)
+      reportError(error)
     }
 
     return new FrameElement()

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -2,7 +2,7 @@ import { FrameElement, FrameElementDelegate, FrameLoadingStyle } from "../../ele
 import { FetchMethod, FetchRequest, FetchRequestDelegate, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/appearance_observer"
-import { clearBusyState, getAttribute, parseHTMLDocument, markAsBusy } from "../../util"
+import { clearBusyState, getAttribute, parseHTMLDocument, markAsBusy, reportError } from "../../util"
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
 import { ViewDelegate } from "../view"
@@ -116,7 +116,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
         this.fetchResponseLoaded(fetchResponse)
       }
     } catch (error) {
-      console.error(error)
+      reportError(error)
       this.view.invalidate()
     } finally {
       this.fetchResponseLoaded = () => {}
@@ -182,7 +182,7 @@ export class FrameController implements AppearanceObserverDelegate, FetchRequest
   }
 
   requestFailedWithResponse(request: FetchRequest, response: FetchResponse) {
-    console.error(response)
+    reportError(response)
     this.resolveVisitPromise()
   }
 

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -1,5 +1,5 @@
 import { StreamActions } from "../core/streams/stream_actions"
-import { nextAnimationFrame } from "../util"
+import { nextAnimationFrame, reportError } from "../util"
 
 // <turbo-stream action=replace target=id><template>...
 
@@ -28,7 +28,7 @@ export class StreamElement extends HTMLElement {
     try {
       await this.render()
     } catch (error) {
-      console.error(error)
+      reportError(error)
     } finally {
       this.disconnect()
     }

--- a/src/tests/fixtures/drive.html
+++ b/src/tests/fixtures/drive.html
@@ -17,5 +17,9 @@
     <div data-turbo="false">
       <a id="drive_disabled" href="/src/tests/fixtures/drive.html">Drive disabled link</a>
     </div>
+
+    <div>
+      <a id="error" href="/__turbo/error">Drive enabled link with error</a>
+    </div>
   </body>
 </html>

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -121,5 +121,15 @@
     <hr class="push-off-screen">
     <input id="below-the-fold-input">
     <a id="below-the-fold-link-frame-action" data-turbo-action="advance" data-turbo-frame="frame" href="/src/tests/fixtures/frames/frame.html">Navigate #frame</a>
+
+    <turbo-frame id="error">
+      <a href="/__turbo/error" id="load-error">Load error</a>
+    </turbo-frame>
+
+    <turbo-frame id="frame-error">
+      <form action="/__turbo/error">
+        <button id="submit-error">Submit with error</button>
+      </form>
+    </turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -31,4 +31,5 @@
   "turbo:visit",
   "turbo:frame-load",
   "turbo:frame-render",
+  "turbo:error",
 ])

--- a/src/tests/functional/drive_tests.ts
+++ b/src/tests/functional/drive_tests.ts
@@ -28,6 +28,14 @@ export class DriveTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, this.path)
     this.assert.equal(await this.visitAction, "load")
   }
+
+  async "test link click network error fires turbo:error event"() {
+    this.clickSelector("#error")
+    await this.nextBody
+    this.assert.equal(await this.pathname, "/__turbo/error")
+    this.assert.equal(await this.visitAction, "advance")
+    this.assert.ok(await this.nextEventNamed("turbo:error"))
+  }
 }
 
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -308,6 +308,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     const title = await this.querySelector("h1")
     this.assert.equal(await title.getVisibleText(), "Unprocessable Entity", "renders the response HTML")
     this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
+    this.assert.ok(await this.nextEventNamed("turbo:error"))
   }
 
   async "test invalid form submission with long form"() {
@@ -330,6 +331,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
     this.assert.equal(await title.getVisibleText(), "Internal Server Error", "renders the response HTML")
     this.assert.notOk(await this.hasSelector("head > #form-fixture-styles"), "replaces head")
     this.assert.notOk(await this.hasSelector("#frame form.reject"), "replaces entire page")
+    this.assert.ok(await this.nextEventNamed("turbo:error"), "fires turbo:error event")
   }
 
   async "test submitter form submission reads button attributes"() {

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -551,6 +551,16 @@ export class FrameTests extends TurboDriveTestCase {
     this.assert.ok(await this.nextEventOnTarget("frame", "turbo:before-fetch-response"))
   }
 
+  async "test link click network error fires turbo:error event"() {
+    await this.clickSelector("#load-error")
+    this.assert.ok(await this.nextEventNamed("turbo:error"))
+  }
+
+  async "test form submit network error fires turbo:error event"() {
+    await this.clickSelector("#submit-error")
+    this.assert.ok(await this.nextEventNamed("turbo:error"))
+  }
+
   async withoutChangingEventListenersCount(callback: () => void) {
     const name = "eventListenersAttachedToDocument"
     const setup = () => {

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -51,6 +51,13 @@ router.post("/reject", (request, response) => {
   response.status(parseInt(status || "422", 10)).sendFile(fixture)
 })
 
+router.get("/error", (request, response) => {
+  const status = request.query.status as string || "500";
+  const fixture = path.join(__dirname, `../../src/tests/fixtures/${status}.html`)
+
+  response.status(parseInt(status, 10)).sendFile(fixture)
+})
+
 router.get("/headers", (request, response) => {
   const template = fs.readFileSync("src/tests/fixtures/headers.html").toString()
   response.type("html").status(200).send(template.replace('$HEADERS', JSON.stringify(request.headers, null, 4)))

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,3 +1,5 @@
+import { FetchResponse } from "./http/fetch_response";
+
 export type DispatchOptions = { target: EventTarget, cancelable: boolean, detail: any }
 
 export function dispatch(eventName: string, { target, cancelable, detail }: Partial<DispatchOptions> = {}) {
@@ -83,7 +85,7 @@ export function clearBusyState(...elements: Element[]) {
   }
 }
 
-export function reportError(error) {
+export function reportError(error: FetchResponse | unknown) {
   console.warn(error)
   dispatch('turbo:error', { detail: { error } })
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -82,3 +82,8 @@ export function clearBusyState(...elements: Element[]) {
     element.removeAttribute("aria-busy")
   }
 }
+
+export function reportError(error) {
+  console.warn(error)
+  dispatch('turbo:error', { detail: { error } })
+}


### PR DESCRIPTION
This pr continues abandoned work on https://github.com/hotwired/turbo/pull/357

I am struggling a bit with adding event firing tests as test cases for failure-scenario are missing for most of the affected functionality and I have not found any documentation on he expected behavior either. For example what do we expect  if a request in a Turbo frame fails? Seems like the frame is not updated at all. What do we expect if a Drive link fails? Seems like the page gets updated with the error response.

There is still a test failing and I'm not entirely sure what to expect here:
```
DriveTests - link click network error fires turbo:error event (0.53s)
    AssertionError: expected 'load' to equal 'advance'
    
    A load
    E advance
    
      at DriveTests.test link click network error fires turbo:error event @ src/tests/functional/drive_tests.ts:36:16
      at processTicksAndRejections @ internal/process/task_queues.js:95:5
      at async DriveTests.runTest @ src/tests/helpers/intern_test_case.ts:43:6
```

And lastly, I'm not entirely sure what the semantics of `turbo:error` should be. Is this for any fetch error response or exception? Should it be limited to fetch errors only? If that's the case, would `turbo:fetch-error` be a more appropriate name? I'm personally only interested in fetch error but #357 contains more.

Anyway, feedback welcome.
