### PR TITLE
Encode Form Submitter `[name]` into submission

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -228,8 +228,8 @@ function buildFormData(formElement: HTMLFormElement, submitter?: HTMLElement): F
   const name = submitter?.getAttribute("name")
   const value = submitter?.getAttribute("value")
 
-  if (name && value != null && formData.get(name) != value) {
-    formData.append(name, value)
+  if (name) {
+    formData.append(name, value || "")
   }
 
   return formData

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -367,14 +367,14 @@ test("test no-action form submission submitter parameters", async ({ page }) => 
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
   assert.equal(getSearchParam(page.url(), "query"), "1")
-  assert.deepEqual(searchParams(page.url()).getAll("button"), [])
+  assert.deepEqual(searchParams(page.url()).getAll("button"), [""])
 
   await page.click("#no-action form.button-param [type=submit]")
   await nextBody(page)
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
   assert.equal(getSearchParam(page.url(), "query"), "1")
-  assert.deepEqual(searchParams(page.url()).getAll("button"), [])
+  assert.deepEqual(searchParams(page.url()).getAll("button"), [""])
 })
 
 test("test submitter with blank formaction submits to the current page", async ({ page }) => {


### PR DESCRIPTION
Closes [hotwired/turbo#272][]

Do not exclude a `<form>` submitter's `[name]` attribute from the
encoded `FormData` instance, even if a `[value]` is not specified.
Instead, encode the value as an empty string if a `[value]` attribute is
unspecified.

The existing tests included a [button][] to exercise this exclusion
behavior. Their assertions were incorrect, so this commit changes them
to reflect the proper behavior.

[button]: https://github.com/hotwired/turbo/blob/1563ebbfa3f4c8530b334e194da9db630163041b/src/tests/fixtures/form.html#L103
[hotwired/turbo#272]: https://github.com/hotwired/turbo/issues/272#issuecomment-1198671657