### PR TITLE
Support development ChromeDriver version overrides

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,7 @@ jobs:
       run: |
         CHROMEVER="$(chromedriver --version | cut -d' ' -f2)"
         echo "Actions ChromeDriver is $CHROMEVER"
-        CONTENTS="$(jq '.tunnelOptions.drivers[0].name = "chrome"' < intern.json)"
-        CONTENTS="$(echo ${CONTENTS} | jq --arg chromever "$CHROMEVER" '.tunnelOptions.drivers[0].version = $chromever')"
-        echo "${CONTENTS}" > intern.json
-        cat intern.json
+        echo "CHROMEVER=${CHROMEVER}" >> $GITHUB_ENV
 
     - name: Lint
       run: yarn lint

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,6 +36,9 @@ Once you are done developing the feature or bug fix you have 2 options:
 ### Testing
 The library is tested by running the test suite (found in: `src/tests/*`) against headless browsers. The browsers are setup in `intern.json` check it out to see the used browser environments.
 
+To override the ChromeDriver version, declare the `CHROMEVER` environment
+variable.
+
 The tests are using the compiled version of the library and they are themselves also compiled. To compile the tests and library and watch for changes:
 
 ```bash

--- a/src/tests/runner.js
+++ b/src/tests/runner.js
@@ -2,6 +2,7 @@ const { TestServer } = require("../../dist/tests/server")
 const configuration = require("../../intern.json")
 const intern = require("intern").default
 const arg = require("arg");
+const { CHROMEVER } = process.env
 
 const args = arg({
   "--grep": String,
@@ -10,6 +11,14 @@ const args = arg({
 
 intern.configure(configuration)
 intern.configure({ reporters: [ "runner" ] })
+
+if (CHROMEVER) {
+  intern.configure({
+    tunnelOptions: {
+      drivers: [{ name: "chrome", version: CHROMEVER }]
+    }
+  })
+}
 
 if (args["--grep"]) {
   intern.configure({ grep: args["--grep"] })


### PR DESCRIPTION
Refines the changes introduced to the CI configuration made in
[b1cbe12][].

Recent Chrome upgrades are causing errors like the following while
executing the test suite locally:

```
SessionNotCreatedException: [POST http://localhost:4444/wd/hub/session / {"desiredCapabilities":{"name":"intern","idle-timeout":60,"browserName":"chrome","goog:chromeOptions":{"args":["headless","disable-gpu","no-sandbox"]},"browser":"chrome"}}] session not created: This version of ChromeDriver only supports Chrome version 99
Current browser version is 102.0.5005.115 with binary path
```

The **only supports Chrome version 99** portion is due to `digdug`'s
locked-support for Chrome version 99 declared in its [webdrivers.json][]
file.

This commit checks for the presence of the `CHROMEWEBDRIVER` environment
variable, and overrides the [intern.json](./intern.json) configuration
to incorporate that into its `tunnelOptions.drivers` value.

[webdrivers.json]: https://github.com/theintern/digdug/blob/806dcf29c2265d3cb1a26a09ef5b43e93fc2a739/src/webdrivers.json#L8-L11
[b1cbe12]: https://github.com/hotwired/turbo/pull/551/commits/b1cbe123895259408d35b1c918ab2e9a51ba6683