### PR TITLE
Don't scroll to top of page on reload

### DIFF
--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -18,7 +18,7 @@ export class PageView extends View<Element, PageSnapshot, PageViewRenderer, Page
 
   renderPage(snapshot: PageSnapshot, isPreview = false, willRender = true) {
     const renderer = new PageRenderer(this.snapshot, snapshot, isPreview, willRender)
-    if (!renderer.trackedElementsAreIdentical) { this.forceReloaded = true }
+    if (!renderer.shouldRender) { this.forceReloaded = true }
     return this.render(renderer)
   }
 

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -18,8 +18,7 @@ export class PageView extends View<Element, PageSnapshot, PageViewRenderer, Page
 
   renderPage(snapshot: PageSnapshot, isPreview = false, willRender = true) {
     const renderer = new PageRenderer(this.snapshot, snapshot, isPreview, willRender)
-    // TODO - make this specific to the meta mismatch
-    if (!renderer.shouldRender) { this.forceReloaded = true }
+    if (!renderer.trackedElementsAreIdentical) { this.forceReloaded = true }
     return this.render(renderer)
   }
 

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -14,9 +14,12 @@ type PageViewRenderer = PageRenderer | ErrorRenderer
 export class PageView extends View<Element, PageSnapshot, PageViewRenderer, PageViewDelegate> {
   readonly snapshotCache = new SnapshotCache(10)
   lastRenderedLocation = new URL(location.href)
+  forceReloaded = false
 
   renderPage(snapshot: PageSnapshot, isPreview = false, willRender = true) {
     const renderer = new PageRenderer(this.snapshot, snapshot, isPreview, willRender)
+    // TODO - make this specific to the meta mismatch
+    if (!renderer.shouldRender) { this.forceReloaded = true }
     return this.render(renderer)
   }
 

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -330,9 +330,6 @@ export class Visit implements FetchRequestDelegate {
   // Scrolling
 
   performScroll() {
-    if (this.view.forceReloaded) {
-      return
-    }
     if (!this.scrolled) {
       if (this.action == "restore") {
         this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()
@@ -411,7 +408,9 @@ export class Visit implements FetchRequestDelegate {
     })
     await callback()
     delete this.frame
-    this.performScroll()
+    if (!this.view.forceReloaded) {
+      this.performScroll()
+    }
   }
 
   cancelRender() {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -330,6 +330,9 @@ export class Visit implements FetchRequestDelegate {
   // Scrolling
 
   performScroll() {
+    if (this.view.forceReloaded) {
+      return
+    }
     if (!this.scrolled) {
       if (this.action == "restore") {
         this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -24,6 +24,9 @@
     <script type="importmap" nonce="123">
       { "imports": { "turbo": "/dist/turbo.es2017-umd.js?123"} }
     </script>
+    <style>
+      .push-off-screen { margin-top: 1000px; }
+    </style>
   </head>
   <body>
     <section>
@@ -53,5 +56,8 @@
       <source src="/src/tests/fixtures/video.mp4" type="video/mp4">
     </video>
     <button id="permanent-video-button" type="button">Play</button>
+
+    <hr class="push-off-screen">
+    <p><a id="below-the-fold-visit-control-reload-link" href="/src/tests/fixtures/visit_control_reload.html">Visit control: reload</a></p>
   </body>
 </html>

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -48,6 +48,31 @@ export class RenderingTests extends TurboDriveTestCase {
     this.assert.equal(await this.visitAction, "load")
   }
 
+  async "test maintains scroll position before visit when turbo-visit-control setting is reload"() {
+    await this.scrollToSelector("#below-the-fold-visit-control-reload-link")
+    // await this.nextBeat
+    this.assert.ok(await this.isScrolledToSelector("#below-the-fold-visit-control-reload-link"), "did not scroll")
+
+    // let sp = await this.scrollPosition
+    // console.log(sp)
+    // this.assert.ok(sp.y > 100)
+    this.assert.notOk(await this.isScrolledToTop(), "scrolled down")
+
+    this.clickSelector("#below-the-fold-visit-control-reload-link")
+    // this.assert.equal(await this.pathname, "/src/tests/fixtures/rendering.html")
+
+    // sp = await this.scrollPosition
+    // console.log(sp)
+    // console.log(await this.pathname)
+    // this.assert.ok(sp.y > 100)
+    this.nextBeat
+    this.assert.notOk(await this.isScrolledToTop(), "stayed scrolled down")
+
+    await this.nextBody
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/visit_control_reload.html")
+    this.assert.equal(await this.visitAction, "load")
+  }
+
   async "test accumulates asset elements in head"() {
     const originalElements = await this.assetElements
 

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -56,20 +56,18 @@ export class RenderingTests extends TurboDriveTestCase {
     await this.scrollToSelector("#below-the-fold-visit-control-reload-link")
     this.assert.notOk(await this.isScrolledToTop(), "scrolled down")
 
-    this.remote.execute(() => addEventListener("turbo:click", () => {
-      let scrolls = 0
-      addEventListener("scroll", () => {
-        scrolls++
-        localStorage.setItem("scrolls", String(scrolls))
-      })
+    await this.remote.execute(() => localStorage.setItem("scrolls", "false"))
+
+    this.remote.execute(() => addEventListener("scroll", () => {
+      localStorage.setItem("scrolls", "true")
     }))
 
     this.clickSelector("#below-the-fold-visit-control-reload-link")
 
     await this.nextBody
 
-    const scrolls = await this.remote.execute(() => Number(localStorage.getItem("scrolls")))
-    this.assert.ok(scrolls === 0, "scroll position is preserved")
+    const scrolls = await this.remote.execute(() => localStorage.getItem("scrolls"))
+    this.assert.ok(scrolls === "false", "scroll position is preserved")
 
     this.assert.equal(await this.pathname, "/src/tests/fixtures/visit_control_reload.html")
     this.assert.equal(await this.visitAction, "load")


### PR DESCRIPTION
Potential solution for https://github.com/hotwired/turbo/issues/387

This change updates how we handle scrolling when the page gets reloaded due to a `reload` directive.

I'm not sure if this is the proper way to gate the behavior but I was able to confirm the fix manual using the fixtures html files.

I'd also love to hear if there is a good way write a test for this fix.

## Before:

https://user-images.githubusercontent.com/2181356/163845443-0c025ea8-5c5c-465e-9c6e-c886164bea72.mov


## After:

https://user-images.githubusercontent.com/2181356/163845321-6354af64-b160-47ae-86fc-922e112614c1.mov

