### PR TITLE
Resolve Issue #747

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -60,7 +60,6 @@ export class FrameController
   private hasBeenLoaded = false
   private ignoredAttributes: Set<FrameElementObservedAttribute> = new Set()
   private action: Action | null = null
-  private frame?: FrameElement
   readonly restorationIdentifier: string
   private previousFrameElement?: FrameElement
   private currentNavigationElement?: Element
@@ -286,7 +285,7 @@ export class FrameController
   formSubmissionSucceededWithResponse(formSubmission: FormSubmission, response: FetchResponse) {
     const frame = this.findFrameElement(formSubmission.formElement, formSubmission.submitter)
 
-    this.proposeVisitIfNavigatedWithAction(frame, formSubmission.formElement, formSubmission.submitter)
+    frame.delegate.proposeVisitIfNavigatedWithAction(frame, formSubmission.formElement, formSubmission.submitter)
 
     frame.delegate.loadResponse(response)
   }
@@ -367,16 +366,15 @@ export class FrameController
   private navigateFrame(element: Element, url: string, submitter?: HTMLElement) {
     const frame = this.findFrameElement(element, submitter)
 
-    this.proposeVisitIfNavigatedWithAction(frame, element, submitter)
+    frame.delegate.proposeVisitIfNavigatedWithAction(frame, element, submitter)
 
     this.withCurrentNavigationElement(element, () => {
       frame.src = url
     })
   }
 
-  private proposeVisitIfNavigatedWithAction(frame: FrameElement, element: Element, submitter?: HTMLElement) {
+  proposeVisitIfNavigatedWithAction(frame: FrameElement, element: Element, submitter?: HTMLElement) {
     this.action = getVisitAction(submitter, element, frame)
-    this.frame = frame
 
     if (isAction(this.action)) {
       const { visitCachedSnapshot } = frame.delegate
@@ -403,9 +401,9 @@ export class FrameController
   }
 
   changeHistory() {
-    if (this.action && this.frame) {
+    if (this.action) {
       const method = getHistoryMethodForAction(this.action)
-      session.history.update(method, expandURL(this.frame.src || ""), this.restorationIdentifier)
+      session.history.update(method, expandURL(this.element.src || ""), this.restorationIdentifier)
     }
   }
 

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -19,6 +19,7 @@ export interface FrameElementDelegate extends LinkClickObserverDelegate, FormSub
   sourceURLReloaded(): Promise<void>
   disabledChanged(): void
   loadResponse(response: FetchResponse): void
+  proposeVisitIfNavigatedWithAction(frame: FrameElement, element: Element, submitter?: HTMLElement): void
   fetchResponseLoaded: (fetchResponse: FetchResponse) => void
   visitCachedSnapshot: (snapshot: Snapshot) => void
   isLoading: boolean

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -297,6 +297,10 @@
       </form>
       <div id="messages">
       </div>
+      <form id="form-with-external-inputs" action="/src/tests/fixtures/frames/hello.html" data-turbo-action="replace" data-turbo-frame="hello"></form>
+      <select id="external-select" form="form-with-external-inputs" name="greeting">
+        <option selected>Hello from a replace Visit</option>
+      </select>
     </turbo-frame>
     <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-outside-frame">Method link outside frame</a><br />
     <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-outside-frame">Stream link outside frame</a>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -185,6 +185,21 @@ test("test standard GET form submission", async ({ page }) => {
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a form")
 })
 
+test("test standard GET HTMLFormElement.requestSubmit() with Turbo Action", async ({ page }) => {
+  await page.evaluate(() => {
+    const formControl = document.querySelector<HTMLSelectElement>("#external-select")
+
+    if (formControl && formControl.form) formControl.form.requestSubmit()
+  })
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("h1"), "Form", "Retains original page state")
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "navigates #hello turbo frame")
+  assert.equal(await visitAction(page), "replace", "reads Turbo Action from <form>")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html", "promotes frame navigation to page Visit")
+  assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a replace Visit", "encodes <form> into request")
+})
+
 test("test standard GET form submission with [data-turbo-stream] declared on the form", async ({ page }) => {
   await page.click("#standard-get-form-with-stream-opt-in-submit")
 


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/747

Prior to this commit, `<turbo-frame>` elements navigated by `[data-turbo-frame]` attributes were not promoted into Visits if navigation initiator (a `<form>` element, for example) had another `<turbo-frame>` as its ancestor.

To resolve that issue, this commit adds the
`proposeVisitIfNavigatedWithAction` method to the `FrameElementDelegate` interface.

Instead of tracking _which_ `FrameElement` would navigate as a `Visit` through an internal `frame?: FrameElement` property, the `FrameController` methods **reach through** the `FrameElement` instance that's resolved by the `FrameController.findFrameElement` method to delegate navigation promotion to **that frame's delegate** instead of to itself.