### PR TITLE
Merge in remaining header elements (eg: link icons, manifest, meta and title)

### DIFF
--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -60,10 +60,10 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
   }
 
   async mergeHead() {
+    const mergedHeadElements = this.mergeProvisionalElements()
     const newStylesheetElements = this.copyNewHeadStylesheetElements()
     this.copyNewHeadScriptElements()
-    this.removeCurrentHeadProvisionalElements()
-    this.copyNewHeadProvisionalElements()
+    await mergedHeadElements
     await newStylesheetElements
   }
 
@@ -94,6 +94,43 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
     for (const element of this.newHeadScriptElements) {
       document.head.appendChild(activateScriptElement(element))
     }
+  }
+
+  async mergeProvisionalElements() {
+
+    let newHeadElements = [...this.newHeadProvisionalElements];
+
+    for (const element of this.currentHeadProvisionalElements) {
+      if(!this.isCurrentElementInElementList(element, newHeadElements)){
+        document.head.removeChild(element)
+      }
+    }
+
+    for (const element of newHeadElements) {
+      document.head.appendChild(element)
+    }
+  }
+
+  isCurrentElementInElementList(element: Element, elementList: Element[]){
+
+    for (const [index, newElement] of elementList.entries()){
+      // if title element...
+      if (element.tagName == "TITLE"){
+        if(newElement.tagName != "TITLE"){
+          continue
+        }
+        if (element.innerHTML == newElement.innerHTML){
+          elementList.splice(index, 1);
+          return true;  
+        }
+      }
+      // if any other element...
+      if (newElement.isEqualNode(element)){
+        elementList.splice(index, 1);
+        return true;
+      }
+    }
+    return false
   }
 
   removeCurrentHeadProvisionalElements() {

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -124,12 +124,14 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
           return true;  
         }
       }
+
       // if any other element...
       if (newElement.isEqualNode(element)){
         elementList.splice(index, 1);
         return true;
       }
     }
+
     return false
   }
 

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -97,11 +97,10 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
   }
 
   async mergeProvisionalElements() {
-
-    let newHeadElements = [...this.newHeadProvisionalElements];
+    const newHeadElements = [...this.newHeadProvisionalElements]
 
     for (const element of this.currentHeadProvisionalElements) {
-      if(!this.isCurrentElementInElementList(element, newHeadElements)){
+      if (!this.isCurrentElementInElementList(element, newHeadElements)) {
         document.head.removeChild(element)
       }
     }
@@ -111,24 +110,23 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
     }
   }
 
-  isCurrentElementInElementList(element: Element, elementList: Element[]){
-
-    for (const [index, newElement] of elementList.entries()){
+  isCurrentElementInElementList(element: Element, elementList: Element[]) {
+    for (const [index, newElement] of elementList.entries()) {
       // if title element...
-      if (element.tagName == "TITLE"){
-        if(newElement.tagName != "TITLE"){
+      if (element.tagName == "TITLE") {
+        if (newElement.tagName != "TITLE") {
           continue
         }
-        if (element.innerHTML == newElement.innerHTML){
-          elementList.splice(index, 1);
-          return true;  
+        if (element.innerHTML == newElement.innerHTML) {
+          elementList.splice(index, 1)
+          return true
         }
       }
 
       // if any other element...
-      if (newElement.isEqualNode(element)){
-        elementList.splice(index, 1);
-        return true;
+      if (newElement.isEqualNode(element)) {
+        elementList.splice(index, 1)
+        return true
       }
     }
 


### PR DESCRIPTION
Resolves #719 

When turbo loads a page, the current behavior is to remove and replace all provisional head elements.  This would include the title tag, meta tags, and link tags to icons, fonts and manifest.json.  This can lead to additional http requests as demonstrated below:  

https://user-images.githubusercontent.com/1790447/193615680-850b415e-5e99-4cc3-ba37-f9c5da353404.mp4

This PR merges the elements instead providing a cleaner page load experience and preventing these potential additional requests.

https://user-images.githubusercontent.com/1790447/193615692-ce90c1c1-91d8-4d78-8350-6839d16b8aac.mp4

**Unit test note:**
I was not able to get the test suite running and encountered this issue:

```
Tunnel started
BUG: suiteEnd was received for invalid session
```

If this PR has potential, I could use some assistance getting things up and running. 

