### PR TITLE
Disabling Drive keeps Frames default behaviour

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -431,11 +431,11 @@ export class FrameController
       }
     }
 
-    if (!session.elementDriveEnabled(element)) {
+    if (!session.elementIsNavigatable(element)) {
       return false
     }
 
-    if (submitter && !session.elementDriveEnabled(submitter)) {
+    if (submitter && !session.elementIsNavigatable(submitter)) {
       return false
     }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -175,7 +175,7 @@ export class Session
 
   willFollowLinkToLocation(link: Element, location: URL, event: MouseEvent) {
     return (
-      this.elementDriveEnabled(link) &&
+      this.elementIsNavigatable(link) &&
       locationIsVisitable(location, this.snapshot.rootLocation) &&
       this.applicationAllowsFollowingLinkToLocation(link, location, event)
     )
@@ -222,8 +222,8 @@ export class Session
     const action = getAction(form, submitter)
 
     return (
-      this.elementDriveEnabled(form) &&
-      (!submitter || this.formElementDriveEnabled(submitter)) &&
+      this.elementIsNavigatable(form) &&
+      (!submitter || this.formElementIsNavigatable(submitter)) &&
       locationIsVisitable(expandURL(action), this.snapshot.rootLocation)
     )
   }
@@ -375,7 +375,7 @@ export class Session
 
   // Helpers
 
-  formElementDriveEnabled(element?: Element) {
+  formElementIsNavigatable(element?: Element) {
     if (this.formMode == "off") {
       return false
     }
@@ -383,22 +383,23 @@ export class Session
       const form = element?.closest("form[data-turbo]")
       return form?.getAttribute("data-turbo") == "true"
     }
-    return this.elementDriveEnabled(element)
+    return this.elementIsNavigatable(element)
   }
 
-  elementDriveEnabled(element?: Element) {
+  elementIsNavigatable(element?: Element) {
     const container = element?.closest("[data-turbo]")
+    const withinFrame = element?.closest("turbo-frame")
 
-    // Check if Drive is enabled on the session.
-    if (this.drive) {
-      // Drive should be enabled by default, unless `data-turbo="false"`.
+    // Check if Drive is enabled on the session or we're within a Frame.
+    if (this.drive || withinFrame) {
+      // Element is navigatable by default, unless `data-turbo="false"`.
       if (container) {
         return container.getAttribute("data-turbo") != "false"
       } else {
         return true
       }
     } else {
-      // Drive should be disabled by default, unless `data-turbo="true"`.
+      // Element isn't navigatable by default, unless `data-turbo="true"`.
       if (container) {
         return container.getAttribute("data-turbo") == "true"
       } else {

--- a/src/tests/fixtures/drive_disabled.html
+++ b/src/tests/fixtures/drive_disabled.html
@@ -34,5 +34,14 @@
       <input type="hidden" name="greeting" value="Hello from a redirect">
       <a href="#" id="requestSubmit">Drive enabled submit via JS</a>
     </form>
+
+    <turbo-frame id="frame">
+      <h2>Hello from a frame</h2>
+
+      <a href="/src/tests/fixtures/drive_disabled.html">Navigate #frame</a>
+      <form action="/src/tests/fixtures/drive_disabled.html">
+        <button>Navigate #frame</button>
+      </form>
+    </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/drive_disabled_tests.ts
+++ b/src/tests/functional/drive_disabled_tests.ts
@@ -3,6 +3,7 @@ import { assert } from "chai"
 import {
   getFromLocalStorage,
   nextBody,
+  nextEventOnTarget,
   pathname,
   searchParams,
   setLocalStorageFromEvent,
@@ -41,4 +42,14 @@ test("test drive disabled by default; submit form inside data-turbo='true'", asy
   assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
   assert.equal(await visitAction(page), "advance")
   assert.equal(await searchParams(page.url()).get("greeting"), "Hello from a redirect")
+})
+
+test("test drive disabled by default; links within <turbo-frame> navigate with Turbo", async ({ page }) => {
+  await page.click("#frame a")
+  await nextEventOnTarget(page, "frame", "turbo:frame-render")
+})
+
+test("test drive disabled by default; forms within <turbo-frame> navigate with Turbo", async ({ page }) => {
+  await page.click("#frame button")
+  await nextEventOnTarget(page, "frame", "turbo:frame-render")
 })


### PR DESCRIPTION
https://github.com/hotwired/turbo/pull/196 introduced the ability to disable Drive by default. An unintentional side-effect was that it also disabled Frame by default. Every Frame needed the data-turbo attribute to be enabled: `<turbo-frame data-turbo="true">`. This makes it so that `Turbo.session.drive = false` only affects Drive.

On top of the logic change, we rename the Session methods to remove the Drive vocabulary.

---

@gregschmit Ping as the author of #196. Am I right to assume that this was an un unintentional side-effect?