### PR TITLE
Change `elementDriveEnabled()` to `elementIsNavigatable()`

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -173,7 +173,7 @@ export class Session
   // Form click observer delegate
 
   willSubmitFormLinkToLocation(link: Element, location: URL): boolean {
-    return this.elementDriveEnabled(link) && locationIsVisitable(location, this.snapshot.rootLocation)
+    return this.elementIsNavigatable(link) && locationIsVisitable(location, this.snapshot.rootLocation)
   }
 
   submittedFormLinkToLocation() {}


### PR DESCRIPTION
The Pull Request #648 refactored the function name of
`session.elementDriveEnabled()` to `session.elementIsNavigatable()`.

This Pull Request fixes an old function reference which kept the library
from building successfully.