### PR TITLE
Introduce client-side Turbo Cache Control API

### DIFF
--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,0 +1,30 @@
+import { Session } from "./session"
+import { setMetaContent } from "../util"
+
+export class Cache {
+  readonly session: Session
+
+  constructor(session: Session) {
+    this.session = session
+  }
+
+  clear() {
+    this.session.clearCache()
+  }
+
+  resetCacheControl() {
+    this.setCacheControl("")
+  }
+
+  exemptPageFromCache() {
+    this.setCacheControl("no-cache")
+  }
+
+  exemptPageFromPreview() {
+    this.setCacheControl("no-preview")
+  }
+
+  private setCacheControl(value: string) {
+    setMetaContent("turbo-cache-control", value)
+  }
+}

--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -1,7 +1,7 @@
 import { FetchRequest, FetchMethod, fetchMethodFromString, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { expandURL } from "../url"
-import { attributeTrue, dispatch } from "../../util"
+import { attributeTrue, dispatch, getMetaContent } from "../../util"
 import { StreamMessage } from "../streams/stream_message"
 
 export interface FormSubmissionDelegate {
@@ -244,11 +244,6 @@ function getCookieValue(cookieName: string | null) {
       return value ? decodeURIComponent(value) : undefined
     }
   }
-}
-
-function getMetaContent(name: string) {
-  const element: HTMLMetaElement | null = document.querySelector(`meta[name="${name}"]`)
-  return element && element.content
 }
 
 function responseSucceededWithoutRedirect(response: FetchResponse) {

--- a/src/core/drive/progress_bar.ts
+++ b/src/core/drive/progress_bar.ts
@@ -1,4 +1,4 @@
-import { unindent } from "../../util"
+import { unindent, getMetaContent } from "../../util"
 
 export class ProgressBar {
   static animationDuration = 300 /*ms*/
@@ -123,6 +123,6 @@ export class ProgressBar {
   }
 
   get cspNonce() {
-    return document.head.querySelector('meta[name="csp-nonce"]')?.getAttribute("content")
+    return getMetaContent("csp-nonce")
   }
 }

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,5 +1,6 @@
 import { Adapter } from "./native/adapter"
 import { Session } from "./session"
+import { Cache } from "./cache"
 import { Locatable } from "./url"
 import { StreamMessage } from "./streams/stream_message"
 import { StreamSource } from "./types"
@@ -10,8 +11,9 @@ import { FrameRenderer } from "./frames/frame_renderer"
 import { FormSubmission } from "./drive/form_submission"
 
 const session = new Session()
+const cache = new Cache(session)
 const { navigator } = session
-export { navigator, session, PageRenderer, PageSnapshot, FrameRenderer }
+export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer }
 export {
   TurboBeforeCacheEvent,
   TurboBeforeRenderEvent,

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,6 +1,7 @@
 import { Bardo, BardoDelegate } from "./bardo"
 import { Snapshot } from "./snapshot"
 import { ReloadReason } from "./native/browser_adapter"
+import { getMetaContent } from "../util"
 
 type ResolvingFunctions<T = unknown> = {
   resolve(value: T | PromiseLike<T>): void
@@ -106,7 +107,7 @@ export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapsh
   }
 
   get cspNonce() {
-    return document.head.querySelector('meta[name="csp-nonce"]')?.getAttribute("content")
+    return getMetaContent("csp-nonce")
   }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -99,3 +99,27 @@ export function clearBusyState(...elements: Element[]) {
 export function attributeTrue(element: Element, attributeName: string) {
   return element.getAttribute(attributeName) === "true"
 }
+
+export function getMetaElement(name: string): HTMLMetaElement | null {
+  return document.querySelector(`meta[name="${name}"]`)
+}
+
+export function getMetaContent(name: string) {
+  const element = getMetaElement(name)
+  return element && element.content
+}
+
+export function setMetaContent(name: string, content: string) {
+  let element = getMetaElement(name)
+
+  if (!element) {
+    element = document.createElement("meta")
+    element.setAttribute("name", name)
+
+    document.head.appendChild(element)
+  }
+
+  element.setAttribute("content", content)
+
+  return element
+}


### PR DESCRIPTION
This Pull Request introduces a `Cache` class which exposes an API as `Turbo.cache` that can be used to control the value of the `turbo-cache-control` meta element form the client-side.

Most of the times you just need to the set the value of the `turbo-cache-control` meta element from the server-side when you are responding to your regular HTML request, based on if you want that page to be cached or not.

I encountered a few use-cases in a couple of apps I worked on where you dynamically want to set the cache control behavior after a certain action happened on the client (i.e. you don't want to show remaining artifacts of a finished animation in a later visit, but if the animation wasn't triggered you still want that page to be properly cached).

You can achieve a similar behavior by dynamically prepending a `<meta>` element to the `<head>` via JavaScript, like:
```javascript
document.head.insertAdjacentHTML(
  'beforeend',
  '<meta name="turbo-cache-control" content="no-cache">'
)
```

Though, this feels very error-prone and doesn't account for duplicate `<meta>` elements in the `<head>`.

This Pull Request aims to simplify this by exposing a client-side API to control the value of the meta element with just the values Turbo actually knows about. With that, the above example becomes:
```javascript
Turbo.cache.exemptPageFromCache()
```

The name of the exposed functions are kept in-line with the helpers in:
https://github.com/hotwired/turbo-rails/blob/43bf84a9b1d2cc78da6810b82f92be2c32c9dbfd/app/helpers/turbo/drive_helper.rb#L15-L23

**Open Points / Design Decisions:** 

- [ ] Introducing a `Cache` class and exposing an instance of said class as `Turbo.cache` might be overkill. It might be just fine to instead add the helpers as top-level functions, similar as with the `Turbo.clearCache()` helper.
  - `Turbo.cache.exemptPageFromCache()`  => `Turbo.exemptPageFromCache()`
  - `Turbo.cache.exemptPageFromPreview()` =>  `Turbo.exemptPageFromPreview()`
  
- [ ] The helper names `exemptPageFromCache()` and `exemptPageFromPreview()` don't exactly line up the with attribute values.
  - An alternative would be to do something like `Turbo.cache.noCache()` / `Turbo.cache.noPreview()`