### PR TITLE
Allow Turbo Streams with GET requests

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -2,7 +2,6 @@ import { FetchRequest, FetchMethod, fetchMethodFromString, FetchRequestHeaders }
 import { FetchResponse } from "../../http/fetch_response"
 import { expandURL } from "../url"
 import { dispatch } from "../../util"
-import { StreamMessage } from "../streams/stream_message"
 
 export interface FormSubmissionDelegate {
   formSubmissionStarted(formSubmission: FormSubmission): void
@@ -153,7 +152,6 @@ export class FormSubmission {
       if (token) {
         headers["X-CSRF-Token"] = token
       }
-      headers["Accept"] = [StreamMessage.contentType, headers["Accept"]].join(", ")
     }
   }
 

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -1,6 +1,7 @@
 import { FetchResponse } from "./fetch_response"
 import { FrameElement } from "../elements/frame_element"
 import { dispatch } from "../util"
+import { StreamMessage } from "../core/streams/stream_message"
 
 export interface FetchRequestDelegate {
   referrer?: URL
@@ -137,7 +138,7 @@ export class FetchRequest {
 
   get defaultHeaders() {
     return {
-      Accept: "text/html, application/xhtml+xml",
+      Accept: [StreamMessage.contentType, "text/html", "application/xhtml+xml"].join(", "),
     }
   }
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -157,7 +157,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     const { fetchOptions } = await this.nextEventNamed("turbo:before-fetch-request")
 
-    this.assert.notOk(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+    this.assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
 
     await this.nextEventNamed("turbo:before-fetch-response")
 
@@ -486,7 +486,7 @@ export class FormSubmissionTests extends TurboDriveTestCase {
 
     const { fetchOptions } = await this.nextEventNamed("turbo:before-fetch-request")
 
-    this.assert.notOk(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+    this.assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
     this.assert.equal("frame", fetchOptions.headers["Turbo-Frame"])
 
     await this.nextEventNamed("turbo:before-fetch-response")


### PR DESCRIPTION
**Note: this is an alternative to #612**

This PR makes Turbo Streams work with all Turbo HTTP requests, including `GET` requests.

## Motivation

Currently, Turbo restricts the HTTP use of Turbo Streams to non-`GET` form submissions. This makes sense when those stream responses correspond to server-side state changes. However there are also cases where it's useful to send targeted DOM updates when not updating server state.

We already allow targeted DOM updates with any request method when using Turbo Frames. And in cases where a request affects a single DOM element, Turbo Frames will often be the most straightforward option. But when you have a change that doesn't fit within a frame, we should make it easy for people to reach for Turbo Streams instead.

Some situations where you might want a stream response to a `GET` include:

- Updating multiple DOM areas at once, such as to change a header when switching in the editable view of a component.
- Any time the inclusion of a `<turbo-frame>` element would disrupt layout.
- When you're appending content, rather than replacing it, for example adding repeated sections to a form.

## Alternatives

- #612 provides a way to opt-in to this behaviour, via a new `data-turbo-stream` attribute. That has the advantage of not changing default behaviour. The downside is that needing to use an attribute to enable streams over `GET` seems non-obvious (it's not needed for Turbo Frames, for example), so we would rely on documentation to help users find it.

- It's possible to achieve this behaviour in application code by intercepting `turbo:before-fetch-request` to modify the `Accept` header. However, putting the onus on the user to do this goes against Turbo's spirit of reducing the need for client-side JavaScript, and again, it's not obvious why it should be needed.
