### PR TITLE
Add `[data-turbo-enforced]` to disable `data-turbo=false`

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -407,12 +407,15 @@ export class Session
 
   elementIsNavigatable(element: Element): boolean {
     const container = element.closest("[data-turbo]")
-    const withinFrame = element.closest("turbo-frame")
 
     // Check if Drive is enabled on the session or we're within a Frame.
-    if (this.drive || withinFrame) {
-      // Element is navigatable by default, unless `data-turbo="false"`.
-      if (container) {
+    if (this.drive || element.closest("turbo-frame")) {
+      // Element is navigatable by default
+      // Use `data-turbo="false"` to disable navigation; add `data-turbo-enforce` to a parent to force Turbo navigation.
+      const enforcedByParent = element.closest("[data-turbo-enforce]")
+      if (enforcedByParent) {
+        return true
+      } else if (container) {
         return container.getAttribute("data-turbo") != "false"
       } else {
         return true

--- a/src/tests/fixtures/drive_enforced.html
+++ b/src/tests/fixtures/drive_enforced.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Drive</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Drive with <code>data-turbo-enforce</code></h1>
+
+    <div data-turbo-enforce>
+      <a id="drive_enabled" href="/src/tests/fixtures/drive_enforced.html">Drive enabled link</a>
+      <a id="drive_enabled_external" href="https://example.com">Drive enabled external link</a>
+      
+      <div data-turbo="false">
+        <a id="drive_disabled" href="/src/tests/fixtures/drive_enforced.html">Drive disabled link</a>
+      </div>
+    </div>
+  </body>
+</html>

--- a/src/tests/functional/drive_enforced_tests.ts
+++ b/src/tests/functional/drive_enforced_tests.ts
@@ -2,28 +2,28 @@ import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBody, pathname, visitAction } from "../helpers/page"
 
-const path = "/src/tests/fixtures/drive.html"
+const path = "/src/tests/fixtures/drive_enforced.html"
 
 test.beforeEach(async ({ page }) => {
   await page.goto(path)
 })
 
-test("test drive enabled by default; click normal link", async ({ page }) => {
+test("test drive enforced; click normal link", async ({ page }) => {
   page.click("#drive_enabled")
   await nextBody(page)
   assert.equal(pathname(page.url()), path)
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test drive to external link", async ({ page }) => {
+test("test drive  enforced to external link", async ({ page }) => {
   page.click("#drive_enabled_external")
   await nextBody(page)
   assert.equal(await page.evaluate(() => window.location.href), "https://example.com/")
 })
 
-test("test drive enabled by default; click link inside data-turbo='false'", async ({ page }) => {
+test("test drive enforced; click link inside data-turbo='false'", async ({ page }) => {
   page.click("#drive_disabled")
   await nextBody(page)
   assert.equal(pathname(page.url()), path)
-  assert.equal(await visitAction(page), "load")
+  assert.equal(await visitAction(page), "advance")
 })


### PR DESCRIPTION
Developers can use [`data-turbo=false`](https://turbo.hotwired.dev/handbook/drive#disabling-turbo-drive-on-specific-links-or-forms) to disable Turbo Drive on specific links or form elements. But this introduces a problem in Turbo Native apps, where using `data-turbo=false` will exit the app and open the link in a web browser.

One of the best things about Turbo is that you can build features that will probably work natively without ever having to test natively. But `data-turbo=false` introduces an easy for developers to break this pact. A recent example I noticed in code review was a developer using `data-turbo=false` on a link to delete a record, because that would cause a full page reload and thus show an empty state again. (A better approach would be to use a Turbo Stream, or the CSS pattern described [here](https://boringrails.com/articles/css-tips-and-tricks-hotwire/).) On the native app, this link switched over the browser, so it didn't work at all.

In https://github.com/hotwired/turbo-site/pull/104 I added a warning about this, but warnings require people to read docs. So in this PR I'm proposing a way of controlling this using Turbo. This example shows what I propose:

```html
<div data-turbo="false">
  <a href="foo.html">Internal link. Full page navigation in browser; exits app in native.</a>
  <a href="https://www.example.com">External link. Full page navigation in browser; exits app in native.</a>
</div>

<div data-turbo-enforced>
  <div data-turbo="false">
    <a href="foo.html">Internal link. Link will be followed using Turbo! (data-turbo="false" is ignored)</a>
    <a href="https://www.example.com">External link. Full page navigation in browser; exits app in native.</a>
  </div>
</div>
```

The most common usage would be adding `data-turbo-enforced` to the `<body>` ([or relevant element](https://github.com/hotwired/turbo/pull/627)), either always or just when rendering in a native app (via user agent). I'd suggest doing it always so that you get the same behaviour in browser development as you do in app production.