### PR TITLE
Preserve input values in cache

### DIFF
--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -24,7 +24,22 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
   }
 
   clone() {
-    return new PageSnapshot(this.element.cloneNode(true), this.headSnapshot)
+    const clonedElement = this.element.cloneNode(true)
+
+    const selectElements = this.element.querySelectorAll("select")
+    const clonedSelectElements = clonedElement.querySelectorAll("select")
+
+    for (const [index, source] of selectElements.entries()) {
+      for (const [optionIndex, option] of Array.from(source.options).entries()) {
+        clonedSelectElements[index].options[optionIndex].selected = option.selected
+      }
+    }
+
+    for (const clonedPasswordInput of clonedElement.querySelectorAll<HTMLInputElement>('input[type="password"]')) {
+      clonedPasswordInput.value = ""
+    }
+
+    return new PageSnapshot(clonedElement, this.headSnapshot)
   }
 
   get headElement() {

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -44,6 +44,24 @@
       <p><a id="permanent-in-frame-element-link" href="/src/tests/fixtures/permanent_element.html" data-turbo-frame="frame">Permanent element in frame</a></p>
       <p><a id="permanent-in-frame-without-layout-element-link" href="/src/tests/fixtures/frames/without_layout.html" data-turbo-frame="frame">Permanent element in frame without layout</a></p>
       <p><a id="delayed-link" href="/__turbo/delayed_response">Delayed link</a></p>
+      <form>
+        <input type="text" id="text-input">
+        <input type="radio" id="radio-input">
+        <input type="checkbox" id="checkbox-input">
+        <textarea id="textarea"></textarea>
+        <select id="select">
+          <option value="1">1</option>
+          <option value="2">2</option>
+        </select>
+        <select id="select-multiple" multiple>
+          <option value="1">1</option>
+          <option value="2">2</option>
+        </select>
+
+        <input type="password" id="password-input">
+
+        <input type="reset" id="reset-input">
+      </form>
     </section>
     <div id="permanent" data-turbo-permanent>Rendering</div>
 


### PR DESCRIPTION
Re-submission of https://github.com/hotwired/turbo/pull/70

This change will save the values of `<input>`s, `<textarea>`s, and
`<select>`s when creating a snapshot so that when you navigate back or
forward in history, form fields will not be reset.

This behavior was already present prior to [5dfc79e][] for `<input>`s
and `<textarea>`s but not `<select>`s (see
[turbolinks/turbolinks#238][]).

[5dfc79e]: https://github.com/hotwired/turbo/commit/5dfc79ee2feba441ea9c9b486009d08336e78d76
[turbolinks/turbolinks#238]: https://github.com/turbolinks/turbolinks/issues/238