### PR TITLE
Generated: execute `yarn lint --fix`

### DIFF
--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -12,13 +12,13 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
   get reloadReason(): ReloadReason {
     if (!this.newSnapshot.isVisitable) {
       return {
-        reason: "turbo_visit_control_is_reload"
+        reason: "turbo_visit_control_is_reload",
       }
     }
 
     if (!this.trackedElementsAreIdentical) {
       return {
-        reason: "tracked_element_mismatch"
+        reason: "tracked_element_mismatch",
       }
     }
   }

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -8,7 +8,7 @@ import { uuid, dispatch } from "../../util"
 export type ReloadReason = StructuredReason | undefined
 interface StructuredReason {
   reason: string
-  context?: {[key: string]: any}
+  context?: { [key: string]: any }
 }
 
 export class BrowserAdapter implements Adapter {
@@ -54,8 +54,8 @@ export class BrowserAdapter implements Adapter {
         return this.reload({
           reason: "request_failed",
           context: {
-            statusCode
-          }
+            statusCode,
+          },
         })
       default:
         return visit.loadResponse()

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -128,7 +128,7 @@ export class Session
       })
     } else {
       this.adapter.pageInvalidated({
-        reason: "turbo_disabled"
+        reason: "turbo_disabled",
       })
     }
   }

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -25,6 +25,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.getAlertText(), "Are you sure?")
     await this.acceptAlert()
+    await this.nextEventNamed("turbo:load")
     this.assert.ok(await this.formSubmitStarted)
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
   }
@@ -42,6 +43,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     this.assert.equal(await this.getAlertText(), "Are you really sure?")
     await this.acceptAlert()
+    await this.nextEventNamed("turbo:load")
     this.assert.ok(await this.formSubmitStarted)
     this.assert.equal(await this.pathname, "/src/tests/fixtures/one.html")
     this.assert.equal(await this.visitAction, "advance")


### PR DESCRIPTION
Generated: execute `yarn lint --fix`
===

Follow-up to [hotwired/turbo#573][].

ESLint support was recently merged and integrated in to the Continuous
Integration checks, but excluded several existing linting violations.

This commit's diff was generated by executing `yarn lint --fix`.

These violations were discovered when rebasing [hotwired/turbo#436][].
Once this is passing and merged, these changes will be rebased into that
branch's changeset.

[hotwired/turbo#573]: https://github.com/hotwired/turbo/pull/573
[hotwired/turbo#436]: https://github.com/hotwired/turbo/pull/436/files

Resolve failing `FormSubmissionTest`
===

There is a race condition in the `FormSubmissionTest` file's coverage
for confirmation. If evaluated quickly enough, the test's assertions
might be checked before the subsequent Turbo Driver navigation occurs,
which would fail the check for the Form Submission's change to the
current path.

This commit adds an additional `await` expression to wait until the next
[turbo:load][] event to fire, so that the entire navigation can complete
before the assertions are evaluated.

[turbo:load]: https://turbo.hotwired.dev/reference/events
