### PR TITLE
Override `FetchOptions` from event listeners

### DIFF
--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -164,7 +164,7 @@ test("test following a same-origin GET form[data-turbo-action=replace]", async (
 })
 
 test("test following a same-origin GET form button[data-turbo-action=replace]", async ({ page }) => {
-  page.click("#same-origin-replace-form-submitter-get button")
+  await page.click("#same-origin-replace-form-submitter-get button")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "replace")

--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -563,8 +563,9 @@ test("test before-cache event", async ({ page }) => {
     addEventListener("turbo:before-cache", () => (document.body.innerHTML = "Modified"), { once: true })
   })
   await page.click("#same-origin-link")
-  await nextBody(page)
+  await nextEventNamed(page, "turbo:load")
   await page.goBack()
+  await nextEventNamed(page, "turbo:load")
 
   assert.equal(await page.textContent("body"), "Modified")
 })

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -103,7 +103,7 @@ test("test turbo:before-fetch-request event.detail", async ({ page }) => {
   await page.click("#same-origin-link")
   const { url, fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.equal(fetchOptions.method, "GET")
+  assert.equal(fetchOptions.method, "get")
   assert.ok(url.includes("/src/tests/fixtures/one.html"))
 })
 


### PR DESCRIPTION
The problem
---

Prior to this commit, instances of `FormSubmission` and `FetchRequest`
referenced in dispatched `turbo:submit-start` and
`turbo:before-fetch-request` events were tedious to modify from a host
application.

For example, the `FormSubmission` instance made available through
`event.detail.formSubmission` exposed properties that _seemed_ writable.

Unfortunately, any mutations to `formSubmission.method` or
`formSubmission.location` from within host application event listeners
(like `turbo:before-fetch-request`) occur _after_ the underlying 
`FetchRequest` instance is built, which has subtle and not obvious 
implications. In practice, modifications to these properties are 
unobserved by the underlying `FetchRequest` instance, and have no effect
on the ensuing `fetch` call.

Luckily, if host applications are aware of these issues and limitations,
they can work around them by mutating the
`event.detail.formSubission.fetchRequest` instance.

The proposal
---

After this commit, the `FormSubmission.constructor` will infer the
required data (like `[method]` and `[action]` values) from its 
`HTMLFormElement` and optional `HTMLElement` arguments, then use those
values to construct the `FetchRequest` instance.

After that construction, any changes to the `FormSubmission` properties
will _delegate_ to the `FetchRequest` instance.

In tandem with those changes, the `FetchRequest` will follow a similar
pattern: extract as much information up-front during construction, then
delegate property reads and writes to properties. In most
cases, it will delegate to its [`fetchOptions:
RequestInit`][RequestInit] instance.

To achieve this behavior, several module-local functions and type
definitions were shuffled around between the `FormSubmission` and
`FetchRequest` modules. The order of arguments for the `FetchRequest`
constructor were also re-arranged to support omitting values that are
made redundant by default arguments.

[RequestInit]: https://developer.mozilla.org/en-US/docs/Web/API/fetch#parameters