### PR TITLE
Fix Markdown Syntax typo in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ variable.
 
 First, install the drivers to test the suite in browsers:
 
-``bash
+```bash
 yarn playwright install  --with-deps
 ```
 

--- a/README.md
+++ b/README.md
@@ -11,4 +11,8 @@ It's all done by sending HTML over the wire. And for those instances when that's
 
 Read more on [turbo.hotwired.dev](https://turbo.hotwired.dev).
 
+## Contributing
+
+Please read [CONTRIBUTING.md](./CONTRIBUTING.md).
+
 © 2021 Basecamp, LLC.


### PR DESCRIPTION
A missing back-tick is at the root of a presentation issue that's
obscuring guidance on how to introduce test dependencies.