### PR TITLE
fix(ie/edge): form.method='delete', raises Invalid argument.

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -164,7 +164,7 @@ export class Session
 
     if (linkMethod) {
       const form = document.createElement("form")
-      form.method = linkMethod
+      form.setAttribute("method", linkMethod)
       form.action = link.getAttribute("href") || "undefined"
       form.hidden = true
 


### PR DESCRIPTION
IE issue (edge) : FormElement.method attribute only accepts "get|post". To my surprise, it seems to be the expected behaviour from the spec: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-attributes. TLDR ;
```
The method and formmethod content attributes are [enumerated attributes](https://html.spec.whatwg.org/multipage/common-microsyntaxes.html#enumerated-attribute) with the following keywords and states:
    The keyword get, mapping to the state GET, indicating the HTTP GET method.
    The keyword post, mapping to the state POST, indicating the HTTP POST method.
    The keyword dialog, mapping to the state dialog, indicating that submitting the [form](https://html.spec.whatwg.org/multipage/forms.html#the-form-element) is intended to close the [dialog](https://html.spec.whatwg.org/multipage/interactive-elements.html#the-dialog-element) box in which the form finds itself, if any, and otherwise not submit.
```
So when the `form.method` attribute is not `get` or `post` IE/edge raises an Invalid argument error. How to reproduce: open ie edge console : `document.createElement('form').method="delete"` > raise Invalid arg
At first, to avoid this issue, we I went the rails way creating an `<input type="hidden" value="{linkMethod}" name="_method" />` appended to the "virtual" form. But tchak is right ; form.setAttribute('method') make it works
 