### PR TITLE
Lazy load Frame styled with `display: contents`

### DIFF
--- a/src/tests/fixtures/loading.html
+++ b/src/tests/fixtures/loading.html
@@ -7,6 +7,8 @@
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
+    <turbo-frame style="display: contents;" id="eager-loaded-frame" src="/src/tests/fixtures/frames/frame_for-eager.html" loading="lazy"></turbo-frame>
+
     <details id="loading-lazy">
       <summary>Lazy-loaded</summary>
 

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -17,6 +17,13 @@ export class LoadingTests extends TurboDriveTestCase {
     this.assert.ok(await this.hasSelector("#loading-eager turbo-frame[complete]"), "has [complete] attribute")
   }
 
+  async "test lazy loading for a frame with display: contents"() {
+    await this.nextBeat
+
+    const frameContents = await this.querySelector("#eager-loaded-frame h2")
+    this.assert.equal(await frameContents.getVisibleText(), "Eager-loaded frame: Loaded")
+  }
+
   async "test lazy loading within a details element"() {
     await this.nextBeat
 


### PR DESCRIPTION
Reproduces [hotwired/turbo#625][]

When a `<turbo-frame>` element is styled as [`display:
contents`](https://developer.mozilla.org/en-US/docs/Web/CSS/display#box),
it derives its box model from its descendants, and browsers treat it as
if the element itself is not present in the document.

Unfortunately, [since it's "omitted" from the
document](https://stackoverflow.com/q/72741599), the underlying
[IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API)
instance that powers the
[`[loading="lazy"]`](https://turbo.hotwired.dev/reference/frames#html-attributes)
behavior never detects when the `<turbo-frame>` contents enter the
viewport.

[hotwired/turbo#625]: https://github.com/hotwired/turbo/issues/625