### PR TITLE
Prevent silent restoration visits when previous visit request is in-flight

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -17,6 +17,7 @@ export class Navigator {
   readonly delegate: NavigatorDelegate
   formSubmission?: FormSubmission
   currentVisit?: Visit
+  lastVisit?: Visit
 
   constructor(delegate: NavigatorDelegate) {
     this.delegate = delegate
@@ -33,6 +34,7 @@ export class Navigator {
   }
 
   startVisit(locatable: Locatable, restorationIdentifier: string, options: Partial<VisitOptions> = {}) {
+    this.lastVisit = this.currentVisit
     this.stop()
     this.currentVisit = new Visit(this, expandURL(locatable), restorationIdentifier, {
       referrer: this.location,
@@ -138,12 +140,13 @@ export class Navigator {
 
   locationWithActionIsSamePage(location: URL, action?: Action): boolean {
     const anchor = getAnchor(location)
-    const currentAnchor = getAnchor(this.view.lastRenderedLocation)
+    const lastLocation = this.lastVisit?.location || this.view.lastRenderedLocation
+    const currentAnchor = getAnchor(lastLocation)
     const isRestorationToTop = action === "restore" && typeof anchor === "undefined"
 
     return (
       action !== "replace" &&
-      getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
+      getRequestURL(location) === getRequestURL(lastLocation) &&
       (isRestorationToTop || (anchor != null && anchor !== currentAnchor))
     )
   }

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -18,7 +18,9 @@ export class PageView extends View<Element, PageSnapshot, PageViewRenderer, Page
 
   renderPage(snapshot: PageSnapshot, isPreview = false, willRender = true) {
     const renderer = new PageRenderer(this.snapshot, snapshot, isPreview, willRender)
-    if (!renderer.shouldRender) { this.forceReloaded = true }
+    if (!renderer.shouldRender) {
+      this.forceReloaded = true
+    }
     return this.render(renderer)
   }
 

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -313,6 +313,21 @@ export class NavigationTests extends TurboDriveTestCase {
     this.assert.equal(await this.pathname, "/__turbo/delayed_response")
     this.assert.equal(await this.visitAction, "advance")
   }
+
+  async "test navigating back whilst a visit is in-flight"() {
+    this.clickSelector("#delayed-link")
+    await this.nextBeat
+    await this.goBack()
+
+    this.assert.ok(
+      await this.nextEventNamed("turbo:visit"),
+      "navigating back whilst a visit is in-flight starts a non-silent Visit"
+    )
+
+    await this.nextBody
+    this.assert.equal(await this.pathname, "/src/tests/fixtures/navigation.html")
+    this.assert.equal(await this.visitAction, "restore")
+  }
 }
 
 NavigationTests.registerSuite()

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -78,9 +78,11 @@ export class RenderingTests extends TurboDriveTestCase {
 
     await this.remote.execute(() => localStorage.setItem("scrolls", "false"))
 
-    this.remote.execute(() => addEventListener("scroll", () => {
-      localStorage.setItem("scrolls", "true")
-    }))
+    this.remote.execute(() =>
+      addEventListener("scroll", () => {
+        localStorage.setItem("scrolls", "true")
+      })
+    )
 
     this.clickSelector("#below-the-fold-visit-control-reload-link")
 


### PR DESCRIPTION
Silent Visits don't dispatch events. A Visit is deemed to be silent if its location is on the current page. Prior to this commit, this is determined by checking the last rendered location. This approach can result in false positives if a Visit is interrupted and never gets rendered. For example, tapping a link, then immediately navigating back, will be incorrectly considered a same-page visit. Checking the previous location using window.location is also not possible on Back/Forward because it is changed _before_ the popstate event, so by the time a new Visit is created, the location has already changed.

This commit accurately compares the last visited location by storing a reference to the lastVisit on the Navigator, falling back to the View's lastRenderedLocation.

Fixes #594 