### PR TITLE
Expose FrameRenderer so we can extend its behavior, e.g. vDOM.

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -6,11 +6,12 @@ import { StreamSource } from "./types"
 import { VisitOptions } from "./drive/visit"
 import { PageRenderer } from "./drive/page_renderer"
 import { PageSnapshot } from "./drive/page_snapshot"
+import { FrameRenderer } from "./frames/frame_renderer"
 import { FormSubmission } from "./drive/form_submission"
 
 const session = new Session
 const { navigator } = session
-export { navigator, session, PageRenderer, PageSnapshot }
+export { navigator, session, PageRenderer, PageSnapshot, FrameRenderer }
 
 /**
  * Starts the main session.


### PR DESCRIPTION
Hello, thank you for Turbo, I really love it! This PR is basically the exact same motivation as exposing PageRenderer in #305

With this, its trivial to replace frame rendering with a Virtual DOM like so:

```javascript
import morphdom from "morphdom";
import { FrameRenderer } from "@hotwired/turbo";

FrameRenderer.prototype.loadFrameElement = function() {
  morphdom(this.currentElement, this.newElement, {
    childrenOnly: true,
    onBeforeElUpdated: function(fromEl, toEl) {
      return !fromEl.isEqualNode(toEl);
    }
  });
}
```

I don't believe there's an alternative, at present. If a `before-frame-render` event gets added, like in #431, it might be possible to do it through that.