### PR TITLE
Revert "Dispatch visit events on the initiator link or form (#695)"

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -8,7 +8,7 @@ import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
-  allowsVisitingLocation(location: URL, options: Partial<VisitOptions>): boolean
+  allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>): Promise<void>
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
@@ -24,7 +24,7 @@ export class Navigator {
   }
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
-    if (this.delegate.allowsVisitingLocation(location, options)) {
+    if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
         return this.delegate.visitProposedToLocation(location, options)
       } else {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -51,7 +51,6 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
-  initiator: Element
 }
 
 const defaultOptions: VisitOptions = {
@@ -62,7 +61,6 @@ const defaultOptions: VisitOptions = {
   updateHistory: true,
   shouldCacheSnapshot: true,
   acceptsStreamResponse: false,
-  initiator: document.documentElement,
 }
 
 export type VisitResponse = {
@@ -88,7 +86,6 @@ export class Visit implements FetchRequestDelegate {
   readonly willRender: boolean
   readonly updateHistory: boolean
   readonly promise: Promise<void>
-  readonly initiator: Element
 
   private resolvingFunctions!: ResolvingFunctions<void>
 
@@ -129,7 +126,6 @@ export class Visit implements FetchRequestDelegate {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
-      initiator,
     } = {
       ...defaultOptions,
       ...options,
@@ -146,7 +142,6 @@ export class Visit implements FetchRequestDelegate {
     this.scrolled = !willRender
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
-    this.initiator = initiator
   }
 
   get adapter() {
@@ -227,7 +222,7 @@ export class Visit implements FetchRequestDelegate {
     if (this.hasPreloadedResponse()) {
       this.simulateRequest()
     } else if (this.shouldIssueRequest() && !this.request) {
-      this.request = new FetchRequest(this, FetchMethod.get, this.location, undefined, this.initiator)
+      this.request = new FetchRequest(this, FetchMethod.get, this.location)
       this.request.perform()
     }
   }

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -195,16 +195,13 @@ export class Session
     const action = this.getActionForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
 
-    this.visit(location.href, { action, acceptsStreamResponse, initiator: link })
+    this.visit(location.href, { action, acceptsStreamResponse })
   }
 
   // Navigator delegate
 
-  allowsVisitingLocation(location: URL, options: Partial<VisitOptions> = {}) {
-    return (
-      this.locationWithActionIsSamePage(location, options.action) ||
-      this.applicationAllowsVisitingLocation(location, options)
-    )
+  allowsVisitingLocationWithAction(location: URL, action?: Action) {
+    return this.locationWithActionIsSamePage(location, action) || this.applicationAllowsVisitingLocation(location)
   }
 
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>) {
@@ -218,7 +215,7 @@ export class Session
     }
     extendURLWithDeprecatedProperties(visit.location)
     if (!visit.silent) {
-      this.notifyApplicationAfterVisitingLocation(visit.location, visit.action, visit.initiator)
+      this.notifyApplicationAfterVisitingLocation(visit.location, visit.action)
     }
   }
 
@@ -323,8 +320,8 @@ export class Session
     return !event.defaultPrevented
   }
 
-  applicationAllowsVisitingLocation(location: URL, options: Partial<VisitOptions> = {}) {
-    const event = this.notifyApplicationBeforeVisitingLocation(location, options.initiator)
+  applicationAllowsVisitingLocation(location: URL) {
+    const event = this.notifyApplicationBeforeVisitingLocation(location)
     return !event.defaultPrevented
   }
 
@@ -336,19 +333,15 @@ export class Session
     })
   }
 
-  notifyApplicationBeforeVisitingLocation(location: URL, element?: Element) {
+  notifyApplicationBeforeVisitingLocation(location: URL) {
     return dispatch<TurboBeforeVisitEvent>("turbo:before-visit", {
-      target: element,
       detail: { url: location.href },
       cancelable: true,
     })
   }
 
-  notifyApplicationAfterVisitingLocation(location: URL, action: Action, element?: Element) {
-    return dispatch<TurboVisitEvent>("turbo:visit", {
-      target: element,
-      detail: { url: location.href, action },
-    })
+  notifyApplicationAfterVisitingLocation(location: URL, action: Action) {
+    return dispatch<TurboVisitEvent>("turbo:visit", { detail: { url: location.href, action } })
   }
 
   notifyApplicationBeforeCachingSnapshot() {

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -1,4 +1,5 @@
 import { FetchResponse } from "./fetch_response"
+import { FrameElement } from "../elements/frame_element"
 import { dispatch } from "../util"
 
 export type TurboBeforeFetchRequestEvent = CustomEvent<{
@@ -65,7 +66,7 @@ export class FetchRequest {
   readonly headers: FetchRequestHeaders
   readonly url: URL
   readonly body?: FetchRequestBody
-  readonly target?: Element | null
+  readonly target?: FrameElement | HTMLFormElement | null
   readonly abortController = new AbortController()
   private resolveRequestPromise = (_value: any) => {}
 
@@ -74,7 +75,7 @@ export class FetchRequest {
     method: FetchMethod,
     location: URL,
     body: FetchRequestBody = new URLSearchParams(),
-    target: Element | null = null
+    target: FrameElement | HTMLFormElement | null = null
   ) {
     this.delegate = delegate
     this.method = method

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -10,7 +10,6 @@ import {
   nextBody,
   nextEventNamed,
   noNextEventNamed,
-  nextEventOnTarget,
   pathname,
   readEventLogs,
   search,
@@ -389,16 +388,4 @@ test("test ignores links that target an iframe", async ({ page }) => {
   await nextBeat()
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-})
-
-test("test visit events are dispatched on the initiator", async ({ page }) => {
-  await page.click("#same-origin-unannotated-link")
-  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-visit")
-  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:visit")
-})
-
-test("test fetch events are dispatched on the initiator", async ({ page }) => {
-  await page.click("#same-origin-unannotated-link")
-  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-request")
-  await nextEventOnTarget(page, "same-origin-unannotated-link", "turbo:before-fetch-response")
 })


### PR DESCRIPTION
The inclusion of the `initiator` in `VisitOptions` causes a JS crash in the Turbo iOS adapter.

This is because Turbo iOS's implementation of `visitProposedToLocation` relies on being able to pass the entire options struct to native code. Initiator is an `Element`, which can't be passed in this way, resulting in a `DataCloneError` exception.

There is some discussion on this [GitHub issue][]. This PR reverts the change for the moment, until we have an implementation of it that works with all adapters.

[GitHub issue]: https://github.com/hotwired/turbo/issues/720

This reverts commit 887181796e8d5586de89c70327f31e9a81dcfec2.