### PR TITLE
Dispatch `turbo:frame-render` when Frame connects

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -59,6 +59,10 @@ export class FrameController {
       this.formLinkClickObserver.start()
       this.linkInterceptor.start()
       this.formSubmitObserver.start()
+
+      if (this.element.isConnected) {
+        session.frameRendered(this.element)
+      }
     }
   }
 
@@ -316,8 +320,8 @@ export class FrameController {
 
       await this.view.render(renderer)
       this.complete = true
-      session.frameRendered(fetchResponse, this.element)
-      session.frameLoaded(this.element)
+      session.frameRendered(this.element, fetchResponse)
+      session.frameLoaded(this.element, fetchResponse)
       await this.fetchResponseLoaded(fetchResponse)
     } else if (this.#willHandleFrameMissingFromResponse(fetchResponse)) {
       this.#handleFrameMissingFromResponse(fetchResponse)

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -362,12 +362,12 @@ export class Session {
 
   // Frame element
 
-  frameLoaded(frame) {
-    this.notifyApplicationAfterFrameLoad(frame)
+  frameLoaded(frame, fetchResponse) {
+    this.notifyApplicationAfterFrameLoad(frame, fetchResponse)
   }
 
-  frameRendered(fetchResponse, frame) {
-    this.notifyApplicationAfterFrameRender(fetchResponse, frame)
+  frameRendered(frame, fetchResponse) {
+    this.notifyApplicationAfterFrameRender(frame, fetchResponse)
   }
 
   // Application events
@@ -422,13 +422,19 @@ export class Session {
     })
   }
 
-  notifyApplicationAfterFrameLoad(frame) {
-    return dispatch("turbo:frame-load", { target: frame })
+  notifyApplicationAfterFrameLoad(frame, fetchResponse) {
+    return dispatch("turbo:frame-load", { target: frame, detail: { fetchResponse } })
   }
 
-  notifyApplicationAfterFrameRender(fetchResponse, frame) {
+  notifyApplicationAfterFrameRender(frame, fetchResponse) {
+    const detailWithDeprecation = {
+      get fetchResponse() {
+        console.warn("DEPRECATED: If your event listener needs to access the detail.fetchResponse, listen for the turbo:frame-load event")
+        return fetchResponse
+      }
+    }
     return dispatch("turbo:frame-render", {
-      detail: { fetchResponse },
+      detail: detailWithDeprecation,
       target: frame,
       cancelable: true
     })

--- a/src/tests/functional/drive_disabled_tests.js
+++ b/src/tests/functional/drive_disabled_tests.js
@@ -42,11 +42,13 @@ test("drive disabled by default; submit form inside data-turbo='true'", async ({
 test("drive disabled by default; links within <turbo-frame> navigate with Turbo", async ({ page }) => {
   await page.click("#frame a")
   await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
 test("drive disabled by default; forms within <turbo-frame> navigate with Turbo", async ({ page }) => {
   await page.click("#frame button")
   await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
 test("drive disabled by default; slot within <turbo-frame> navigate with Turbo", async ({ page }) => {


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo-rails/issues/379

Currently, a `<turbo-frame>` element only dispatches events when its
contents are fetched over HTTP. The `turbo:frame-render` and
`turbo:frame-load` events are dispatched sequentially and immediately
following one another. The `turbo:frame-render` detail exposes a
reference to the `FetchResponse`, while the `turbo:frame-load` event has
no details.

Consumer applications might expect a `<turbo-frame>` to dispatch a
`turbo:frame-render` event immediately whenever a `<turbo-frame>` is
connected to the document (similar to the way that `turbo:render` is
dispatched prior to `turbo:load`, even on restoration Visits).

For the sake of consistency and distinguishing between two events that
are more or less equivalent and temporally interchangeable, this commit
proposes that a `<turbo-frame>` should dispatch a `turbo:frame-render`
_whenever its contents change_, including its initial render.

As a complementary change to that behavior, the `turbo:frame-load`
events will be dispatched with `detail.fetchResponse` as a reference to
the `FetchResponse`.

Ideally, the `turbo:frame-render` would not expose the
`detail.fetchResponse` reference. However, removing it would be a
breaking change. To that end, this commit dispatches a `detail` that
prints a console warning (encouraging a migration to `turbo:frame-load`)
whenever a `turbo:frame-render` listener reads the
`detail.fetchResponse` property. Future major releases can remove the
property and warning.