### PR TITLE
Let developers associate lifecycle events

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -8,7 +8,7 @@ import { Visit, VisitDelegate, VisitOptions } from "./visit"
 import { PageSnapshot } from "./page_snapshot"
 
 export type NavigatorDelegate = VisitDelegate & {
-  allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
+  allowsVisitingLocation(location: URL, options: Partial<VisitOptions>): boolean
   visitProposedToLocation(location: URL, options: Partial<VisitOptions>): void
   notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
 }
@@ -24,7 +24,7 @@ export class Navigator {
   }
 
   proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
-    if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
+    if (this.delegate.allowsVisitingLocation(location, options)) {
       if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
         this.delegate.visitProposedToLocation(location, options)
       } else {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -322,6 +322,7 @@ export class Visit implements FetchRequestDelegate {
       this.adapter.visitProposedToLocation(this.redirectedToLocation, {
         action: "replace",
         response: this.response,
+        lifecycleIdentifier: this.lifecycleIdentifier,
       })
       this.followedRedirect = true
     }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -52,6 +52,7 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
+  lifecycleIdentifier: string
 }
 
 const defaultOptions: VisitOptions = {
@@ -62,6 +63,7 @@ const defaultOptions: VisitOptions = {
   updateHistory: true,
   shouldCacheSnapshot: true,
   acceptsStreamResponse: false,
+  lifecycleIdentifier: uuid(),
 }
 
 export type VisitResponse = {
@@ -102,6 +104,7 @@ export class Visit implements FetchRequestDelegate {
   snapshotCached = false
   state = VisitState.initialized
   snapshot?: PageSnapshot
+  lifecycleIdentifier: string
 
   constructor(
     delegate: VisitDelegate,
@@ -125,6 +128,7 @@ export class Visit implements FetchRequestDelegate {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
+      lifecycleIdentifier,
     } = {
       ...defaultOptions,
       ...options,
@@ -142,6 +146,7 @@ export class Visit implements FetchRequestDelegate {
     this.scrolled = !willRender
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
+    this.lifecycleIdentifier = lifecycleIdentifier
   }
 
   get adapter() {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -18,3 +18,8 @@ export type StreamSource = {
     options?: boolean | EventListenerOptions
   ): void
 }
+
+export type InitiationOptions = {
+  event: MouseEvent
+  lifecycleIdentifier: string
+}

--- a/src/observers/form_link_click_observer.ts
+++ b/src/observers/form_link_click_observer.ts
@@ -1,7 +1,8 @@
+import { InitiationOptions } from "../core/types"
 import { LinkClickObserver, LinkClickObserverDelegate } from "./link_click_observer"
 
 export type FormLinkClickObserverDelegate = {
-  willSubmitFormLinkToLocation(link: Element, location: URL, event: MouseEvent): boolean
+  willSubmitFormLinkToLocation(link: Element, location: URL, options: InitiationOptions): boolean
   submittedFormLinkToLocation(link: Element, location: URL, form: HTMLFormElement): void
 }
 
@@ -22,11 +23,8 @@ export class FormLinkClickObserver implements LinkClickObserverDelegate {
     this.linkInterceptor.stop()
   }
 
-  willFollowLinkToLocation(link: Element, location: URL, originalEvent: MouseEvent): boolean {
-    return (
-      this.delegate.willSubmitFormLinkToLocation(link, location, originalEvent) &&
-      link.hasAttribute("data-turbo-method")
-    )
+  willFollowLinkToLocation(link: Element, location: URL, options: InitiationOptions): boolean {
+    return this.delegate.willSubmitFormLinkToLocation(link, location, options) && link.hasAttribute("data-turbo-method")
   }
 
   followedLinkToLocation(link: Element, location: URL): void {

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -1,8 +1,10 @@
+import { InitiationOptions } from "../core/types"
 import { expandURL } from "../core/url"
+import { uuid } from "../util"
 
 export interface LinkClickObserverDelegate {
-  willFollowLinkToLocation(link: Element, location: URL, event: MouseEvent): boolean
-  followedLinkToLocation(link: Element, location: URL): void
+  willFollowLinkToLocation(link: Element, location: URL, options: InitiationOptions): boolean
+  followedLinkToLocation(link: Element, location: URL, options: InitiationOptions): void
 }
 
 export class LinkClickObserver {
@@ -40,9 +42,10 @@ export class LinkClickObserver {
       const link = this.findLinkFromClickTarget(target)
       if (link && doesNotTargetIFrame(link)) {
         const location = this.getLocationForLink(link)
-        if (this.delegate.willFollowLinkToLocation(link, location, event)) {
+        const options = { lifecycleIdentifier: uuid(), event }
+        if (this.delegate.willFollowLinkToLocation(link, location, options)) {
           event.preventDefault()
-          this.delegate.followedLinkToLocation(link, location)
+          this.delegate.followedLinkToLocation(link, location, options)
         }
       }
     }

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -406,3 +406,14 @@ test("test lifecycleIdentifier is present in event details", async ({ page }) =>
     )
   }
 })
+
+test("test redirection visits have the same lifecycleIdentifier", async ({ page }) => {
+  await page.click("#redirection-link")
+  const { lifecycleIdentifier } = await nextEventNamed(page, "turbo:visit")
+
+  assert.equal(
+    (await nextEventNamed(page, "turbo:visit")).lifecycleIdentifier,
+    lifecycleIdentifier,
+    "lifecycleIdentifier for redirection visit matches initial lifecycleIdentifier"
+  )
+})

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -389,3 +389,20 @@ test("test ignores links that target an iframe", async ({ page }) => {
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
 })
+
+test("test lifecycleIdentifier is present in event details", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link")
+  const { lifecycleIdentifier } = await nextEventNamed(page, "turbo:click")
+  assert.ok(lifecycleIdentifier, "lifecycleIdentifier present in turbo:click events")
+
+  const events = ["turbo:before-visit", "turbo:visit", "turbo:before-render", "turbo:render", "turbo:load"]
+
+  for (let i = 0; i < events.length; i++) {
+    const eventName = events[i]
+    assert.equal(
+      (await nextEventNamed(page, eventName)).lifecycleIdentifier,
+      lifecycleIdentifier,
+      `correct lifecycleIdentifier present in ${eventName}`
+    )
+  }
+})


### PR DESCRIPTION
Currently there is no way to know which events are tied to a given user action. For example, it's not possible to associate a `turbo:click` with a `turbo:visit`. One might link a `turbo:click` with the next `turbo:visit`, but this isn't accurate because a navigation can be ended by cancelling `turbo:click` or `turbo:before-visit` (as mentioned by @pfeiffer in https://github.com/hotwired/turbo/issues/99#issuecomment-757535307).

With a lifecycle ID present in each event, it'll be possible to reference the initiator element, providing a way for developers to customise visit behaviour based on HTML attributes. For example:

```js
let initiator = []
addEventListener('turbo:click', ({ detail }) =>
  initiator = [detail.lifecycleIdentifier, detail.originalEvent.target]
)
addEventListener('turbo:visit', ({ detail }) => {
  const [id, element] = initiator
  if (detail.lifecycleIdentifier === id && element.dataset.animate) {
    // do something
  }
}) 
```

It could also be used to determine redirect visits, as `turbo:visit` is dispatched twice:

```js
let lifecycleIdentifier
addEventListener('turbo:visit', ({ detail }) =>
  const isRedirect = detail.lifecycleIdentifier === lifecycleIdentifier
  lifecycleIdentifier = detail.lifecycleIdentifier
)
```

This is a lower-level alternative to https://github.com/hotwired/turbo/pull/750, and whilst I still think that the type annotations in that PR are worthwhile, this might provide some useful information for other cases without having to manipulate `VisitOptions` too much.

If we think this approach is worth pursuing, I can finish it up by adding identifiers to the remaining events.

