### PR TITLE
Prevent empty string warning

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -110,7 +110,7 @@ export class Session
   }
 
   visit(location: Locatable, options: Partial<VisitOptions> = {}): Promise<void> {
-    const frameElement = document.getElementById(options.frame || "")
+    const frameElement = options.frame ? document.getElementById(options.frame) : null
 
     if (frameElement instanceof FrameElement) {
       frameElement.src = location.toString()


### PR DESCRIPTION
The console was showing this warning when navigating:

    Empty string passed to getElementById().

It's harmless, but a little noisy. This change rewrites the statement
that was causing it, to avoid the warning.