### PR TITLE
Stream responses to GET should clear busy state

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -11,7 +11,7 @@ import { Navigator, NavigatorDelegate } from "./drive/navigator"
 import { PageObserver, PageObserverDelegate } from "../observers/page_observer"
 import { ScrollObserver } from "../observers/scroll_observer"
 import { StreamMessage } from "./streams/stream_message"
-import { StreamObserver } from "../observers/stream_observer"
+import { StreamObserver, StreamDelivery } from "../observers/stream_observer"
 import { Action, Position, StreamSource, isAction } from "./types"
 import { clearBusyState, dispatch, markAsBusy } from "../util"
 import { PageView, PageViewDelegate, PageViewRenderOptions } from "./drive/page_view"
@@ -260,7 +260,10 @@ export class Session
 
   // Stream observer delegate
 
-  receivedMessageFromStream(message: StreamMessage) {
+  receivedMessageFromStream(message: StreamMessage, delivery: StreamDelivery) {
+    if (delivery === "http") {
+      clearBusyState(document.documentElement)
+    }
     this.renderStreamMessage(message)
   }
 

--- a/src/observers/stream_observer.ts
+++ b/src/observers/stream_observer.ts
@@ -3,8 +3,10 @@ import { FetchResponse } from "../http/fetch_response"
 import { StreamMessage } from "../core/streams/stream_message"
 import { StreamSource } from "../core/types"
 
+export type StreamDelivery = "http" | "event"
+
 export interface StreamObserverDelegate {
-  receivedMessageFromStream(message: StreamMessage): void
+  receivedMessageFromStream(message: StreamMessage, delivery: StreamDelivery): void
 }
 
 export class StreamObserver {
@@ -58,19 +60,19 @@ export class StreamObserver {
 
   receiveMessageEvent = (event: MessageEvent) => {
     if (this.started && typeof event.data == "string") {
-      this.receiveMessageHTML(event.data)
+      this.receiveMessageHTML(event.data, "event")
     }
   }
 
   async receiveMessageResponse(response: FetchResponse) {
     const html = await response.responseHTML
     if (html) {
-      this.receiveMessageHTML(html)
+      this.receiveMessageHTML(html, "http")
     }
   }
 
-  receiveMessageHTML(html: string) {
-    this.delegate.receivedMessageFromStream(StreamMessage.wrap(html))
+  receiveMessageHTML(html: string, delivery: StreamDelivery) {
+    this.delegate.receivedMessageFromStream(StreamMessage.wrap(html), delivery)
   }
 }
 

--- a/src/tests/fixtures/visit.html
+++ b/src/tests/fixtures/visit.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html id="html">
   <head>
     <meta charset="utf-8">
     <title>Turbo</title>
@@ -19,7 +19,9 @@
       <hr class="push-below-fold">
       <p><a id="below-the-fold-link" href="/src/tests/fixtures/one.html">one.html</a></p>
       <hr class="push-below-fold">
-      <p><a id="stream-link" href="/src/tests/fixtures/one.html?key=value" data-turbo-stream>Stream link with ?key=value</a></p>
+      <p><a id="stream-link" href="/__turbo/stream-response?content=link&type=stream&key=value" data-turbo-stream>Stream link with ?key=value</a></p>
     </section>
+
+    <div id="messages"></div>
   </body>
 </html>

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -5,6 +5,7 @@ import {
   getSearchParam,
   isScrolledToSelector,
   isScrolledToTop,
+  nextAttributeMutationNamed,
   nextBeat,
   nextEventNamed,
   readEventLogs,
@@ -185,6 +186,21 @@ test("test visits with data-turbo-stream include MIME type & search params", asy
 
   assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
   assert.equal(getSearchParam(url, "key"), "value")
+})
+
+test("test visits with data-turbo-stream set and clear aria-busy", async ({ page }) => {
+  await page.click("#stream-link")
+
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    "true",
+    "sets [aria-busy] on the document element"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    null,
+    "removes [aria-busy] from the document element"
+  )
 })
 
 test("test cache does not override response after redirect", async ({ page }) => {

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -86,6 +86,17 @@ router.post("/messages", (request, response) => {
   }
 })
 
+router.get("/stream-response", (request, response) => {
+  const params = { ...request.body, ...request.query }
+  const { content, target, targets } = params
+  if (acceptsStreams(request)) {
+    response.type("text/vnd.turbo-stream.html; charset=utf-8")
+    response.send(targets ? renderMessageForTargets(content, targets) : renderMessage(content, target))
+  } else {
+    response.sendStatus(422)
+  }
+})
+
 router.put("/messages/:id", (request, response) => {
   const { content, type } = request.body
   const { id } = request.params


### PR DESCRIPTION
We set the `aria-busy` state on the document element whenever a link is
clicked that initiates a visit. After the visit completes, we clear this
state.

However, Turbo Stream responses are not visits, and so in the case where
the server chooses to respond with a stream response that busy state
wasn't being cleared.

To fix this, we'll now also clear the busy state when a stream response
is received in response to an HTTP request.