### PR TITLE
Export Custom Elements and Stream Action Types

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -30,9 +30,8 @@ export {
 export { TurboSubmitStartEvent, TurboSubmitEndEvent } from "./drive/form_submission"
 export { TurboFrameMissingEvent } from "./frames/frame_controller"
 export { TurboBeforeFetchRequestEvent, TurboBeforeFetchResponseEvent } from "../http/fetch_request"
-export { TurboBeforeStreamRenderEvent } from "../elements/stream_element"
 
-export { StreamActions } from "./streams/stream_actions"
+export { StreamActions, TurboStreamAction, TurboStreamActions } from "./streams/stream_actions"
 
 /**
  * Starts the main session.

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -29,7 +29,6 @@ export {
 
 export { TurboSubmitStartEvent, TurboSubmitEndEvent } from "./drive/form_submission"
 export { TurboFrameMissingEvent } from "./frames/frame_controller"
-export { TurboBeforeFetchRequestEvent, TurboBeforeFetchResponseEvent } from "../http/fetch_request"
 
 export { StreamActions, TurboStreamAction, TurboStreamActions } from "./streams/stream_actions"
 

--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -1,8 +1,9 @@
 import { StreamElement } from "../../elements/stream_element"
 
-export const StreamActions: {
-  [action: string]: (this: StreamElement) => void
-} = {
+export type TurboStreamAction = (this: StreamElement) => void
+export type TurboStreamActions = { [action: string]: TurboStreamAction }
+
+export const StreamActions: TurboStreamActions = {
   after() {
     this.targetElements.forEach((e) => e.parentElement?.insertBefore(this.templateContent, e.nextSibling))
   },

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -7,6 +7,7 @@ FrameElement.delegateConstructor = FrameController
 
 export * from "./frame_element"
 export * from "./stream_element"
+export * from "./stream_source_element"
 
 if (customElements.get("turbo-frame") === undefined) {
   customElements.define("turbo-frame", FrameElement)

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,0 +1,1 @@
+export { TurboBeforeFetchRequestEvent, TurboBeforeFetchResponseEvent } from "./fetch_request"

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ Turbo.start()
 
 export * from "./core"
 export * from "./elements"
+export * from "./http"

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,3 +8,4 @@ window.Turbo = Turbo
 Turbo.start()
 
 export * from "./core"
+export * from "./elements"


### PR DESCRIPTION
When working with TypeScript in applications and libraries in can be quite frustrating to get the right types, especially when a library doesn't export all the required types.

Therefore this Pull Request exports the types and classes for the Custom Elements and Stream Actions so they can be used in applications and libraries without the need to redefine the types manually.

I also re-organized to exports for the `http` subfolder, since those types were exported from the core subfolder, which technically shouldn't need to care about the exports of other subfolders.