### PR TITLE
Treat `[data-turbo-stream]` as boolean attribute

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -1,7 +1,7 @@
 import { FetchRequest, FetchMethod, fetchMethodFromString, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { expandURL } from "../url"
-import { attributeTrue, dispatch, getMetaContent } from "../../util"
+import { dispatch, getMetaContent } from "../../util"
 import { StreamMessage } from "../streams/stream_message"
 
 export interface FormSubmissionDelegate {
@@ -219,7 +219,7 @@ export class FormSubmission {
   }
 
   requestAcceptsTurboStreamResponse(request: FetchRequest) {
-    return !request.isIdempotent || attributeTrue(this.formElement, "data-turbo-stream")
+    return !request.isIdempotent || this.formElement.hasAttribute("data-turbo-stream")
   }
 }
 

--- a/src/observers/form_link_interceptor.ts
+++ b/src/observers/form_link_interceptor.ts
@@ -41,8 +41,8 @@ export class FormLinkInterceptor implements LinkInterceptorDelegate {
     const turboConfirm = link.getAttribute("data-turbo-confirm")
     if (turboConfirm) form.setAttribute("data-turbo-confirm", turboConfirm)
 
-    const turboStream = link.getAttribute("data-turbo-stream")
-    if (turboStream) form.setAttribute("data-turbo-stream", turboStream)
+    const turboStream = link.hasAttribute("data-turbo-stream")
+    if (turboStream) form.setAttribute("data-turbo-stream", "")
 
     this.delegate.formLinkClickIntercepted(link, form)
 

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -25,7 +25,7 @@
         <input type="hidden" name="greeting" value="Hello from a redirect">
         <input id="standard-get-form-submit" type="submit" value="form[method=get]">
       </form>
-      <form action="/__turbo/redirect" method="get" data-turbo-stream="true" class="redirect">
+      <form action="/__turbo/redirect" method="get" data-turbo-stream class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
         <input type="hidden" name="greeting" value="Hello from a redirect">
         <input id="standard-get-form-with-stream-opt-in-submit" type="submit" value="form[method=get]">
@@ -259,8 +259,8 @@
       <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" data-turbo-frame="_top" id="link-method-inside-frame-target-top">Break-out of frame with method link inside frame</a><br />
       <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" data-turbo-frame="hello" id="link-method-inside-frame-with-target">Method link inside frame targeting another frame</a><br />
       <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-inside-frame">Stream link inside frame</a>
-      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="get" data-turbo-stream="true" id="stream-link-get-method-inside-frame">Stream link GET inside frame</a>
-      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-stream="true" id="stream-link-inside-frame">Stream link (no method) inside frame</a>
+      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="get" data-turbo-stream id="stream-link-get-method-inside-frame">Stream link GET inside frame</a>
+      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-stream id="stream-link-inside-frame">Stream link (no method) inside frame</a>
       <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" data-turbo-confirm="Are you sure?" id="link-method-inside-frame-with-confirmation"data-turbo-confirm="Are you sure?">Stream link inside frame with confirmation</a>
       <form>
         <a href="/src/tests/fixtures/frames/frame.html" data-turbo-method="get" id="method-link-within-form-inside-frame">Method link within form inside frame</a><br />
@@ -290,7 +290,7 @@
     </turbo-frame>
     <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-outside-frame">Method link outside frame</a><br />
     <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-outside-frame">Stream link outside frame</a>
-    <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-stream="true" id="stream-link-outside-frame">Stream link (no method) outside frame</a>
+    <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-stream id="stream-link-outside-frame">Stream link (no method) outside frame</a>
     <form>
       <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-within-form-outside-frame">Method link within form outside frame</a><br />
       <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-within-form-outside-frame">Stream link within form outside frame</a>

--- a/src/util.ts
+++ b/src/util.ts
@@ -96,10 +96,6 @@ export function clearBusyState(...elements: Element[]) {
   }
 }
 
-export function attributeTrue(element: Element, attributeName: string) {
-  return element.getAttribute(attributeName) === "true"
-}
-
 export function getMetaElement(name: string): HTMLMetaElement | null {
   return document.querySelector(`meta[name="${name}"]`)
 }


### PR DESCRIPTION
Replace equality checks for `[data-turbo-stream="true"]` with presence
checks for `[data-turbo-stream]` to more closely match the canonical
behavior for [boolean HTML attributes][].

Turbo already supports other boolean attributes like
`[data-turbo-permanent]` and `[data-turbo-confirm]`, so
`[data-turbo-stream]` should match the precedent.

[boolean HTML attributes]: https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes#boolean_attributes