### PR TITLE
Reintroduce `Visit` `identifier` property

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -79,6 +79,7 @@ export enum SystemStatusCode {
 
 export class Visit implements FetchRequestDelegate {
   readonly delegate: VisitDelegate
+  readonly identifier = uuid() // Required by turbo-ios
   readonly restorationIdentifier: string
   readonly action: Action
   readonly referrer?: URL


### PR DESCRIPTION
This property is required by turbo-ios, so removing it causes crashes within that library.

E.g. https://github.com/hotwired/turbo-ios/blob/main/Source/WebView/WebViewBridge.swift#L129

This reverts commit d81e24db77da05f53c6ab3c66e2620574c9e08c9.