### PR TITLE
Cache PageSnapshot with original HTML from the frame's page

### DIFF
--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -39,12 +39,12 @@ export class PageView extends View<HTMLBodyElement, PageSnapshot, PageViewRender
     this.snapshotCache.clear()
   }
 
-  async cacheSnapshot(pageSnapshot?: PageSnapshot) {
-    if (this.shouldCacheSnapshot(pageSnapshot)) {
+  async cacheSnapshot(snapshot: PageSnapshot = this.snapshot) {
+    if (snapshot.isCacheable) {
       this.delegate.viewWillCacheSnapshot()
-      const { snapshot, lastRenderedLocation: location } = this
+      const { lastRenderedLocation: location } = this
       await nextEventLoopTick()
-      const cachedSnapshot = (pageSnapshot || snapshot).clone()
+      const cachedSnapshot = snapshot.clone()
       this.snapshotCache.put(location, cachedSnapshot)
       return cachedSnapshot
     }
@@ -56,9 +56,5 @@ export class PageView extends View<HTMLBodyElement, PageSnapshot, PageViewRender
 
   get snapshot() {
     return PageSnapshot.fromElement(this.element)
-  }
-
-  shouldCacheSnapshot(pageSnapshot?: PageSnapshot) {
-    return (pageSnapshot || this.snapshot).isCacheable
   }
 }

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -39,12 +39,12 @@ export class PageView extends View<HTMLBodyElement, PageSnapshot, PageViewRender
     this.snapshotCache.clear()
   }
 
-  async cacheSnapshot() {
-    if (this.shouldCacheSnapshot) {
+  async cacheSnapshot(pageSnapshot?: PageSnapshot) {
+    if (this.shouldCacheSnapshot(pageSnapshot)) {
       this.delegate.viewWillCacheSnapshot()
       const { snapshot, lastRenderedLocation: location } = this
       await nextEventLoopTick()
-      const cachedSnapshot = snapshot.clone()
+      const cachedSnapshot = (pageSnapshot || snapshot).clone()
       this.snapshotCache.put(location, cachedSnapshot)
       return cachedSnapshot
     }
@@ -58,7 +58,7 @@ export class PageView extends View<HTMLBodyElement, PageSnapshot, PageViewRender
     return PageSnapshot.fromElement(this.element)
   }
 
-  get shouldCacheSnapshot() {
-    return this.snapshot.isCacheable
+  shouldCacheSnapshot(pageSnapshot?: PageSnapshot) {
+    return (pageSnapshot || this.snapshot).isCacheable
   }
 }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -51,6 +51,7 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
+  pageSnapshot?: PageSnapshot
 }
 
 const defaultOptions: VisitOptions = {
@@ -61,6 +62,7 @@ const defaultOptions: VisitOptions = {
   updateHistory: true,
   shouldCacheSnapshot: true,
   acceptsStreamResponse: false,
+  pageSnapshot: undefined,
 }
 
 export type VisitResponse = {
@@ -100,6 +102,7 @@ export class Visit implements FetchRequestDelegate {
   snapshotHTML?: string
   snapshotCached = false
   state = VisitState.initialized
+  pageSnapshot?: PageSnapshot
 
   constructor(
     delegate: VisitDelegate,
@@ -122,6 +125,7 @@ export class Visit implements FetchRequestDelegate {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
+      pageSnapshot,
     } = {
       ...defaultOptions,
       ...options,
@@ -138,6 +142,7 @@ export class Visit implements FetchRequestDelegate {
     this.scrolled = !willRender
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
+    this.pageSnapshot = pageSnapshot
   }
 
   get adapter() {
@@ -451,7 +456,7 @@ export class Visit implements FetchRequestDelegate {
 
   cacheSnapshot() {
     if (!this.snapshotCached) {
-      this.view.cacheSnapshot().then((snapshot) => snapshot && this.visitCachedSnapshot(snapshot))
+      this.view.cacheSnapshot(this.pageSnapshot).then((snapshot) => snapshot && this.visitCachedSnapshot(snapshot))
       this.snapshotCached = true
     }
   }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -42,6 +42,7 @@ export type VisitOptions = {
   action: Action
   historyChanged: boolean
   referrer?: URL
+  snapshot?: PageSnapshot
   snapshotHTML?: string
   response?: VisitResponse
   visitCachedSnapshot(snapshot: Snapshot): void
@@ -51,7 +52,6 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
-  pageSnapshot?: PageSnapshot
 }
 
 const defaultOptions: VisitOptions = {
@@ -62,7 +62,6 @@ const defaultOptions: VisitOptions = {
   updateHistory: true,
   shouldCacheSnapshot: true,
   acceptsStreamResponse: false,
-  pageSnapshot: undefined,
 }
 
 export type VisitResponse = {
@@ -102,7 +101,7 @@ export class Visit implements FetchRequestDelegate {
   snapshotHTML?: string
   snapshotCached = false
   state = VisitState.initialized
-  pageSnapshot?: PageSnapshot
+  snapshot?: PageSnapshot
 
   constructor(
     delegate: VisitDelegate,
@@ -118,6 +117,7 @@ export class Visit implements FetchRequestDelegate {
       action,
       historyChanged,
       referrer,
+      snapshot,
       snapshotHTML,
       response,
       visitCachedSnapshot,
@@ -125,7 +125,6 @@ export class Visit implements FetchRequestDelegate {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
-      pageSnapshot,
     } = {
       ...defaultOptions,
       ...options,
@@ -133,6 +132,7 @@ export class Visit implements FetchRequestDelegate {
     this.action = action
     this.historyChanged = historyChanged
     this.referrer = referrer
+    this.snapshot = snapshot
     this.snapshotHTML = snapshotHTML
     this.response = response
     this.isSamePage = this.delegate.locationWithActionIsSamePage(this.location, this.action)
@@ -142,7 +142,6 @@ export class Visit implements FetchRequestDelegate {
     this.scrolled = !willRender
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
-    this.pageSnapshot = pageSnapshot
   }
 
   get adapter() {
@@ -456,7 +455,7 @@ export class Visit implements FetchRequestDelegate {
 
   cacheSnapshot() {
     if (!this.snapshotCached) {
-      this.view.cacheSnapshot(this.pageSnapshot).then((snapshot) => snapshot && this.visitCachedSnapshot(snapshot))
+      this.view.cacheSnapshot(this.snapshot).then((snapshot) => snapshot && this.visitCachedSnapshot(snapshot))
       this.snapshotCached = true
     }
   }

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -358,7 +358,7 @@ export class FrameController
 
   private navigateFrame(element: Element, url: string, submitter?: HTMLElement) {
     const frame = this.findFrameElement(element, submitter)
-    this.pageSnapshot = PageSnapshot.fromElement(element).clone()
+    this.pageSnapshot = PageSnapshot.fromElement(frame).clone()
 
     this.proposeVisitIfNavigatedWithAction(frame, element, submitter)
 

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -358,6 +358,7 @@ export class FrameController
 
   private navigateFrame(element: Element, url: string, submitter?: HTMLElement) {
     const frame = this.findFrameElement(element, submitter)
+    this.pageSnapshot = PageSnapshot.fromElement(element).clone()
 
     this.proposeVisitIfNavigatedWithAction(frame, element, submitter)
 
@@ -569,7 +570,6 @@ export class FrameController
   }
 
   private withCurrentNavigationElement(element: Element, callback: () => void) {
-    this.pageSnapshot = PageSnapshot.fromElement(element).clone()
     this.currentNavigationElement = element
     callback()
     delete this.currentNavigationElement

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -31,6 +31,7 @@ import { isAction, Action } from "../types"
 import { VisitOptions } from "../drive/visit"
 import { TurboBeforeFrameRenderEvent } from "../session"
 import { StreamMessage } from "../streams/stream_message"
+import { PageSnapshot } from "../drive/page_snapshot"
 
 type VisitFallback = (location: Response | Locatable, options: Partial<VisitOptions>) => Promise<void>
 export type TurboFrameMissingEvent = CustomEvent<{ response: Response; visit: VisitFallback }>
@@ -64,6 +65,7 @@ export class FrameController
   readonly restorationIdentifier: string
   private previousFrameElement?: FrameElement
   private currentNavigationElement?: Element
+  pageSnapshot?: PageSnapshot
 
   constructor(element: FrameElement) {
     this.element = element
@@ -382,6 +384,7 @@ export class FrameController
             willRender: false,
             updateHistory: false,
             restorationIdentifier: this.restorationIdentifier,
+            pageSnapshot: this.pageSnapshot,
           }
 
           if (this.action) options.action = this.action
@@ -566,6 +569,7 @@ export class FrameController
   }
 
   private withCurrentNavigationElement(element: Element, callback: () => void) {
+    this.pageSnapshot = PageSnapshot.fromElement(session.view.element).clone()
     this.currentNavigationElement = element
     callback()
     delete this.currentNavigationElement

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -384,7 +384,7 @@ export class FrameController
             willRender: false,
             updateHistory: false,
             restorationIdentifier: this.restorationIdentifier,
-            pageSnapshot: this.pageSnapshot,
+            snapshot: this.pageSnapshot,
           }
 
           if (this.action) options.action = this.action
@@ -569,7 +569,7 @@ export class FrameController
   }
 
   private withCurrentNavigationElement(element: Element, callback: () => void) {
-    this.pageSnapshot = PageSnapshot.fromElement(session.view.element).clone()
+    this.pageSnapshot = PageSnapshot.fromElement(element).clone()
     this.currentNavigationElement = element
     callback()
     delete this.currentNavigationElement

--- a/src/tests/functional/frame_navigation_tests.ts
+++ b/src/tests/functional/frame_navigation_tests.ts
@@ -1,5 +1,5 @@
 import { test } from "@playwright/test"
-import { getFromLocalStorage, nextBeat, nextEventNamed, nextEventOnTarget, pathname } from "../helpers/page"
+import { getFromLocalStorage, nextEventNamed, nextEventOnTarget, pathname } from "../helpers/page"
 import { assert } from "chai"
 
 test("test frame navigation with descendant link", async ({ page }) => {
@@ -56,28 +56,30 @@ test("test promoted frame navigations are cached", async ({ page }) => {
   await page.goto("/src/tests/fixtures/tabs.html")
 
   await page.click("#tab-2")
-  await nextEventNamed(page, "turbo:frame-render")
+  await nextEventOnTarget(page, "tab-frame", "turbo:frame-load")
+  await nextEventNamed(page, "turbo:load")
 
   assert.equal(await page.textContent("#tab-content"), "Two")
   assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
   assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "sets [complete]")
 
   await page.click("#tab-3")
-  await nextEventNamed(page, "turbo:frame-render")
+  await nextEventOnTarget(page, "tab-frame", "turbo:frame-load")
+  await nextEventNamed(page, "turbo:load")
 
   assert.equal(await page.textContent("#tab-content"), "Three")
   assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/three.html")
   assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "sets [complete]")
 
   await page.goBack()
-  await nextBeat()
+  await nextEventNamed(page, "turbo:load")
 
   assert.equal(await page.textContent("#tab-content"), "Two")
   assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
   assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "caches two.html with [complete]")
 
   await page.goBack()
-  await nextBeat()
+  await nextEventNamed(page, "turbo:load")
 
   assert.equal(await page.textContent("#tab-content"), "One")
   assert.equal(await page.getAttribute("#tab-frame", "src"), null, "caches one.html without #tab-frame[src]")

--- a/src/tests/functional/frame_navigation_tests.ts
+++ b/src/tests/functional/frame_navigation_tests.ts
@@ -59,19 +59,27 @@ test("test promoted frame navigations are cached", async ({ page }) => {
   await nextEventNamed(page, "turbo:frame-render")
 
   assert.equal(await page.textContent("#tab-content"), "Two")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "sets [complete]")
 
   await page.click("#tab-3")
   await nextEventNamed(page, "turbo:frame-render")
 
   assert.equal(await page.textContent("#tab-content"), "Three")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/three.html")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "sets [complete]")
 
   await page.goBack()
   await nextBeat()
 
   assert.equal(await page.textContent("#tab-content"), "Two")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "caches two.html with [complete]")
 
   await page.goBack()
   await nextBeat()
 
   assert.equal(await page.textContent("#tab-content"), "One")
+  assert.equal(await page.getAttribute("#tab-frame", "src"), null, "caches one.html without #tab-frame[src]")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), null, "caches one.html without [complete]")
 })

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -767,7 +767,7 @@ test("test navigating frame with button[data-turbo-action=advance] pushes URL st
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test.only("test navigating back after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames previous contents", async ({
+test("test navigating back after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames previous contents", async ({
   page,
 }) => {
   await page.click("#add-turbo-action-to-frame")

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -767,7 +767,7 @@ test("test navigating frame with button[data-turbo-action=advance] pushes URL st
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test("test navigating back after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames previous contents", async ({
+test.only("test navigating back after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames previous contents", async ({
   page,
 }) => {
   await page.click("#add-turbo-action-to-frame")
@@ -778,12 +778,11 @@ test("test navigating back after pushing URL state from a turbo-frame[data-turbo
 
   const title = await page.textContent("h1")
   const frameTitle = await page.textContent("#frame h2")
-  const src = new URL((await attributeForSelector(page, "#frame", "src")) || "")
 
   assert.equal(title, "Frames")
   assert.equal(frameTitle, "Frames: #frame")
   assert.equal(pathname(page.url()), "/src/tests/fixtures/frames.html")
-  assert.equal(src.pathname, "/src/tests/fixtures/frames/frame.html")
+  assert.equal(await attributeForSelector(page, "#frame", "src"), null)
   assert.equal(await propertyForSelector(page, "#frame", "src"), null)
 })
 


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/745

Before this change, when a promoted frame finished its navigation, a visit was started and the visit would add a new PageSnapshot to the cache. The problem is that this snapshot was looking at a page that was already modified by the frame navigation, so the snapshot cache would be incorrect.

With this proposed change, we are taking a PageSnapshot as soon as the frame navigation starts, so we guarantee that the page hasn't been modified yet. Then, I'm passing this snapshot forward to the Visit and using it as the correct cache instead of calculating a new one.