### PR TITLE
Dispatch `turbo:before-stream-render` with reference to `<turbo-stream>`

### DIFF
--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -1,7 +1,7 @@
 import { StreamActions } from "../core/streams/stream_actions"
 import { nextAnimationFrame } from "../util"
 
-export type TurboBeforeStreamRenderEvent = CustomEvent
+export type TurboBeforeStreamRenderEvent = CustomEvent<{ newStream: StreamElement }>
 
 // <turbo-stream action=replace target=id><template>...
 
@@ -149,6 +149,7 @@ export class StreamElement extends HTMLElement {
     return new CustomEvent("turbo:before-stream-render", {
       bubbles: true,
       cancelable: true,
+      detail: { newStream: this },
     })
   }
 

--- a/src/tests/fixtures/stream.html
+++ b/src/tests/fixtures/stream.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8">
     <title>Turbo Streams</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>
     <form id="append-target" method="post" action="/__turbo/messages">

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -39,6 +39,7 @@
      }
    }).observe(document, { subtree: true, childList: true, attributes: true })
 })([
+  "turbo:before-stream-render",
   "turbo:before-cache",
   "turbo:before-render",
   "turbo:before-visit",

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -7,7 +7,7 @@ import {
   nextBody,
   nextEventNamed,
   nextEventOnTarget,
-  noNextEventNamed,
+  noNextEventOnTarget,
   readEventLogs,
 } from "../helpers/page"
 
@@ -138,7 +138,6 @@ test("test removing the [complete] attribute of an eager frame reloads the conte
 })
 
 test("test changing [src] attribute on a [complete] frame with loading=lazy defers navigation", async ({ page }) => {
-  await nextEventOnTarget(page, "frame", "turbo:frame-load")
   await page.click("#loading-lazy summary")
   await nextEventOnTarget(page, "hello", "turbo:frame-load")
 
@@ -150,7 +149,7 @@ test("test changing [src] attribute on a [complete] frame with loading=lazy defe
   await nextEventNamed(page, "turbo:load")
   await page.goBack()
   await nextEventNamed(page, "turbo:load")
-  await noNextEventNamed(page, "turbo:frame-load")
+  await noNextEventOnTarget(page, "hello", "turbo:frame-load")
 
   let src = new URL((await attributeForSelector(page, "#hello", "src")) || "")
 
@@ -158,7 +157,7 @@ test("test changing [src] attribute on a [complete] frame with loading=lazy defe
   assert.equal(src.pathname, "/src/tests/fixtures/frames/hello.html", "lazy frame retains [src]")
 
   await page.click("#link-lazy-frame")
-  await noNextEventNamed(page, "turbo:frame-load")
+  await noNextEventOnTarget(page, "hello", "turbo:frame-load")
 
   assert.ok(await hasSelector(page, "#loading-lazy turbo-frame:not([complete])"), "lazy frame is not complete")
 

--- a/src/tests/functional/stream_tests.ts
+++ b/src/tests/functional/stream_tests.ts
@@ -1,9 +1,10 @@
 import { test } from "@playwright/test"
 import { assert } from "chai"
-import { nextBeat } from "../helpers/page"
+import { nextBeat, nextEventNamed, readEventLogs } from "../helpers/page"
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/stream.html")
+  await readEventLogs(page)
 })
 
 test("test receiving a stream message", async ({ page }) => {
@@ -15,6 +16,14 @@ test("test receiving a stream message", async ({ page }) => {
   await nextBeat()
 
   assert.deepEqual(await messages.allTextContents(), ["First", "Hello world!"])
+})
+
+test("test dispatches a turbo:before-stream-render event", async ({ page }) => {
+  await page.click("#append-target button")
+  const { newStream } = await nextEventNamed(page, "turbo:before-stream-render")
+
+  assert.ok(newStream.includes(`action="append"`))
+  assert.ok(newStream.includes(`target="messages"`))
 })
 
 test("test receiving a stream message with css selector target", async ({ page }) => {


### PR DESCRIPTION
Since the `turbo:before-stream-render` event is dispatched _before_ the
`<turbo-stream>` element is connected to the document, it isn't possible
to dispatch the event with the element as its `Event.target` property.

To work around that constraint, dispatch the reference as
`CustomEvent.detail.newStream` (named in the same way as `newBody` for
`turbo:before-render` and `newFrame` for `turbo:before-frame-render`).