### PR TITLE
Dispatch visit events on the initiator link or form

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -8,7 +8,7 @@ import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
-  allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
+  allowsVisitingLocation(location: URL, options: Partial<VisitOptions>): boolean
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>): Promise<void>
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
@@ -24,7 +24,7 @@ export class Navigator {
   }
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
-    if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
+    if (this.delegate.allowsVisitingLocation(location, options)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
         return this.delegate.visitProposedToLocation(location, options)
       } else {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -51,7 +51,7 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean,
-  initiator?: Element
+  initiator?: HTMLAnchorElement | HTMLFormElement
 }
 
 const defaultOptions: VisitOptions = {
@@ -87,6 +87,7 @@ export class Visit implements FetchRequestDelegate {
   readonly willRender: boolean
   readonly updateHistory: boolean
   readonly promise: Promise<void>
+  readonly initiator?: HTMLAnchorElement | HTMLFormElement
 
   private resolvingFunctions!: ResolvingFunctions<void>
 
@@ -127,6 +128,7 @@ export class Visit implements FetchRequestDelegate {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
+      initiator
     } = {
       ...defaultOptions,
       ...options,
@@ -143,6 +145,7 @@ export class Visit implements FetchRequestDelegate {
     this.scrolled = !willRender
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
+    this.initiator = initiator
   }
 
   get adapter() {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -51,7 +51,7 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
-  initiator?: HTMLAnchorElement | HTMLFormElement
+  initiator?: Element
 }
 
 const defaultOptions: VisitOptions = {
@@ -87,7 +87,7 @@ export class Visit implements FetchRequestDelegate {
   readonly willRender: boolean
   readonly updateHistory: boolean
   readonly promise: Promise<void>
-  readonly initiator?: HTMLAnchorElement | HTMLFormElement
+  readonly initiator?: Element
 
   private resolvingFunctions!: ResolvingFunctions<void>
 

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -226,7 +226,7 @@ export class Visit implements FetchRequestDelegate {
     if (this.hasPreloadedResponse()) {
       this.simulateRequest()
     } else if (this.shouldIssueRequest() && !this.request) {
-      this.request = new FetchRequest(this, FetchMethod.get, this.location)
+      this.request = new FetchRequest(this, FetchMethod.get, this.location, undefined, this.initiator)
       this.request.perform()
     }
   }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -50,7 +50,7 @@ export type VisitOptions = {
   restorationIdentifier?: string
   shouldCacheSnapshot: boolean
   frame?: string
-  acceptsStreamResponse: boolean,
+  acceptsStreamResponse: boolean
   initiator?: HTMLAnchorElement | HTMLFormElement
 }
 
@@ -128,7 +128,7 @@ export class Visit implements FetchRequestDelegate {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
-      initiator
+      initiator,
     } = {
       ...defaultOptions,
       ...options,

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -50,7 +50,8 @@ export type VisitOptions = {
   restorationIdentifier?: string
   shouldCacheSnapshot: boolean
   frame?: string
-  acceptsStreamResponse: boolean
+  acceptsStreamResponse: boolean,
+  initiator?: Element
 }
 
 const defaultOptions: VisitOptions = {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -51,7 +51,7 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
-  initiator?: Element
+  initiator: Element
 }
 
 const defaultOptions: VisitOptions = {
@@ -62,6 +62,7 @@ const defaultOptions: VisitOptions = {
   updateHistory: true,
   shouldCacheSnapshot: true,
   acceptsStreamResponse: false,
+  initiator: document.documentElement,
 }
 
 export type VisitResponse = {
@@ -87,7 +88,7 @@ export class Visit implements FetchRequestDelegate {
   readonly willRender: boolean
   readonly updateHistory: boolean
   readonly promise: Promise<void>
-  readonly initiator?: Element
+  readonly initiator: Element
 
   private resolvingFunctions!: ResolvingFunctions<void>
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -191,7 +191,7 @@ export class Session
     )
   }
 
-  followedLinkToLocation(link: Element, location: URL) {
+  followedLinkToLocation(link: HTMLAnchorElement, location: URL) {
     const action = this.getActionForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
 
@@ -215,7 +215,7 @@ export class Session
     }
     extendURLWithDeprecatedProperties(visit.location)
     if (!visit.silent) {
-      this.notifyApplicationAfterVisitingLocation(visit.location, visit.action)
+      this.notifyApplicationAfterVisitingLocation(visit.location, visit.action, visit.initiator)
     }
   }
 
@@ -350,8 +350,11 @@ export class Session
     })
   }
 
-  notifyApplicationAfterVisitingLocation(location: URL, action: Action) {
-    return dispatch<TurboVisitEvent>("turbo:visit", { detail: { url: location.href, action } })
+  notifyApplicationAfterVisitingLocation(location: URL, action: Action, element?: Element) {
+    return dispatch<TurboVisitEvent>("turbo:visit", {
+      target: element,
+      detail: { url: location.href, action }
+    })
   }
 
   notifyApplicationBeforeCachingSnapshot() {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -191,7 +191,7 @@ export class Session
     )
   }
 
-  followedLinkToLocation(link: HTMLAnchorElement, location: URL) {
+  followedLinkToLocation(link: Element, location: URL) {
     const action = this.getActionForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -201,7 +201,10 @@ export class Session
   // Navigator delegate
 
   allowsVisitingLocation(location: URL, options: Partial<VisitOptions> = {}) {
-    return this.locationWithActionIsSamePage(location, options.action) || this.applicationAllowsVisitingLocation(location, options)
+    return (
+      this.locationWithActionIsSamePage(location, options.action) ||
+      this.applicationAllowsVisitingLocation(location, options)
+    )
   }
 
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>) {
@@ -353,7 +356,7 @@ export class Session
   notifyApplicationAfterVisitingLocation(location: URL, action: Action, element?: Element) {
     return dispatch<TurboVisitEvent>("turbo:visit", {
       target: element,
-      detail: { url: location.href, action }
+      detail: { url: location.href, action },
     })
   }
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -195,13 +195,13 @@ export class Session
     const action = this.getActionForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
 
-    this.visit(location.href, { action, acceptsStreamResponse })
+    this.visit(location.href, { action, acceptsStreamResponse, initiator: link })
   }
 
   // Navigator delegate
 
-  allowsVisitingLocationWithAction(location: URL, action?: Action) {
-    return this.locationWithActionIsSamePage(location, action) || this.applicationAllowsVisitingLocation(location)
+  allowsVisitingLocation(location: URL, options: Partial<VisitOptions> = {}) {
+    return this.locationWithActionIsSamePage(location, options.action) || this.applicationAllowsVisitingLocation(location, options)
   }
 
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>) {
@@ -329,8 +329,8 @@ export class Session
     return !event.defaultPrevented
   }
 
-  applicationAllowsVisitingLocation(location: URL) {
-    const event = this.notifyApplicationBeforeVisitingLocation(location)
+  applicationAllowsVisitingLocation(location: URL, options: Partial<VisitOptions> = {}) {
+    const event = this.notifyApplicationBeforeVisitingLocation(location, options.initiator)
     return !event.defaultPrevented
   }
 
@@ -342,8 +342,9 @@ export class Session
     })
   }
 
-  notifyApplicationBeforeVisitingLocation(location: URL) {
+  notifyApplicationBeforeVisitingLocation(location: URL, element?: Element) {
     return dispatch<TurboBeforeVisitEvent>("turbo:before-visit", {
+      target: element,
       detail: { url: location.href },
       cancelable: true,
     })

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -62,7 +62,7 @@ export class FetchRequest {
   readonly headers: FetchRequestHeaders
   readonly url: URL
   readonly body?: FetchRequestBody
-  readonly target?: FrameElement | HTMLFormElement | null
+  readonly target?: FrameElement | HTMLFormElement | HTMLAnchorElement | null
   readonly abortController = new AbortController()
   private resolveRequestPromise = (_value: any) => {}
 
@@ -71,7 +71,7 @@ export class FetchRequest {
     method: FetchMethod,
     location: URL,
     body: FetchRequestBody = new URLSearchParams(),
-    target: FrameElement | HTMLFormElement | null = null
+    target: FrameElement | HTMLFormElement | HTMLAnchorElement | null = null
   ) {
     this.delegate = delegate
     this.method = method

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -1,5 +1,4 @@
 import { FetchResponse } from "./fetch_response"
-import { FrameElement } from "../elements/frame_element"
 import { dispatch } from "../util"
 
 export type TurboBeforeFetchRequestEvent = CustomEvent<{
@@ -62,7 +61,7 @@ export class FetchRequest {
   readonly headers: FetchRequestHeaders
   readonly url: URL
   readonly body?: FetchRequestBody
-  readonly target?: FrameElement | HTMLFormElement | HTMLAnchorElement | null
+  readonly target?: Element | null
   readonly abortController = new AbortController()
   private resolveRequestPromise = (_value: any) => {}
 
@@ -71,7 +70,7 @@ export class FetchRequest {
     method: FetchMethod,
     location: URL,
     body: FetchRequestBody = new URLSearchParams(),
-    target: FrameElement | HTMLFormElement | HTMLAnchorElement | null = null
+    target: Element | null = null
   ) {
     this.delegate = delegate
     this.method = method

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -383,8 +383,8 @@ test("test ignores links that target an iframe", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
 })
 
-test("test turbo:before-visit is dispatched on the initiator", async ({ page }) => {
+test("test visit events are dispatched on the initiator", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
-  const event = await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-visit")
-  assert.ok(event)
+  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-visit")
+  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:visit")
 })

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -10,6 +10,7 @@ import {
   nextBody,
   nextEventNamed,
   noNextEventNamed,
+  nextEventOnTarget,
   pathname,
   readEventLogs,
   search,
@@ -380,4 +381,10 @@ test("test ignores links that target an iframe", async ({ page }) => {
   await nextBeat()
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+})
+
+test("test turbo:before-visit is dispatched on the initiator", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link")
+  const event = await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-visit")
+  assert.ok(event)
 })

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -388,3 +388,9 @@ test("test visit events are dispatched on the initiator", async ({ page }) => {
   await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-visit")
   await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:visit")
 })
+
+test("test fetch events are dispatched on the initiator", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link")
+  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-response")
+})


### PR DESCRIPTION
In a similar vein to #367, this pull request dispatches `turbo:visit`, `turbo:before-visit`, `turbo:before-fetch-request`, and `turbo:before-fetch-response` on the initiator link or form (where applicable), rather than solely on the `html` element.

**Why?** When developing libraries that build on top of Turbo, it'd be nice to customise behaviour based on HTML attributes of the clicked link or submitted form. For example, if I were building an animation library and wished to disable a transition when clicking a particular element, I could do:

```html
<a href="…" data-animate="false">Do not animate me</a>
```

I could then use `event.target.dataset.animate` in the `turbo:visit` event to conditionally animate.
Other examples are mentioned in #99.

Closes #99