### PR TITLE
Use `element.localName` over `element.tagName.toLowerCase()`

### DIFF
--- a/src/core/drive/head_snapshot.ts
+++ b/src/core/drive/head_snapshot.ts
@@ -96,22 +96,22 @@ function elementIsTracked(element: Element) {
 }
 
 function elementIsScript(element: Element) {
-  const tagName = element.tagName.toLowerCase()
+  const tagName = element.localName
   return tagName == "script"
 }
 
 function elementIsNoscript(element: Element) {
-  const tagName = element.tagName.toLowerCase()
+  const tagName = element.localName
   return tagName == "noscript"
 }
 
 function elementIsStylesheet(element: Element) {
-  const tagName = element.tagName.toLowerCase()
+  const tagName = element.localName
   return tagName == "style" || (tagName == "link" && element.getAttribute("rel") == "stylesheet")
 }
 
 function elementIsMetaElementWithName(element: Element, name: string) {
-  const tagName = element.tagName.toLowerCase()
+  const tagName = element.localName
   return tagName == "meta" && element.getAttribute("name") == name
 }
 


### PR DESCRIPTION
[`element.tagName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/tagName) always returns the elements tag name in all uppercase so we needed to cast it to all lower-case in order to fit our needs. 

In contrast, [`element.localName`](https://developer.mozilla.org/en-US/docs/Web/API/Element/localName) returns the actual tag HTML name, so this is more accurate.

Since we are already using `element.localName` in a few other places in the codebase and because of it's good browser-support it's much more preferable to use.