### PR TITLE
Opt-into Turbo Stream `GET` from Form submitter

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -1,7 +1,7 @@
 import { FetchRequest, FetchMethod, fetchMethodFromString, FetchRequestHeaders } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { expandURL } from "../url"
-import { dispatch, getAttribute, getMetaContent } from "../../util"
+import { dispatch, getAttribute, getMetaContent, hasAttribute } from "../../util"
 import { StreamMessage } from "../streams/stream_message"
 import { TurboFetchRequestErrorEvent } from "../session"
 
@@ -221,7 +221,7 @@ export class FormSubmission {
   }
 
   requestAcceptsTurboStreamResponse(request: FetchRequest) {
-    return !request.isIdempotent || this.formElement.hasAttribute("data-turbo-stream")
+    return !request.isIdempotent || hasAttribute("data-turbo-stream", this.submitter, this.formElement)
   }
 }
 

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -30,6 +30,10 @@
         <input type="hidden" name="greeting" value="Hello from a redirect">
         <input id="standard-get-form-with-stream-opt-in-submit" type="submit" value="form[method=get]">
       </form>
+      <form action="/__turbo/redirect" class="redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
+        <button id="standard-get-form-with-stream-opt-in-submitter" data-turbo-stream>form[method=get] button[data-turbo-stream]</button>
+      </form>
       <hr>
       <form>
         <button id="form-action-none-q-a" name="q" value="a">Submit ?q=a to form:not([action])</button>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -185,8 +185,16 @@ test("test standard GET form submission", async ({ page }) => {
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a form")
 })
 
-test("test standard GET form submission with data-turbo-stream", async ({ page }) => {
+test("test standard GET form submission with [data-turbo-stream] declared on the form", async ({ page }) => {
   await page.click("#standard-get-form-with-stream-opt-in-submit")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+})
+
+test("test standard GET form submission with [data-turbo-stream] declared on submitter", async ({ page }) => {
+  await page.click("#standard-get-form-with-stream-opt-in-submitter")
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -107,6 +107,10 @@ export function getAttribute(attributeName: string, ...elements: (Element | unde
   return null
 }
 
+export function hasAttribute(attributeName: string, ...elements: (Element | undefined)[]): boolean {
+  return elements.some((element) => element && element.hasAttribute(attributeName))
+}
+
 export function markAsBusy(...elements: Element[]) {
   for (const element of elements) {
     if (element.localName == "turbo-frame") {


### PR DESCRIPTION
Prior to this commit, declaring `[data-turbo-stream]` on a `<form>`
element with `[method=get]` would opt-into Turbo Stream support for the
response.

This commit extends that same support to `<form>` elements declared
_without_ the `[data-turbo-stream]` attribute that are submitted by
`<button>` or `<input type="submit">` elements that declare the
`[data-turbo-stream]` attribute.
