### PR TITLE
Introduce `FormLinkInterceptor`

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -7,7 +7,7 @@ import {
 import { FetchMethod, FetchRequest, FetchRequestDelegate, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/appearance_observer"
-import { clearBusyState, getAttribute, parseHTMLDocument, markAsBusy, attributeTrue } from "../../util"
+import { clearBusyState, getAttribute, parseHTMLDocument, markAsBusy } from "../../util"
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
 import { ViewDelegate } from "../view"
@@ -15,6 +15,7 @@ import { getAction, expandURL, urlsAreEqual, locationIsVisitable } from "../url"
 import { FormInterceptor, FormInterceptorDelegate } from "./form_interceptor"
 import { FrameView } from "./frame_view"
 import { LinkInterceptor, LinkInterceptorDelegate } from "./link_interceptor"
+import { FormLinkInterceptor, FormLinkInterceptorDelegate } from "../../observers/form_link_interceptor"
 import { FrameRenderer } from "./frame_renderer"
 import { session } from "../index"
 import { isAction } from "../types"
@@ -26,12 +27,14 @@ export class FrameController
     FormInterceptorDelegate,
     FormSubmissionDelegate,
     FrameElementDelegate,
+    FormLinkInterceptorDelegate,
     LinkInterceptorDelegate,
     ViewDelegate<Snapshot<FrameElement>>
 {
   readonly element: FrameElement
   readonly view: FrameView
   readonly appearanceObserver: AppearanceObserver
+  readonly formLinkInterceptor: FormLinkInterceptor
   readonly linkInterceptor: LinkInterceptor
   readonly formInterceptor: FormInterceptor
   formSubmission?: FormSubmission
@@ -46,6 +49,7 @@ export class FrameController
     this.element = element
     this.view = new FrameView(this, this.element)
     this.appearanceObserver = new AppearanceObserver(this, this.element)
+    this.formLinkInterceptor = new FormLinkInterceptor(this, this.element)
     this.linkInterceptor = new LinkInterceptor(this, this.element)
     this.formInterceptor = new FormInterceptor(this, this.element)
   }
@@ -58,6 +62,7 @@ export class FrameController
       } else {
         this.loadSourceURL()
       }
+      this.formLinkInterceptor.start()
       this.linkInterceptor.start()
       this.formInterceptor.start()
     }
@@ -67,6 +72,7 @@ export class FrameController
     if (this.connected) {
       this.connected = false
       this.appearanceObserver.stop()
+      this.formLinkInterceptor.stop()
       this.linkInterceptor.stop()
       this.formInterceptor.stop()
     }
@@ -146,14 +152,21 @@ export class FrameController
     this.loadSourceURL()
   }
 
+  // Form link interceptor delegate
+
+  shouldInterceptFormLinkClick(link: Element): boolean {
+    return this.shouldInterceptNavigation(link)
+  }
+
+  formLinkClickIntercepted(link: Element, form: HTMLFormElement): void {
+    const frame = this.findFrameElement(link)
+    if (frame) form.setAttribute("data-turbo-frame", frame.id)
+  }
+
   // Link interceptor delegate
 
   shouldInterceptLinkClick(element: Element, _url: string) {
-    if (element.hasAttribute("data-turbo-method") || attributeTrue(element, "data-turbo-stream")) {
-      return false
-    } else {
-      return this.shouldInterceptNavigation(element)
-    }
+    return this.shouldInterceptNavigation(element)
   }
 
   linkClickIntercepted(element: Element, url: string) {

--- a/src/observers/form_link_interceptor.ts
+++ b/src/observers/form_link_interceptor.ts
@@ -31,8 +31,9 @@ export class FormLinkInterceptor implements LinkInterceptorDelegate {
 
   linkClickIntercepted(link: Element, action: string): void {
     const form = document.createElement("form")
+    form.setAttribute("data-turbo", "true")
     form.setAttribute("action", action)
-    form.hidden = true
+    form.setAttribute("hidden", "")
 
     const method = link.getAttribute("data-turbo-method")
     if (method) form.setAttribute("method", method)

--- a/src/observers/form_link_interceptor.ts
+++ b/src/observers/form_link_interceptor.ts
@@ -1,0 +1,52 @@
+import { LinkInterceptor, LinkInterceptorDelegate } from "../core/frames/link_interceptor"
+
+export type FormLinkInterceptorDelegate = {
+  shouldInterceptFormLinkClick(link: Element): boolean
+  formLinkClickIntercepted(link: Element, form: HTMLFormElement): void
+}
+
+export class FormLinkInterceptor implements LinkInterceptorDelegate {
+  readonly linkInterceptor: LinkInterceptor
+  readonly delegate: FormLinkInterceptorDelegate
+
+  constructor(delegate: FormLinkInterceptorDelegate, element: HTMLElement) {
+    this.delegate = delegate
+    this.linkInterceptor = new LinkInterceptor(this, element)
+  }
+
+  start() {
+    this.linkInterceptor.start()
+  }
+
+  stop() {
+    this.linkInterceptor.stop()
+  }
+
+  shouldInterceptLinkClick(link: Element): boolean {
+    return (
+      this.delegate.shouldInterceptFormLinkClick(link) &&
+      (link.hasAttribute("data-turbo-method") || link.hasAttribute("data-turbo-stream"))
+    )
+  }
+
+  linkClickIntercepted(link: Element, action: string): void {
+    const form = document.createElement("form")
+    form.setAttribute("action", action)
+    form.hidden = true
+
+    const method = link.getAttribute("data-turbo-method")
+    if (method) form.setAttribute("method", method)
+
+    const turboConfirm = link.getAttribute("data-turbo-confirm")
+    if (turboConfirm) form.setAttribute("data-turbo-confirm", turboConfirm)
+
+    const turboStream = link.getAttribute("data-turbo-stream")
+    if (turboStream) form.setAttribute("data-turbo-stream", turboStream)
+
+    this.delegate.formLinkClickIntercepted(link, form)
+
+    document.body.appendChild(form)
+    form.requestSubmit()
+    form.remove()
+  }
+}

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -299,6 +299,7 @@
     <form method="post" action="https://httpbin.org/post">
       <button id="submit-external">POST to https://httpbin.org/post</button>
     </form>
+     <a href="/__turbo/redirect?path=/src/tests/fixtures/frames/hello.html" data-turbo-method="post" data-turbo-frame="hello" id="turbo-method-post-to-targeted-frame">Turbo method post to targeted frame</a>
     <turbo-frame id="hello"></turbo-frame>
     <hr>
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -976,6 +976,16 @@ test("test POST to external action targetting frame ignored", async ({ page }) =
   assert.equal(page.url(), "https://httpbin.org/post")
 })
 
+test("test following a link with data-turbo-method set and a target set navigates the target frame", async ({
+  page,
+}) => {
+  await page.click("#turbo-method-post-to-targeted-frame")
+  await nextBeat()
+
+  const frameText = await page.locator("#hello h2")
+  assert.equal(await frameText.textContent(), "Hello from a frame")
+})
+
 function formSubmitStarted(page: Page) {
   return getFromLocalStorage(page, "formSubmitStarted")
 }


### PR DESCRIPTION
In an effort to match the patterns established by `LinkInterceptor`
and `FormInterceptor`, this commit introduces a
`FormLinkInterceptor` and `FormLinkInterceptorDelegate`.

Behind the scenes, the `FormLinkInterceptor` relies on an instance of
the `LinkInterceptor` to intervene in `<a>` element clicks when
`[data-turbo-method]` or `[data-turbo-stream]` are present. When those
clicks are detected, it creates a `<form hidden>` element, attaches it
to the document, delegates to a `FormLinkInterceptorDelegate` to map
the `<a>` element's attributes to the `<form>` element, submits the form
through the polyfilled [HTMLFormElement.requestSubmit][] method, then
removes the `<form>` from the document.

The `Session` serves as a `FormLinkInterceptorDelegate`, making sure
to start and stop the observer _before_ its `LinkInterceptor`
instance, so that clicks that are intercepted by the
`FormLinkInterceptor` are not also intercepted by the
`LinkInterceptor`.

[HTMLFormElement.requestSubmit]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit