### PR TITLE
Fix: Dispatch `turbo:click` when driving a Frame

### DIFF
--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="html" data-skip-event-details="turbo:before-render">
+<html id="html" data-skip-event-details="turbo:click turbo:before-render">
   <head>
     <meta charset="utf-8">
     <title>Frame</title>
@@ -88,6 +88,7 @@
       <a href="/src/tests/fixtures/one.html?key=value">Visit one.html?key=value</a>
       <a href="/src/tests/fixtures/one.html" data-turbo-frame="_self">Visit self</a>
     </turbo-frame>
+    <a id="outside-navigate-top-link" href="/src/tests/fixtures/one.html">Visit one.html from outside #navigate-top</a>
 
     <turbo-frame id="missing">
       <a id="missing-frame-link" href="/src/tests/fixtures/frames/frame.html">Missing frame</a>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -47,6 +47,7 @@
      }
    }).observe(document, { subtree: true, childList: true, attributes: true })
 })([
+  "turbo:click",
   "turbo:before-stream-render",
   "turbo:before-cache",
   "turbo:before-render",

--- a/src/tests/helpers/page.ts
+++ b/src/tests/helpers/page.ts
@@ -14,6 +14,15 @@ export function attributeForSelector(page: Page, selector: string, attributeName
   return page.locator(selector).getAttribute(attributeName)
 }
 
+type CancellableEvent = "turbo:click" | "turbo:before-visit"
+
+export function cancelNextEvent(page: Page, eventName: CancellableEvent): Promise<void> {
+  return page.evaluate(
+    (eventName) => addEventListener(eventName, (event) => event.preventDefault(), { once: true }),
+    eventName
+  )
+}
+
 export function clickWithoutScrolling(page: Page, selector: string, options = {}) {
   const element = page.locator(selector, options)
 


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/726

Prior to this commit, clicking on `<a>` elements nested within
`<turbo-frame>` elements, or `<a>` elements that drive `<turbo-frame>`
elements did not dispatch `turbo:click` events in the same way that they
did before [hotwired/turbo#412][].

This commit re-instates those events as part of the `FrameController`
and `FrameRedirector` implementations for the `willFollowLinkToLocation`
methods they define as part of the `LinkClickObserverDelegate`
interface.

To be consistent with the existing `turbo:click` dispatch behavior, and
to guard against introducing similar regressions in the future, this
commit also adds test coverage for falling back to page-wide navigations
when `turbo:click` events are canceled.

In support of those changes, first, introduce the `cancelNextEvent`
helper to accept the name of a Turbo event that is cancellable (in this
case, `turbo:click` and `turbo:before-visit`). Next, implement
`cancelNextVisit` in terms of `cancelNextEvent`.

Finally, use the `cancelNextEvent` helper in the Frame test coverage to
ensure that canceling a `turbo:click` prevents navigating the Frame and
falls back to built-in browser behavior.

[hotwired/turbo#412]: https://github.com/hotwired/turbo/pull/412
