### PR TITLE
[Flaky Tests]: Link Form Submission

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,10 +35,10 @@ jobs:
       run: yarn test:unit
 
     - name: Chrome Test
-      run: yarn test:browser --project=chrome
+      run: yarn test:browser --project=chrome --reporter=github
 
     - name: Firefox Test
-      run: yarn test:browser --project=firefox
+      run: yarn test:browser --project=firefox --reporter=github
 
     - name: Upload test results
       if: always()

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -25,6 +25,7 @@ import {
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/form.html")
+  await page.evaluate(() => (window.Turbo.session.drive = true))
   await setLocalStorageFromEvent(page, "turbo:submit-start", "formSubmitStarted", "true")
   await setLocalStorageFromEvent(page, "turbo:submit-end", "formSubmitEnded", "true")
   await readEventLogs(page)


### PR DESCRIPTION
The test passes consistently locally, but fails consistently in CI:

```
1) [chrome] › form_submission_tests.ts:909:1 › test following a link with [data-turbo-method] and [data-turbo=true] set when html[data-turbo=false]

  AssertionError: does not navigate the full page: expected 'Hello' to equal 'Form'

    918 |   await link.click()

    919 |

  > 920 |   assert.equal(await page.textContent("h1"), "Form", "does not navigate the full page")

        |          ^

    921 |   assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "drives the turbo-frame")

    922 | })

    923 |

      at /home/runner/work/turbo/turbo/src/tests/functional/form_submission_tests.ts:920:10

2) [chrome] › form_submission_tests.ts:924:1 › test following a link with [data-turbo-method] and [data-turbo=true] set when Turbo.session.drive = false

  AssertionError: does not navigate the full page: expected 'Hello' to equal 'Form'

    932 |   await link.click()

    933 |

  > 934 |   assert.equal(await page.textContent("h1"), "Form", "does not navigate the full page")

        |          ^

    935 |   assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "drives the turbo-frame")

    936 | })

    937 |

      at /home/runner/work/turbo/turbo/src/tests/functional/form_submission_tests.ts:934:10
```