### PR TITLE
Revert "Return `Promise<void>` from `Turbo.visit` (#650)"

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -9,7 +9,7 @@ import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
   allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
-  visitProposedToLocation(location: URL, options: Partial<VisitOptions>): Promise<void>
+  visitProposedToLocation(location: URL, options: Partial<VisitOptions>): void
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
 
@@ -26,14 +26,10 @@ export class Navigator {
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
     if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
-        return this.delegate.visitProposedToLocation(location, options)
+        this.delegate.visitProposedToLocation(location, options)
       } else {
         window.location.href = location.toString()
-
-        return Promise.resolve()
       }
-    } else {
-      return Promise.reject()
     }
   }
 
@@ -45,8 +41,6 @@ export class Navigator {
       ...options,
     })
     this.currentVisit.start()
-
-    return this.currentVisit.promise
   }
 
   submitForm(form: HTMLFormElement, submitter?: HTMLElement) {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -5,7 +5,7 @@ import { History } from "./history"
 import { getAnchor } from "../url"
 import { Snapshot } from "../snapshot"
 import { PageSnapshot } from "./page_snapshot"
-import { Action, ResolvingFunctions } from "../types"
+import { Action } from "../types"
 import { getHistoryMethodForAction, uuid } from "../../util"
 import { PageView } from "./page_view"
 import { StreamMessage } from "../streams/stream_message"
@@ -85,9 +85,6 @@ export class Visit implements FetchRequestDelegate {
   readonly visitCachedSnapshot: (snapshot: Snapshot) => void
   readonly willRender: boolean
   readonly updateHistory: boolean
-  readonly promise: Promise<void>
-
-  private resolvingFunctions!: ResolvingFunctions<void>
 
   followedRedirect = false
   frame?: number
@@ -113,7 +110,6 @@ export class Visit implements FetchRequestDelegate {
     this.delegate = delegate
     this.location = location
     this.restorationIdentifier = restorationIdentifier || uuid()
-    this.promise = new Promise((resolve, reject) => (this.resolvingFunctions = { resolve, reject }))
 
     const {
       action,
@@ -180,8 +176,6 @@ export class Visit implements FetchRequestDelegate {
       }
       this.cancelRender()
       this.state = VisitState.canceled
-
-      this.resolvingFunctions.reject()
     }
   }
 
@@ -195,8 +189,6 @@ export class Visit implements FetchRequestDelegate {
         this.adapter.visitCompleted(this)
         this.delegate.visitCompleted(this)
       }
-
-      this.resolvingFunctions.resolve()
     }
   }
 
@@ -204,8 +196,6 @@ export class Visit implements FetchRequestDelegate {
     if (this.state == VisitState.started) {
       this.state = VisitState.failed
       this.adapter.visitFailed(this)
-
-      this.resolvingFunctions.reject()
     }
   }
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -64,8 +64,8 @@ export function registerAdapter(adapter: Adapter) {
  * @param options.snapshotHTML Cached snapshot to render
  * @param options.response Response of the specified location
  */
-export function visit(location: Locatable, options?: Partial<VisitOptions>): Promise<void> {
-  return session.visit(location, options)
+export function visit(location: Locatable, options?: Partial<VisitOptions>) {
+  session.visit(location, options)
 }
 
 /**

--- a/src/core/native/adapter.ts
+++ b/src/core/native/adapter.ts
@@ -3,7 +3,7 @@ import { FormSubmission } from "../drive/form_submission"
 import { ReloadReason } from "./browser_adapter"
 
 export interface Adapter {
-  visitProposedToLocation(location: URL, options?: Partial<VisitOptions>): Promise<void>
+  visitProposedToLocation(location: URL, options?: Partial<VisitOptions>): void
   visitStarted(visit: Visit): void
   visitCompleted(visit: Visit): void
   visitFailed(visit: Visit): void

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -24,7 +24,7 @@ export class BrowserAdapter implements Adapter {
   }
 
   visitProposedToLocation(location: URL, options?: Partial<VisitOptions>) {
-    return this.navigator.startVisit(location, options?.restorationIdentifier || uuid(), options)
+    this.navigator.startVisit(location, options?.restorationIdentifier || uuid(), options)
   }
 
   visitStarted(visit: Visit) {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,7 +1,11 @@
-import { ResolvingFunctions } from "./types"
 import { Bardo, BardoDelegate } from "./bardo"
 import { Snapshot } from "./snapshot"
 import { ReloadReason } from "./native/browser_adapter"
+
+type ResolvingFunctions<T = unknown> = {
+  resolve(value: T | PromiseLike<T>): void
+  reject(reason?: any): void
+}
 
 export type Render<E> = (newElement: E, currentElement: E) => void
 

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -109,14 +109,14 @@ export class Session
     this.adapter = adapter
   }
 
-  visit(location: Locatable, options: Partial<VisitOptions> = {}): Promise<void> {
+  visit(location: Locatable, options: Partial<VisitOptions> = {}) {
     const frameElement = options.frame ? document.getElementById(options.frame) : null
 
     if (frameElement instanceof FrameElement) {
       frameElement.src = location.toString()
-      return frameElement.loaded
+      frameElement.loaded
     } else {
-      return this.navigator.proposeVisit(expandURL(location), options)
+      this.navigator.proposeVisit(expandURL(location), options)
     }
   }
 
@@ -206,7 +206,7 @@ export class Session
 
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>) {
     extendURLWithDeprecatedProperties(location)
-    return this.adapter.visitProposedToLocation(location, options)
+    this.adapter.visitProposedToLocation(location, options)
   }
 
   visitStarted(visit: Visit) {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,8 +18,3 @@ export type StreamSource = {
     options?: boolean | EventListenerOptions
   ): void
 }
-
-export type ResolvingFunctions<T = unknown> = {
-  resolve(value: T | PromiseLike<T>): void
-  reject(reason?: any): void
-}

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -40,38 +40,9 @@ test("test programmatically visiting a same-origin location", async ({ page }) =
   assert.ok(timing)
 })
 
-test("test programmatically Turbo.visit-ing a same-origin location", async ({ page }) => {
-  const urlBeforeVisit = page.url()
-  await page.evaluate(async () => await window.Turbo.visit("/src/tests/fixtures/one.html"))
-
-  const urlAfterVisit = page.url()
-  assert.notEqual(urlBeforeVisit, urlAfterVisit)
-  assert.equal(await visitAction(page), "advance")
-
-  const { url: urlFromBeforeVisitEvent } = await nextEventNamed(page, "turbo:before-visit")
-  assert.equal(urlFromBeforeVisitEvent, urlAfterVisit)
-
-  const { url: urlFromVisitEvent } = await nextEventNamed(page, "turbo:visit")
-  assert.equal(urlFromVisitEvent, urlAfterVisit)
-
-  const { timing } = await nextEventNamed(page, "turbo:load")
-  assert.ok(timing)
-})
-
 test("skip programmatically visiting a cross-origin location falls back to window.location", async ({ page }) => {
   const urlBeforeVisit = page.url()
   await visitLocation(page, "about:blank")
-
-  const urlAfterVisit = page.url()
-  assert.notEqual(urlBeforeVisit, urlAfterVisit)
-  assert.equal(await visitAction(page), "load")
-})
-
-test("skip programmatically Turbo.visit-ing a cross-origin location falls back to window.location", async ({
-  page,
-}) => {
-  const urlBeforeVisit = page.url()
-  await page.evaluate(async () => await window.Turbo.visit("about:blank"))
 
   const urlAfterVisit = page.url()
   assert.notEqual(urlBeforeVisit, urlAfterVisit)
@@ -105,28 +76,6 @@ test("test canceling a before-visit event prevents navigation", async ({ page })
 
   const urlAfterVisit = page.url()
   assert.equal(urlAfterVisit, urlBeforeVisit)
-})
-
-test("test canceling a before-visit event prevents a Turbo.visit-initiated navigation", async ({ page }) => {
-  await cancelNextVisit(page)
-  const urlBeforeVisit = page.url()
-
-  assert.notOk<boolean>(
-    await willChangeBody(page, async () => {
-      await page.evaluate(async () => {
-        try {
-          return await window.Turbo.visit("/src/tests/fixtures/one.html")
-        } catch {
-          const title = document.querySelector("h1")
-          if (title) title.innerHTML = "Visit canceled"
-        }
-      })
-    })
-  )
-
-  const urlAfterVisit = page.url()
-  assert.equal(urlAfterVisit, urlBeforeVisit)
-  assert.equal(await page.textContent("h1"), "Visit canceled")
 })
 
 test("test navigation by history is not cancelable", async ({ page }) => {

--- a/src/tests/unit/deprecated_adapter_support_test.ts
+++ b/src/tests/unit/deprecated_adapter_support_test.ts
@@ -34,10 +34,8 @@ export class DeprecatedAdapterSupportTest extends DOMTestCase implements Adapter
 
   // Adapter interface
 
-  visitProposedToLocation(location: URL, _options?: Partial<VisitOptions>): Promise<void> {
+  visitProposedToLocation(location: URL, _options?: Partial<VisitOptions>): void {
     this.locations.push(location)
-
-    return Promise.resolve()
   }
 
   visitStarted(visit: Visit): void {


### PR DESCRIPTION
Since #650, errors are present in the console whenever initiating a visit causes cancellation of the previous visit.

Reported in:
- https://github.com/hotwired/turbo/issues/706
- https://github.com/hotwired/turbo/issues/716

Reverting until a solution is found for the errors.

This reverts commit aeeaae8edb5f6ec6ef6b19eaf93dc060a1e67b10.