### PR TITLE
Address CI Test Flakiness

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -19,6 +19,7 @@ export {
   TurboBeforeRenderEvent,
   TurboBeforeVisitEvent,
   TurboClickEvent,
+  TurboBeforeFrameRenderEvent,
   TurboFrameLoadEvent,
   TurboFrameRenderEvent,
   TurboLoadEvent,

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -140,6 +140,7 @@ test("test failing to follow a link to a page without a matching frame dispatche
   const { response } = await nextEventOnTarget(page, "missing", "turbo:frame-missing")
   await noNextEventNamed(page, "turbo:before-fetch-request")
   await noNextEventNamed(page, "turbo:load")
+  await nextEventNamed(page, "turbo:render")
 
   assert.ok(response, "dispatches turbo:frame-missing with event.detail.response")
   assert.equal(pathname(page.url()), "/missing.html", "navigates the page")

--- a/src/tests/helpers/page.ts
+++ b/src/tests/helpers/page.ts
@@ -59,7 +59,7 @@ export async function isScrolledToSelector(page: Page, selector: string): Promis
     const { y: pageY } = await scrollPosition(page)
     const { y: elementY } = boundingBox
     const offset = pageY - elementY
-    return Math.abs(offset) < 2
+    return Math.abs(offset) <= 2
   } else {
     return false
   }

--- a/src/tests/unit/export_tests.ts
+++ b/src/tests/unit/export_tests.ts
@@ -1,0 +1,51 @@
+import { DOMTestCase } from "../helpers/dom_test_case"
+import * as Turbo from "../../index"
+
+export {
+  PageRenderer,
+  PageSnapshot,
+  FrameRenderer,
+  FrameElement,
+  StreamActions,
+  StreamElement,
+  StreamSourceElement,
+  TurboBeforeCacheEvent,
+  TurboBeforeFetchRequestEvent,
+  TurboBeforeFetchResponseEvent,
+  TurboBeforeFrameRenderEvent,
+  TurboBeforeRenderEvent,
+  TurboBeforeStreamRenderEvent,
+  TurboBeforeVisitEvent,
+  TurboClickEvent,
+  TurboFetchRequestErrorEvent,
+  TurboFrameLoadEvent,
+  TurboFrameMissingEvent,
+  TurboFrameRenderEvent,
+  TurboLoadEvent,
+  TurboRenderEvent,
+  TurboStreamAction,
+  TurboStreamActions,
+  TurboSubmitEndEvent,
+  TurboSubmitStartEvent,
+  TurboVisitEvent,
+} from "../../index"
+
+export class ExportTests extends DOMTestCase {
+  async "test Turbo interface"() {
+    this.assert.equal(typeof Turbo.start, "function")
+    this.assert.equal(typeof Turbo.registerAdapter, "function")
+    this.assert.equal(typeof Turbo.visit, "function")
+    this.assert.equal(typeof Turbo.connectStreamSource, "function")
+    this.assert.equal(typeof Turbo.disconnectStreamSource, "function")
+    this.assert.equal(typeof Turbo.renderStreamMessage, "function")
+    this.assert.equal(typeof Turbo.clearCache, "function")
+    this.assert.equal(typeof Turbo.setProgressBarDelay, "function")
+    this.assert.equal(typeof Turbo.setConfirmMethod, "function")
+    this.assert.equal(typeof Turbo.setFormMode, "function")
+    this.assert.equal(typeof Turbo.cache, "object")
+    this.assert.equal(typeof Turbo.navigator, "object")
+    this.assert.equal(typeof Turbo.session, "object")
+  }
+}
+
+ExportTests.registerSuite()

--- a/src/tests/unit/index.ts
+++ b/src/tests/unit/index.ts
@@ -1,2 +1,3 @@
+export * from "./export_tests"
 export * from "./deprecated_adapter_support_test"
 export * from "./stream_element_tests"


### PR DESCRIPTION
Frame Missing Tests: Wait for `turbo:render`
===

One of the `turbo:frame-missing` event tests is flaky since the
assertions execute without first waiting for a synchronizing event. This
commit changes the test to wait until a `turbo:render` event is
dispatched before making its assertions.

Scrolling Tests: Increase scrollY threshold
===

Tests are often flaky when exercising scrolling. More often than not,
Firefox scrolls to within _exactly_ 2 Y units.

This commit changes the `isScrolledToSelector` boolean to treat a 2 unit
difference as within the threshold.

Add test coverage for exports
===

Introduce the `src/tests/unit/export_tests.ts` module to cover what's
exported from the `src/index.ts` module, including both Turbo-prefixed
classes and objects and functions accessible as the `Turbo.`-prefixed
accessors.
