### PR TITLE
Add support for data-turbo-action to link_to 

### DIFF
--- a/src/observers/form_link_click_observer.ts
+++ b/src/observers/form_link_click_observer.ts
@@ -42,6 +42,9 @@ export class FormLinkClickObserver implements LinkClickObserverDelegate {
     const turboFrame = link.getAttribute("data-turbo-frame")
     if (turboFrame) form.setAttribute("data-turbo-frame", turboFrame)
 
+    const turboAction = link.getAttribute("data-turbo-action")
+    if (turboAction) form.setAttribute("data-turbo-action", turboAction)
+
     const turboConfirm = link.getAttribute("data-turbo-confirm")
     if (turboConfirm) form.setAttribute("data-turbo-confirm", turboConfirm)
 

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -37,6 +37,7 @@
       <p><a id="same-origin-unannotated-link-search-params" href="/src/tests/fixtures/one.html?key=value">Same-origin unannotated link ?key=value</a></p>
       <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button>Same-origin unannotated form</button></form></p>
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>
+      <p><a id="same-origin-replace-post-link" href="/__turbo/redirect" data-turbo-method="post" data-turbo-action="replace">Same-origin data-turbo-action=replace link with post method</a></p>
       <p><form id="same-origin-replace-form-get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>
       <p><form id="same-origin-replace-form-submitter-get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin data-turbo-action=replace form</button></form></p>
       <form id="same-origin-replace-form-post" method="post" action="/__turbo/redirect" data-turbo-action="replace">

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -37,7 +37,6 @@
       <p><a id="same-origin-unannotated-link-search-params" href="/src/tests/fixtures/one.html?key=value">Same-origin unannotated link ?key=value</a></p>
       <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button>Same-origin unannotated form</button></form></p>
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>
-      <p><a id="same-origin-replace-post-link" href="/__turbo/redirect" data-turbo-method="post" data-turbo-action="replace">Same-origin data-turbo-action=replace link with post method</a></p>
       <p><form id="same-origin-replace-form-get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>
       <p><form id="same-origin-replace-form-submitter-get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin data-turbo-action=replace form</button></form></p>
       <form id="same-origin-replace-form-post" method="post" action="/__turbo/redirect" data-turbo-action="replace">
@@ -62,6 +61,7 @@
       <p><a id="same-origin-download-link" href="/intentionally_missing_fake_download.html" download="x.html">Same-origin download link</a></p>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
+      <p><a id="same-origin-replace-post-link" href="/__turbo/redirect" data-turbo-method="post" data-turbo-action="replace">Same-origin data-turbo-action=replace link with post method</a></p>
       <p><a id="link-to-disabled-frame" href="/src/tests/fixtures/frames/hello.html" data-turbo-frame="hello">Disabled turbo-frame</a></p>
       <p><a id="autofocus-link" href="/src/tests/fixtures/autofocus.html">autofocus.html link</a></p>
       <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/one.html">Redirection link</a></p>

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -149,6 +149,14 @@ test("test following a POST form clears cache", async ({ page }) => {
   assert.notOk(await hasSelector(page, "some-cached-element"))
 })
 
+test("test following a same-origin POST link with data-turbo-action=replace", async ({ page }) => {
+  page.click("#same-origin-replace-post-link")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "replace")
+})
+
 test("test following a same-origin data-turbo=false link", async ({ page }) => {
   page.click("#same-origin-false-link")
   await nextBody(page)


### PR DESCRIPTION
As I described in https://github.com/hotwired/turbo-rails/issues/359 `link_to` ignores `data-turbo-action` in combination with `data-turbo-method`.

Original error was found in `convertLinkWithMethodClickToFormSubmission` but it was overwritten by https://github.com/hotwired/turbo/pull/631. Unfortunately the `data-turbo-action` for `link_to` is still missing.

I added the `data-turbo-action` setting to `FormLinkInterceptor` in the same way as `data-turbo-confirm` and added a test  for it.