### PR TITLE
Avoid bubbling form submissions that target a new window/tab

### DIFF
--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -57,7 +57,7 @@ function submissionDoesNotDismissDialog(form: HTMLFormElement, submitter?: HTMLE
 }
 
 function submissionDoesNotHaveSpecificTarget(form: HTMLFormElement, submitter?: HTMLElement): boolean {
-  const target = submitter?.getAttribute("formtarget") || form.target
+  const target = submitter?.getAttribute("formtarget") || form.getAttribute("target")
 
   return !target || target == "_self"
 }

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -41,6 +41,7 @@ export class FormSubmitObserver {
         form &&
         submissionDoesNotDismissDialog(form, submitter) &&
         submissionDoesNotTargetIFrame(form, submitter) &&
+        submissionDoesNotTargetBlankWindow(form, submitter) &&
         this.delegate.willSubmitForm(form, submitter)
       ) {
         event.preventDefault()
@@ -64,4 +65,10 @@ function submissionDoesNotTargetIFrame(form: HTMLFormElement, submitter?: HTMLEl
   }
 
   return true
+}
+
+function submissionDoesNotTargetBlankWindow(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+  const target = submitter?.getAttribute("formtarget") || form.target
+
+  return target != "_blank"
 }

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -40,8 +40,7 @@ export class FormSubmitObserver {
       if (
         form &&
         submissionDoesNotDismissDialog(form, submitter) &&
-        submissionDoesNotTargetIFrame(form, submitter) &&
-        submissionDoesNotTargetBlankWindow(form, submitter) &&
+        submissionDoesNotHaveSpecificTarget(form, submitter) &&
         this.delegate.willSubmitForm(form, submitter)
       ) {
         event.preventDefault()
@@ -57,18 +56,8 @@ function submissionDoesNotDismissDialog(form: HTMLFormElement, submitter?: HTMLE
   return method != "dialog"
 }
 
-function submissionDoesNotTargetIFrame(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+function submissionDoesNotHaveSpecificTarget(form: HTMLFormElement, submitter?: HTMLElement): boolean {
   const target = submitter?.getAttribute("formtarget") || form.target
 
-  for (const element of document.getElementsByName(target)) {
-    if (element instanceof HTMLIFrameElement) return false
-  }
-
-  return true
-}
-
-function submissionDoesNotTargetBlankWindow(form: HTMLFormElement, submitter?: HTMLElement): boolean {
-  const target = submitter?.getAttribute("formtarget") || form.target
-
-  return target != "_blank"
+  return target != "_self"
 }

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -59,5 +59,5 @@ function submissionDoesNotDismissDialog(form: HTMLFormElement, submitter?: HTMLE
 function submissionDoesNotHaveSpecificTarget(form: HTMLFormElement, submitter?: HTMLElement): boolean {
   const target = submitter?.getAttribute("formtarget") || form.target
 
-  return target != "_self"
+  return !target || target == "_self"
 }

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -38,7 +38,7 @@ export class LinkClickObserver {
     if (event instanceof MouseEvent && this.clickEventIsSignificant(event)) {
       const target = (event.composedPath && event.composedPath()[0]) || event.target
       const link = this.findLinkFromClickTarget(target)
-      if (link && doesNotTargetIFrame(link)) {
+      if (link && doesNotHaveSpecificTarget(link)) {
         const location = this.getLocationForLink(link)
         if (this.delegate.willFollowLinkToLocation(link, location, event)) {
           event.preventDefault()
@@ -71,10 +71,6 @@ export class LinkClickObserver {
   }
 }
 
-function doesNotTargetIFrame(anchor: HTMLAnchorElement): boolean {
-  for (const element of document.getElementsByName(anchor.target)) {
-    if (element instanceof HTMLIFrameElement) return false
-  }
-
-  return true
+function doesNotHaveSpecificTarget(anchor: HTMLAnchorElement): boolean {
+  return anchor.target != "_self"
 }

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -72,5 +72,7 @@ export class LinkClickObserver {
 }
 
 function doesNotHaveSpecificTarget(anchor: HTMLAnchorElement): boolean {
-  return !anchor.target || anchor.target == "_self"
+  const target = anchor.getAttribute("target")
+
+  return !target || target == "_self"
 }

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -62,7 +62,7 @@ export class LinkClickObserver {
 
   findLinkFromClickTarget(target: EventTarget | null) {
     if (target instanceof Element) {
-      return target.closest<HTMLAnchorElement>("a[href]:not([target^=_]):not([download])")
+      return target.closest<HTMLAnchorElement>("a[href]:not([download])")
     }
   }
 
@@ -72,5 +72,5 @@ export class LinkClickObserver {
 }
 
 function doesNotHaveSpecificTarget(anchor: HTMLAnchorElement): boolean {
-  return anchor.target != "_self"
+  return !anchor.target || anchor.target == "_self"
 }

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -68,8 +68,8 @@
       <p><a id="same-origin-targeted-link" href="/src/tests/fixtures/one.html" target="_blank">Same-origin targeted link</a></p>
       <p><a id="same-origin-self-targeted-link" href="/src/tests/fixtures/one.html" target="_self">Same-origin link with [target=_self]</a></p>
       <p><a id="same-origin-download-link" href="/intentionally_missing_fake_download.html" download="x.html">Same-origin download link</a></p>
-      <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
-      <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
+      <svg id="svg-element-with-same-origin-link-inside" width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
+      <svg id="svg-element-with-cross-origin-link-inside" width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
       <p><a id="same-origin-replace-post-link" href="/__turbo/redirect" data-turbo-method="post" data-turbo-action="replace">Same-origin data-turbo-action=replace link with post method</a></p>
       <p><a id="link-to-disabled-frame" href="/src/tests/fixtures/frames/hello.html" data-turbo-frame="hello">Disabled turbo-frame</a></p>
       <p><a id="autofocus-link" href="/src/tests/fixtures/autofocus.html">autofocus.html link</a></p>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -55,6 +55,10 @@
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
         <input type="submit" id="targeted-form-post-submit" value="Submit with [target=_blank]"/>
       </form>
+      <form id="self-targeted-form-post" method="post" action="/__turbo/redirect" target="_self">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="submit" id="self-targeted-form-post-submit" value="Submit with [target=_self]"/>
+      </form>
       <p><a id="same-origin-false-link" href="/src/tests/fixtures/one.html" data-turbo="false">Same-origin data-turbo=false link</a></p>
       <p data-turbo="false"><a id="same-origin-unannotated-link-inside-false-container" href="/src/tests/fixtures/one.html">Same-origin unannotated link inside data-turbo=false container</a></p>
       <p data-turbo="false"><a id="same-origin-true-link-inside-false-container" href="/src/tests/fixtures/one.html" data-turbo="true">Same-origin data-turbo=true link inside data-turbo=false container</a></p>
@@ -62,6 +66,7 @@
       <p><a id="same-origin-anchored-link-named" href="/src/tests/fixtures/one.html#named-anchor">Same-origin link to named anchor</a></p>
       <p><a id="cross-origin-unannotated-link" href="about:blank">Cross-origin unannotated link</a></p>
       <p><a id="same-origin-targeted-link" href="/src/tests/fixtures/one.html" target="_blank">Same-origin targeted link</a></p>
+      <p><a id="same-origin-self-targeted-link" href="/src/tests/fixtures/one.html" target="_self">Same-origin link with [target=_self]</a></p>
       <p><a id="same-origin-download-link" href="/intentionally_missing_fake_download.html" download="x.html">Same-origin download link</a></p>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -51,6 +51,10 @@
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
         <input type="submit" id="form-post-submit" value="Submit"/>
       </form>
+      <form id="targeted-form-post" method="post" action="/__turbo/redirect" target="_blank">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="submit" id="targeted-form-post-submit" value="Submit with [target=_blank]"/>
+      </form>
       <p><a id="same-origin-false-link" href="/src/tests/fixtures/one.html" data-turbo="false">Same-origin data-turbo=false link</a></p>
       <p data-turbo="false"><a id="same-origin-unannotated-link-inside-false-container" href="/src/tests/fixtures/one.html">Same-origin unannotated link inside data-turbo=false container</a></p>
       <p data-turbo="false"><a id="same-origin-true-link-inside-false-container" href="/src/tests/fixtures/one.html" data-turbo="true">Same-origin data-turbo=true link inside data-turbo=false container</a></p>

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -151,6 +151,14 @@ test("test following a POST form clears cache", async ({ page }) => {
   assert.notOk(await hasSelector(page, "some-cached-element"))
 })
 
+test("test following a same-origin POST form with [target=_self]", async ({ page }) => {
+  await page.click("#self-targeted-form-post-submit")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+})
+
 test("test following a same-origin POST form with [target=_blank]", async ({ page }) => {
   const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#targeted-form-post-submit")])
 
@@ -217,6 +225,13 @@ test("test following a same-origin [target] link", async ({ page }) => {
 
   assert.equal(pathname(popup.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(popup), "load")
+})
+
+test("test following a same-origin [target=_self] link", async ({ page }) => {
+  page.click("#same-origin-self-targeted-link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
 })
 
 test("test following a same-origin [download] link", async ({ page }) => {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -12,6 +12,7 @@ import {
   noNextEventNamed,
   pathname,
   readEventLogs,
+  scrollToSelector,
   search,
   selectorHasFocus,
   visitAction,
@@ -246,6 +247,7 @@ test("test following a same-origin [download] link", async ({ page }) => {
 })
 
 test("test following a same-origin link inside an SVG element", async ({ page }) => {
+  await scrollToSelector(page, "#svg-element-with-same-origin-link-inside + *")
   await page.click("#same-origin-link-inside-svg-element", { force: true })
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
@@ -253,6 +255,7 @@ test("test following a same-origin link inside an SVG element", async ({ page })
 })
 
 test("test following a cross-origin link inside an SVG element", async ({ page }) => {
+  await scrollToSelector(page, "#svg-element-with-cross-origin-link-inside + *")
   await page.click("#cross-origin-link-inside-svg-element", { force: true })
   await nextBody(page)
   assert.equal(page.url(), "about:blank")

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -151,6 +151,13 @@ test("test following a POST form clears cache", async ({ page }) => {
   assert.notOk(await hasSelector(page, "some-cached-element"))
 })
 
+test("test following a same-origin POST form with [target=_blank]", async ({ page }) => {
+  const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#targeted-form-post-submit")])
+
+  assert.equal(pathname(popup.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(popup), "load")
+})
+
 test("test following a same-origin POST link with data-turbo-action=replace", async ({ page }) => {
   page.click("#same-origin-replace-post-link")
   await nextBody(page)


### PR DESCRIPTION
Resolves #754 

Avoid bubbling `<form>` element submissions when they target a new window/tab. This occurs when:

* a `<form>` declares a [target](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/form#attr-target) of `_blank`
* a `<form>` element's submitting `<button>` element declares a [formtarget](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button#attr-formtarget) of `_blank`
* a `<form>` element's submitting `<input type="submit">` element declares a [formtarget](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/submit#formtarget) of `_blank`

Based on #389