### PR TITLE
Convert search parameters to form inputs when using `data-turbo-stream`

### DIFF
--- a/src/observers/form_link_interceptor.ts
+++ b/src/observers/form_link_interceptor.ts
@@ -35,6 +35,16 @@ export class FormLinkInterceptor implements LinkInterceptorDelegate {
     form.setAttribute("action", action)
     form.setAttribute("hidden", "")
 
+    const searchParameters = new URLSearchParams(new URL(action, window.location.toString()).search)
+    for (const [name, value] of searchParameters) {
+      const input = document.createElement("input")
+      input.setAttribute("type", "hidden")
+      input.setAttribute("name", name)
+      input.setAttribute("value", value)
+
+      form.appendChild(input)
+    }
+
     const method = link.getAttribute("data-turbo-method")
     if (method) form.setAttribute("method", method)
 


### PR DESCRIPTION
Fixes a problem pointed out recently on #612 by @seanabrahams and @kevinmcconnell.

Links with `data-turbo-stream` are converted to forms, and forms with method="GET" don't submit the query string part of their action. This can be circumvented by iterating through any query string parameters and adding them to the generated form as hidden inputs.

Note: MDN refers to what we usually call "query string parameters" as "search parameters". This is a bit confusing, but it's the correct terminology I guess :)