### PR TITLE
`turbo:frame-missing`: Re-use `FetchResponse` HTML

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -309,9 +309,13 @@ export class Session
     this.notifyApplicationAfterFrameRender(fetchResponse, frame)
   }
 
-  frameMissing(frame: FrameElement, fetchResponse: FetchResponse): Promise<void> {
-    console.warn(`Completing full-page visit as matching frame for #${frame.id} was missing from the response`)
-    return this.visit(fetchResponse.location)
+  async frameMissing(frame: FrameElement, fetchResponse: FetchResponse): Promise<void> {
+    console.warn(`A matching frame for #${frame.id} was missing from the response, transforming into full-page Visit.`)
+
+    const responseHTML = await fetchResponse.responseHTML
+    const { location, redirected, statusCode } = fetchResponse
+
+    return this.visit(location, { response: { redirected, statusCode, responseHTML } })
   }
 
   // Application events

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -120,6 +120,7 @@ test("test following a link to a page without a matching frame dispatches a turb
   await noNextEventOnTarget(page, "missing", "turbo:frame-render")
   await noNextEventOnTarget(page, "missing", "turbo:frame-load")
   const { fetchResponse } = await nextEventOnTarget(page, "missing", "turbo:frame-missing")
+  await noNextEventNamed(page, "turbo:before-fetch-request")
   await nextEventNamed(page, "turbo:load")
 
   assert.ok(fetchResponse, "dispatchs turbo:frame-missing with event.detail.fetchResponse")


### PR DESCRIPTION
After re-considering a comment on [hotwired/turbo#445][], this commit
re-purposes the response HTML from the `FetchResponse` instance, instead
of issuing a follow-up HTTP request.

[hotwired/turbo#445]: https://github.com/hotwired/turbo/pull/445#discussion_r934776811