### PR TITLE
Remove unused property `identifier`

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -68,7 +68,6 @@ export enum SystemStatusCode {
 
 export class Visit implements FetchRequestDelegate {
   readonly delegate: VisitDelegate
-  readonly identifier = uuid()
   readonly restorationIdentifier: string
   readonly action: Action
   readonly referrer?: URL


### PR DESCRIPTION
Removed the redundant `identifier` property on the `Visit` class. 