### PR TITLE
Form Link Submissions: Don't remove `<form>` until submission is complete

### DIFF
--- a/src/observers/form_link_click_observer.ts
+++ b/src/observers/form_link_click_observer.ts
@@ -51,7 +51,7 @@ export class FormLinkClickObserver implements LinkClickObserverDelegate {
     this.delegate.submittedFormLinkToLocation(link, location, form)
 
     document.body.appendChild(form)
-    form.requestSubmit()
-    form.remove()
+    form.addEventListener("turbo:submit-end", () => form.remove(), { once: true })
+    requestAnimationFrame(() => form.requestSubmit())
   }
 }

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="html">
+<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end">
   <head>
     <meta charset="utf-8">
     <title>Form</title>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -46,6 +46,8 @@
   "turbo:load",
   "turbo:render",
   "turbo:before-fetch-request",
+  "turbo:submit-start",
+  "turbo:submit-end",
   "turbo:before-fetch-response",
   "turbo:visit",
   "turbo:before-frame-render",

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -330,20 +330,18 @@ test("test does not evaluate data-turbo-eval=false scripts", async ({ page }) =>
 })
 
 test("test redirecting in a form is still navigatable after redirect", async ({ page }) => {
-  await nextBeat()
   await page.click("#navigate-form-redirect")
-  await nextBeat()
-  assert.ok(await hasSelector(page, "#form-redirect"))
+  await nextEventOnTarget(page, "form-redirect", "turbo:frame-load")
+  assert.equal(await page.textContent("turbo-frame#form-redirect h2"), "Form Redirect")
 
-  await nextBeat()
   await page.click("#submit-form")
-  await nextBeat()
-  assert.ok(await hasSelector(page, "#form-redirected-header"))
+  await nextEventOnTarget(page, "form-redirect", "turbo:frame-load")
+  assert.equal(await page.textContent("turbo-frame#form-redirect h2"), "Form Redirected")
 
-  await nextBeat()
   await page.click("#navigate-form-redirect")
-  await nextBeat()
-  assert.ok(await hasSelector(page, "#form-redirect-header"))
+  await nextEventOnTarget(page, "form-redirect", "turbo:frame-load")
+
+  assert.equal(await page.textContent("turbo-frame#form-redirect h2"), "Form Redirect")
 })
 
 test("test 'turbo:frame-render' is triggered after frame has finished rendering", async ({ page }) => {


### PR DESCRIPTION
When an `<a>` element annotated with `[data-turbo-method]` is clicked,
Turbo Drive creates, appends, submits, and removes a `<form>` element
behind the scenes.

Unfortunately, prior to this commit, the `<form>` element is submitted
then removed synchronously and immediately. This means that by the time
the `submit` events (and resulting `turbo:before-fetch-request` and
`turbo:submit-start` events) bubble up through the document, the
`<form>` element is already disconnected.

In its absence, the `document.documentElement` serves as the event's
target.

This commit changes that process to defer the elements removal until
_after_ it dispatches a `turbo:submit-end` event.

The result is that the element is present throughout all the events, and
is accessible through `event.target`.
