### PR TITLE
Add `render` to `turbo:before-stream-render` event

### DIFF
--- a/src/tests/fixtures/stream.html
+++ b/src/tests/fixtures/stream.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-skip-event-details="turbo:submit-start turbo:submit-end">
   <head>
     <meta charset="utf-8">
     <title>Turbo Streams</title>
@@ -10,6 +10,7 @@
     <form id="append-target" method="post" action="/__turbo/messages">
       <input type="hidden" name="content" value="Hello world!">
       <input type="hidden" name="type" value="stream">
+      <input type="hidden" name="id" value="a-turbo-stream">
       <button>Create</button>
     </form>
 

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -1,5 +1,7 @@
 (function(eventNames) {
-  function serializeToChannel(object, returned = {}) {
+  function serializeToChannel(object, visited = new Set()) {
+    const returned = {}
+
     for (const key in object) {
       const value = object[key]
 
@@ -8,7 +10,13 @@
       } else if (value instanceof Element) {
         returned[key] = value.outerHTML
       } else if (typeof value == "object") {
-        returned[key] = serializeToChannel(value)
+        if (visited.has(value))  {
+          returned[key] = "skipped to prevent infinitely recursing"
+        } else {
+          visited.add(value)
+
+          returned[key] = serializeToChannel(value, visited)
+        }
       } else {
         returned[key] = value
       }

--- a/src/tests/helpers/page.ts
+++ b/src/tests/helpers/page.ts
@@ -1,7 +1,14 @@
 import { JSHandle, Locator, Page } from "@playwright/test"
 
-type EventLog = [string, any, string | null]
-type MutationLog = [string, string | null, string | null]
+type Target = string | null
+
+type EventType = string
+type EventDetail = any
+type EventLog = [EventType, EventDetail, Target]
+
+type MutationAttributeName = string
+type MutationAttributeValue = string | null
+type MutationLog = [MutationAttributeName, Target, MutationAttributeValue]
 
 export function attributeForSelector(page: Page, selector: string, attributeName: string): Promise<string | null> {
   return page.locator(selector).getAttribute(attributeName)

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -91,7 +91,7 @@ router.get("/stream-response", (request, response) => {
   const { content, target, targets } = params
   if (acceptsStreams(request)) {
     response.type("text/vnd.turbo-stream.html; charset=utf-8")
-    response.send(targets ? renderMessageForTargets(content, targets) : renderMessage(content, target))
+    response.send(targets ? renderMessageForTargets(content, null, targets) : renderMessage(content, target))
   } else {
     response.sendStatus(422)
   }


### PR DESCRIPTION
Follow-up to https://github.com/hotwired/turbo/pull/479
Related to https://github.com/hotwired/turbo-site/pull/107

As an alternative to exposing an otherwise private and internal
`StreamActions` "class", support custom `<turbo-stream action="...">`
values the same way as custom `<turbo-frame>` rendering or `<body>`
rendering: as part of its `turbo:before-render-stream` event.

For example, if Turbo were to rename `StreamActions` to something else,
it would need to continue to export `StreamActions` publicly for the
sake of backwards compatibility. By depending on an event listener
instead, client applications are insulated from any internal restructuring.

To change how Turbo renders the document during page rendering, client
applications declare a `turbo:before-render` event listener that
overrides its `CustomEvent.detail.render` function from its
[default][PageRenderer.renderElement].

Similarly, to change how Turbo renders a frame, client applications
declare a `turbo:before-frame-render` and override its
`CustomEvent.detail.render` function from its [default][FrameRenderer.renderElement].

This commit introduces the `StreamElement.renderElement` function, and
extends the existing `turbo:before-stream-render` event to support the
same pattern with `StreamElement.renderElement` serving as the default
`CustomEvent.detail.render` value.

With those changes in place, callers can declare a document-wide event
listener and override based on the value of `StreamElement.action`:

```javascript
const CustomActions = {
  customUpdate: (stream) => { /* ... */ },
  customReplace: (stream) => { /* ... */ },
  // ...
}

document.addEventListener("turbo:before-stream-render", (({ target, detail }) => {
  const defaultRender = detail.render

  detail.render = CustomActions[target.action] || defaultRender
}))
```

[PageRenderer.renderElement]: https://github.com/hotwired/turbo/blob/256418fee0178ee483d82cd9bb579bd5df5a151f/src/core/drive/page_renderer.ts#L7-L13
[FrameRenderer.renderElement]: https://github.com/hotwired/turbo/blob/256418fee0178ee483d82cd9bb579bd5df5a151f/src/core/frames/frame_renderer.ts#L13-L24
