### PR TITLE
PageSnapshot: reduce cloning loop iterations

### DIFF
--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -30,9 +30,9 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
     const clonedSelectElements = clonedElement.querySelectorAll("select")
 
     for (const [index, source] of selectElements.entries()) {
-      for (const [optionIndex, option] of Array.from(source.options).entries()) {
-        clonedSelectElements[index].options[optionIndex].selected = option.selected
-      }
+      const clone = clonedSelectElements[index]
+      for (const option of clone.selectedOptions) option.selected = false
+      for (const option of source.selectedOptions) clone.options[option.index].selected = true
     }
 
     for (const clonedPasswordInput of clonedElement.querySelectorAll<HTMLInputElement>('input[type="password"]')) {


### PR DESCRIPTION
Follow-up to https://github.com/hotwired/turbo/pull/666

Following [a suggestion][] provided by review of #666, this commit
remove unnecessary loops when cloning a page's form controls to be
cached by a snapshot.

[a suggestion]: https://github.com/hotwired/turbo/pull/666#discussion_r938988401