### PR TITLE
Return `Promise<void>` from `FrameElement.reload`

### DIFF
--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -62,11 +62,12 @@ export class FrameElement extends HTMLElement {
     this.delegate.disconnect()
   }
 
-  reload() {
+  reload(): Promise<void> {
     const { src } = this
     this.removeAttribute("complete")
     this.src = null
     this.src = src
+    return this.loaded
   }
 
   attributeChangedCallback(name: string) {

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -3,6 +3,7 @@ import { assert } from "chai"
 import {
   attributeForSelector,
   hasSelector,
+  nextAttributeMutationNamed,
   nextBeat,
   nextBody,
   nextEventNamed,
@@ -103,18 +104,16 @@ test("test changing src attribute on a frame with loading=eager navigates", asyn
 })
 
 test("test reloading a frame reloads the content", async ({ page }) => {
-  await nextBeat()
-
   await page.click("#loading-eager summary")
-  await nextBeat()
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
   const frameContent = "#loading-eager turbo-frame#frame h2"
   assert.ok(await hasSelector(page, frameContent))
-  assert.ok(await hasSelector(page, "#loading-eager turbo-frame[complete]"), "has [complete] attribute")
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "complete"), "", "has [complete] attribute")
 
   await page.evaluate(() => (document.querySelector("#loading-eager turbo-frame") as any)?.reload())
   assert.ok(await hasSelector(page, frameContent))
-  assert.ok(await hasSelector(page, "#loading-eager turbo-frame:not([complete])"), "clears [complete] attribute")
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "complete"), null, "clears [complete] attribute")
 })
 
 test("test navigating away from a page does not reload its frames", async ({ page }) => {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -11,6 +11,7 @@ import {
   nextEventNamed,
   noNextEventNamed,
   pathname,
+  readEventLogs,
   search,
   selectorHasFocus,
   visitAction,
@@ -21,6 +22,7 @@ import {
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/navigation.html")
+  await readEventLogs(page)
 })
 
 test("test navigating renders a progress bar", async ({ page }) => {
@@ -129,8 +131,8 @@ test("test following a same-origin POST form[data-turbo-action=replace]", async 
 })
 
 test("test following a same-origin POST form button[data-turbo-action=replace]", async ({ page }) => {
-  page.click("#same-origin-replace-form-submitter-post button")
-  await nextBody(page)
+  await page.click("#same-origin-replace-form-submitter-post button")
+  await nextEventNamed(page, "turbo:load")
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "replace")
@@ -339,10 +341,11 @@ test("test correct referrer header", async ({ page }) => {
 })
 
 test("test double-clicking on a link", async ({ page }) => {
-  page.click("#delayed-link")
-  page.click("#delayed-link")
+  await page.click("#delayed-link", { clickCount: 2 })
+  await nextBeat()
 
-  await nextBody(page, 1200)
+  await nextEventNamed(page, "turbo:load")
+
   assert.equal(pathname(page.url()), "/__turbo/delayed_response")
   assert.equal(await visitAction(page), "advance")
 })


### PR DESCRIPTION
Following the pattern established by `Turbo.visit(...)` and
`Turbo.visit(..., { frame: "..." })`, return the `FrameElement.loaded`
promise from calls to `FrameElement.reload()`.

That way, callers can block on it:

```js
const frame = document.getElementById("my-frame")
await frame.reload()
// ...
```