### PR TITLE
Add .php as a valid isHTML extension

### DIFF
--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -25,7 +25,7 @@ export function getExtension(url: URL) {
 }
 
 export function isHTML(url: URL) {
-  return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml))$/)
+  return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml|php))$/)
 }
 
 export function isPrefixedBy(baseURL: URL, url: URL) {


### PR DESCRIPTION
Before we fully resolve #519, we can sort out the main hurt from this, which seems to be .php extensions.