### PR TITLE
Configure Playwright to retry failed tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,6 +11,7 @@ const config: PlaywrightTestConfig = {
       use: { ...devices["Desktop Firefox"] },
     },
   ],
+  retries: 2,
   testDir: "./src/tests/functional",
   testMatch: /.*_tests\.ts/,
   webServer: {


### PR DESCRIPTION
[Configure Playwright][] to retry a failed test at least twice before considering it failed. This should help cut down on CI flakiness.

[Configure Playwright]: https://playwright.dev/docs/test-configuration