### PR TITLE
`turbo:frame-missing`: Do not `Turbo.visit` by default

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -313,15 +313,6 @@ export class Session
     this.notifyApplicationAfterFrameRender(fetchResponse, frame)
   }
 
-  async frameMissing(frame: FrameElement, fetchResponse: FetchResponse): Promise<void> {
-    console.warn(`A matching frame for #${frame.id} was missing from the response, transforming into full-page Visit.`)
-
-    const responseHTML = await fetchResponse.responseHTML
-    const { location, redirected, statusCode } = fetchResponse
-
-    return this.visit(location, { response: { redirected, statusCode, responseHTML } })
-  }
-
   // Application events
 
   applicationAllowsFollowingLinkToLocation(link: Element, location: URL, ev: MouseEvent) {


### PR DESCRIPTION
Restore the existing default behavior when a matching frame is missing
from a response: log an error and blank the frame.

Alongside that original behavior, yield the [Response][] instance and a
`Turbo.visit`-like callback that can transform the `Response` instance
into a `Visit`. It also accepts all the arguments that the `Turbo.visit`
call normally does.

[Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response