### PR TITLE
Don't convert `data-turbo-stream` links to forms

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -161,7 +161,7 @@ export class FormSubmission {
     }
 
     if (this.requestAcceptsTurboStreamResponse(request)) {
-      headers["Accept"] = [StreamMessage.contentType, headers["Accept"]].join(", ")
+      request.acceptResponseType(StreamMessage.contentType)
     }
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -191,7 +191,9 @@ export class Session
 
   followedLinkToLocation(link: Element, location: URL) {
     const action = this.getActionForLink(link)
-    this.visit(location.href, { action })
+    const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
+
+    this.visit(location.href, { action, acceptsStreamResponse })
   }
 
   // Navigator delegate

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -158,6 +158,10 @@ export class FetchRequest {
     return this.abortController.signal
   }
 
+  acceptResponseType(mimeType: string) {
+    this.headers["Accept"] = [mimeType, this.headers["Accept"]].join(", ")
+  }
+
   private async allowRequestToBeIntercepted(fetchOptions: RequestInit) {
     const requestInterception = new Promise((resolve) => (this.resolveRequestPromise = resolve))
     const event = dispatch<TurboBeforeFetchRequestEvent>("turbo:before-fetch-request", {

--- a/src/observers/form_link_click_observer.ts
+++ b/src/observers/form_link_click_observer.ts
@@ -25,7 +25,7 @@ export class FormLinkClickObserver implements LinkClickObserverDelegate {
   willFollowLinkToLocation(link: Element, location: URL, originalEvent: MouseEvent): boolean {
     return (
       this.delegate.willSubmitFormLinkToLocation(link, location, originalEvent) &&
-      (link.hasAttribute("data-turbo-method") || link.hasAttribute("data-turbo-stream"))
+      link.hasAttribute("data-turbo-method")
     )
   }
 

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -296,7 +296,6 @@
     </turbo-frame>
     <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-outside-frame">Method link outside frame</a><br />
     <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-outside-frame">Stream link outside frame</a>
-    <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-stream id="stream-link-outside-frame">Stream link (no method) outside frame</a>
     <form>
       <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-within-form-outside-frame">Method link within form outside frame</a><br />
       <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-within-form-outside-frame">Stream link within form outside frame</a>

--- a/src/tests/fixtures/visit.html
+++ b/src/tests/fixtures/visit.html
@@ -19,6 +19,7 @@
       <hr class="push-below-fold">
       <p><a id="below-the-fold-link" href="/src/tests/fixtures/one.html">one.html</a></p>
       <hr class="push-below-fold">
+      <p><a id="stream-link" href="/src/tests/fixtures/one.html?key=value" data-turbo-stream>Stream link with ?key=value</a></p>
     </section>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -886,17 +886,10 @@ test("test stream link GET method form submission inside frame", async ({ page }
 test("test stream link inside frame", async ({ page }) => {
   await page.click("#stream-link-inside-frame")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { fetchOptions, url } = await nextEventNamed(page, "turbo:before-fetch-request")
 
   assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
-})
-
-test("test stream link outside frame", async ({ page }) => {
-  await page.click("#stream-link-outside-frame")
-
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
-
-  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal(getSearchParam(url, "content"), "Link!")
 })
 
 test("test link method form submission within form inside frame", async ({ page }) => {

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -2,6 +2,7 @@ import { Page, test } from "@playwright/test"
 import { assert } from "chai"
 import { get } from "http"
 import {
+  getSearchParam,
   isScrolledToSelector,
   isScrolledToTop,
   nextBeat,
@@ -176,6 +177,14 @@ test("test turbo:before-fetch-response open new site", async ({ page }) => {
 
   assert.isTrue(fetchResponseResult.responseText.indexOf("An element with an ID") > -1)
   assert.isTrue(fetchResponseResult.responseHTML.indexOf("An element with an ID") > -1)
+})
+
+test("test visits with data-turbo-stream include MIME type & search params", async ({ page }) => {
+  await page.click("#stream-link")
+  const { fetchOptions, url } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal(getSearchParam(url, "key"), "value")
 })
 
 test("test cache does not override response after redirect", async ({ page }) => {


### PR DESCRIPTION
The initial implementation of the `data-turbo-stream` attribute worked
by treating requests with that attribute as form submissions (which
would be `GET` form submissions, unless a different method type was
indicated).

This allowed us to include the `data-turbo-stream` logic in
`FormSubmission`, which was responsible for properly setting the
`Accept` header.

However, there are some downsides to submitting the requests as form
submissions. For example, a `GET` form submission does not include the
search portion of the URL. Additionally, servers are free to respond to
`data-turbo-stream` requests with plain HTML responses, and in that case
we don't want Turbo's handling of the response to differ from what it
would have been if the `data-turbo-stream` attribute wasn't present.

This commit takes a different approach. In this version, elements that
have `data-turbo-stream` continue to be processed by the same object
that they would otherwise, whether that's a `FormSubmission`, a `Visit`
or a `FrameController`. However each of these objects is now aware of
the `data-turbo-stream` attribute, and each will include the Turbo
Stream MIME type when appropriate.

This minimizes the impact of `data-turbo-stream` so that the only effect
it has is on the inclusion of that MIME type.