### PR TITLE
Don't toggle `turbo-frame[busy]` when navigating `_top`

### DIFF
--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -31,6 +31,10 @@
       <a id="link-frame" href="/src/tests/fixtures/frames/frame.html">Navigate #frame from within</a>
       <a id="link-frame-with-search-params" href="/src/tests/fixtures/frames/frame.html?key=value">Navigate #frame with ?key=value</a>
       <a id="link-nested-frame-action-advance" href="/src/tests/fixtures/frames/frame.html" data-turbo-action="advance">Navigate #frame from within with a[data-turbo-action="advance"]</a>
+      <a id="link-top" href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
+      <form action="/src/tests/fixtures/one.html" data-turbo-frame="_top">
+        <button id="form-submit-top">Visit one.html</button>
+      </form>
     </turbo-frame>
     <a id="outside-frame-form" href="/src/tests/fixtures/frames/form.html" data-turbo-frame="frame">Navigate #frame to /frames/form.html</a>
 

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -5,6 +5,7 @@ import {
   hasSelector,
   innerHTMLForSelector,
   nextAttributeMutationNamed,
+  noNextAttributeMutationNamed,
   nextBeat,
   nextEventNamed,
   nextEventOnTarget,
@@ -110,6 +111,30 @@ test("test following a link driving a frame toggles the [aria-busy=true] attribu
     await nextAttributeMutationNamed(page, "frame", "aria-busy"),
     null,
     "removes [aria-busy] from the #frame"
+  )
+})
+
+test("test following an a[data-turbo-frame=_top] does not toggle the frame's [aria-busy=true] attribute", async ({
+  page,
+}) => {
+  await page.click("#frame #link-top")
+
+  assert.ok(await noNextAttributeMutationNamed(page, "frame", "busy"), "does not toggle [busy] on parent frame")
+  assert.ok(
+    await noNextAttributeMutationNamed(page, "frame", "aria-busy"),
+    "does not toggle [aria-busy=true] on parent frame"
+  )
+})
+
+test("test submitting a form[data-turbo-frame=_top] does not toggle the frame's [aria-busy=true] attribute", async ({
+  page,
+}) => {
+  await page.click("#frame #form-submit-top")
+
+  assert.ok(await noNextAttributeMutationNamed(page, "frame", "busy"), "does not toggle [busy] on parent frame")
+  assert.ok(
+    await noNextAttributeMutationNamed(page, "frame", "aria-busy"),
+    "does not toggle [aria-busy=true] on parent frame"
   )
 })
 

--- a/src/tests/helpers/page.ts
+++ b/src/tests/helpers/page.ts
@@ -111,7 +111,7 @@ export async function noNextAttributeMutationNamed(
   attributeName: string
 ): Promise<boolean> {
   const records = await readMutationLogs(page, 1)
-  return !records.some(([name]) => name == attributeName)
+  return !records.some(([name, _, target]) => name == attributeName && target == elementId)
 }
 
 export async function noNextEventNamed(page: Page, eventName: string): Promise<boolean> {


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/727

Add test coverage to ensure that an `<a>` element click or `<form>` element submission nested within a `<turbo-frame>` _does not_ toggle `[aria-busy]` or `[busy]` on the `turbo-frame` if the navigation is targeting `_top` (with `[data-turbo-frame="_top"]`).