### PR TITLE
CI: Restore passing tests

### DIFF
--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -7,7 +7,6 @@ import {
   isScrolledToTop,
   nextBeat,
   nextEventNamed,
-  nextEventOnTarget,
   noNextAttributeMutationNamed,
   readEventLogs,
   scrollToSelector,
@@ -209,7 +208,7 @@ test("test Visit with network error", async ({ page }) => {
   })
   await page.context().setOffline(true)
   await page.click("#same-origin-link")
-  await nextEventOnTarget(page, "same-origin-link", "turbo:fetch-request-error")
+  await nextEventNamed(page, "turbo:fetch-request-error")
 })
 
 async function visitLocation(page: Page, location: string) {


### PR DESCRIPTION
With the reverting of [hotwired/turbo#695][] (merged as [hotwired/turbo#723][]), the "Visit with network error" test coverage was missed in the diff.

Prior to the revert, the test was listening for
`turbo:fetch-request-error` events dispatched on the _link_ that was clicked. Since that's no longer the case, this commit changes the test to listen for `turbo:fetch-request-error` that bubble up to the document.

[hotwired/turbo#695]: https://github.com/hotwired/turbo/pull/695
[hotwired/turbo#723]: https://github.com/hotwired/turbo/pull/723