### PR TITLE
Update Github actions to use Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,11 +8,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v2
+    - uses: actions/checkout@v3
+    - uses: actions/setup-node@v3
       with:
-        node-version: '12'
-    - uses: actions/cache@v2
+        node-version: '16'
+    - uses: actions/cache@v3
       with:
         path: node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Node 12 will reach EOL at the end of April. Many Github actions have recently updated to use Node 16 (the Active LTS) and moved off of 12.

Updated `actions/checkout`, `actions/setup-node` and `actions/cache` in ci.yml to their most recent versions which are ran/built against Node 16. Also, chnged the node-version used in Github actions to 16.

The dev container appears to already be set up to use Ndoe 16.