### PR TITLE
Allow isHTML to be overridden

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -52,6 +52,7 @@ export class Session
   progressBarDelay = 500
   started = false
   formMode = "on"
+  isHTML:any = null
 
   start() {
     if (!this.started) {

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,3 +1,5 @@
+import { session } from "../index"
+
 export type Locatable = URL | string
 
 export function expandURL(locatable: Locatable) {
@@ -25,6 +27,10 @@ export function getExtension(url: URL) {
 }
 
 export function isHTML(url: URL) {
+  if (typeof(session.isHTML) === "function") { 
+    return session.isHTML(url);
+  }
+
   return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml))$/)
 }
 


### PR DESCRIPTION
This exposes isHTML as a session variable to allow overriding the function used in the same manner as ```Turbo.session.drive = false``` can be used to disable turbo functionality by default and placing it in opt-in mode. To modify the default isHTML check one can simply do the following. 

```
Turbo.session.isHTML = (url) => { return true; }
```