### PR TITLE
Redirect to Location with a URL hash

### DIFF
--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -25,6 +25,11 @@
         <input type="hidden" name="greeting" value="Hello from a redirect">
         <input id="standard-get-form-submit" type="submit" value="form[method=get]">
       </form>
+      <form action="/__turbo/redirect" method="get" class="redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="hidden" name="hash" value="element-id">
+        <button id="standard-get-form-submit-redirect-with-hash">Redirect with hash</button>
+      </form>
       <form action="/__turbo/redirect" method="get" data-turbo-stream class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
         <input type="hidden" name="greeting" value="Hello from a redirect">

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -35,6 +35,7 @@
       <h1>Navigation</h1>
       <p><a id="same-origin-unannotated-link" href="/src/tests/fixtures/one.html">Same-origin unannotated link</a></p>
       <p><a id="same-origin-unannotated-link-search-params" href="/src/tests/fixtures/one.html?key=value">Same-origin unannotated link ?key=value</a></p>
+      <p><a id="same-origin-unannotated-link-redirect-with-hash" href="/__turbo/redirect?path=/src/tests/fixtures/one.html&hash=element-id">Same-origin unannotated link redirect to one.html#element-id</a></p>
       <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button>Same-origin unannotated form</button></form></p>
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>
       <p><form id="same-origin-replace-form-get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -3,8 +3,10 @@ import { assert } from "chai"
 import {
   getFromLocalStorage,
   getSearchParam,
+  hash,
   hasSelector,
   isScrolledToTop,
+  isScrolledToSelector,
   nextAttributeMutationNamed,
   nextBeat,
   nextBody,
@@ -183,6 +185,15 @@ test("test standard GET form submission", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a form")
+})
+
+test("test standard GET form submission redirect with hash", async ({ page }) => {
+  await page.click("#standard-get-form-submit-redirect-with-hash")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(hash(page.url()), "#element-id")
+  assert.equal(await visitAction(page), "advance")
+  assert(await isScrolledToSelector(page, "#element-id"))
 })
 
 test("test standard GET HTMLFormElement.requestSubmit() with Turbo Action", async ({ page }) => {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -189,6 +189,16 @@ test("test following a same-origin anchored link", async ({ page }) => {
   assert(await isScrolledToSelector(page, "#element-id"))
 })
 
+test("test following a same-origin redirect link", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link-redirect-with-hash")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(hash(page.url()), "#element-id")
+  assert.equal(await visitAction(page), "advance")
+  assert(await isScrolledToSelector(page, "#element-id"))
+})
+
 test("test following a same-origin link to a named anchor", async ({ page }) => {
   await page.click("#same-origin-anchored-link-named")
   await nextBody(page)

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -34,13 +34,13 @@ router.post("/redirect", (request, response) => {
 })
 
 router.get("/redirect", (request, response) => {
-  const { path, ...query } = request.query as any
+  const { hash, path, ...query } = request.query as any
   const pathname = path ?? "/src/tests/fixtures/one.html"
   const enctype = request.get("Content-Type")
   if (enctype) {
     query.enctype = enctype
   }
-  response.redirect(301, url.format({ pathname, query }))
+  response.redirect(301, url.format({ hash, pathname, query }))
 })
 
 router.post("/reject/tall", (request, response) => {


### PR DESCRIPTION
This pull request adds test coverage to demonstrate a limitation in Turbo's support for redirecting to a URL with a [hash][] value.

Currently, redirecting to a URL with a hash (for example, `/src/tests/fixtures/one.html#element-id`) omits the hash (`#element-id`) when navigating to the final destination.

According to the [fetch specification][], redirects should preserve URL fragments during redirection.

[hash]: https://developer.mozilla.org/en-US/docs/Web/API/URL/hash
[fetch specification]: https://fetch.spec.whatwg.org/#http-redirect-fetch