### PR TITLE
Prevent form links from submitting multiple requests

### DIFF
--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -7,33 +7,35 @@ export interface LinkClickObserverDelegate {
 
 export class LinkClickObserver {
   readonly delegate: LinkClickObserverDelegate
+  readonly eventTarget: EventTarget
   started = false
 
-  constructor(delegate: LinkClickObserverDelegate) {
+  constructor(delegate: LinkClickObserverDelegate, eventTarget: EventTarget) {
     this.delegate = delegate
+    this.eventTarget = eventTarget
   }
 
   start() {
     if (!this.started) {
-      addEventListener("click", this.clickCaptured, true)
+      this.eventTarget.addEventListener("click", this.clickCaptured, true)
       this.started = true
     }
   }
 
   stop() {
     if (this.started) {
-      removeEventListener("click", this.clickCaptured, true)
+      this.eventTarget.removeEventListener("click", this.clickCaptured, true)
       this.started = false
     }
   }
 
   clickCaptured = () => {
-    removeEventListener("click", this.clickBubbled, false)
-    addEventListener("click", this.clickBubbled, false)
+    this.eventTarget.removeEventListener("click", this.clickBubbled, false)
+    this.eventTarget.addEventListener("click", this.clickBubbled, false)
   }
 
-  clickBubbled = (event: MouseEvent) => {
-    if (this.clickEventIsSignificant(event)) {
+  clickBubbled = (event: Event) => {
+    if (event instanceof MouseEvent && this.clickEventIsSignificant(event)) {
       const target = (event.composedPath && event.composedPath()[0]) || event.target
       const link = this.findLinkFromClickTarget(target)
       if (link && doesNotTargetIFrame(link)) {

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -798,6 +798,49 @@ test("test form submission targeting a frame submits the Turbo-Frame header", as
   assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
 })
 
+test("test link method form submission submits a single request", async ({ page }) => {
+  let requestCounter = 0
+  page.on("request", () => requestCounter++)
+
+  await page.click("#stream-link-method-within-form-outside-frame")
+  await nextBeat()
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  await noNextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(requestCounter, 1, "submits a single HTTP request")
+})
+
+test("test link method form submission inside frame submits a single request", async ({ page }) => {
+  let requestCounter = 0
+  page.on("request", () => requestCounter++)
+
+  await page.click("#stream-link-method-inside-frame")
+  await nextBeat()
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  await noNextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(requestCounter, 1, "submits a single HTTP request")
+})
+
+test("test link method form submission targetting frame submits a single request", async ({ page }) => {
+  let requestCounter = 0
+  page.on("request", () => requestCounter++)
+
+  await page.click("#turbo-method-post-to-targeted-frame")
+  await nextBeat()
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  await noNextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(requestCounter, 2, "submits a single HTTP request then follows a redirect")
+})
+
 test("test link method form submission inside frame", async ({ page }) => {
   await page.click("#link-method-inside-frame")
   await nextBeat()


### PR DESCRIPTION
The `LinkInterceptor` class contains some Frame-specific checks that
were at the root of `<a data-turbo-method="...">` element clicks
submitting multiple HTTP requests.

To resolve the underlying issue, this commit changes the
`FormLinkInterceptor` class to rely on an instance of
`LinkClickObserver` instead of `LinkInterceptor`.

In order to make that possible, this commit also extends the
`LinkClickObserver` to accept a second argument to server as the
[EventTarget][] for the `click` event listeners. As a consumer, the
`FormLinkInterceptor` instances attached to `<turbo-frame>` element
scope their listeners to the element, while the `Session`'s
`FormLinkInterceptor` instance attaches a catch-all listener to the
`window`.

Since this commit changes the underlying event listening mechanism, it
also renames the `FormLinkInterceptor` and delegate to
`FormLinkClickObserver` to match the `LinkClickObserver` naming
patterns.

[EventTarget]: https://developer.mozilla.org/en-US/docs/Web/API/EventTarget