### PR TITLE
`turbo:frame-missing`: Dispatch for 4xx and 5xx

### DIFF
--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -313,15 +313,6 @@ export class Session
     this.notifyApplicationAfterFrameRender(fetchResponse, frame)
   }
 
-  async frameMissing(frame: FrameElement, fetchResponse: FetchResponse): Promise<void> {
-    console.warn(`A matching frame for #${frame.id} was missing from the response, transforming into full-page Visit.`)
-
-    const responseHTML = await fetchResponse.responseHTML
-    const { location, redirected, statusCode } = fetchResponse
-
-    return this.visit(location, { response: { redirected, statusCode, responseHTML } })
-  }
-
   // Application events
 
   applicationAllowsFollowingLinkToLocation(link: Element, location: URL, ev: MouseEvent) {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -90,7 +90,8 @@
     </turbo-frame>
 
     <turbo-frame id="missing">
-      <a href="/src/tests/fixtures/frames/frame.html">Missing frame</a>
+      <a id="missing-frame-link" href="/src/tests/fixtures/frames/frame.html">Missing frame</a>
+      <a id="missing-page-link" href="/missing.html">404</a>
     </turbo-frame>
 
     <turbo-frame id="body-script" target="body-script">


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/670

Re-use the existing `2xx` and `3xx` behavior for a response to handle
error responses. When the frame is missing from the page (likely for
error pages like `404`), dispatch a `turbo:frame-missing` event.

Alongside that behavior, yield the [Response][] instance and a
`Turbo.visit`-like callback that can transform the `Response` instance
into a `Visit`. It also accepts all the arguments that the `Turbo.visit`
call normally does.

When the event is not canceled, treat the `Response` as a Visit. When
the event **is** canceled, let the listener handle it.

[Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response