### PR TITLE
Use `devEngines` to relax the minimum required `node` version in external projects

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "release": "npm publish && git commit -am \"$npm_package_name v$npm_package_version\" && git push",
     "lint": "eslint . --ext .ts"
   },
-  "engines": {
+  "devEngines": {
     "node": ">= 14"
   }
 }


### PR DESCRIPTION
This PR moves the minimum required `node` version under a `devEngines` section at the `package.json`.

The introduction of the [playwright][] test suite forced the minimum required `node` version to v14. As a side effect, using the `engines` section of the `package.json` to set this dependency, introduces an unreasonable constraint to use the `turbo` library in other projects. Considering that `playwright` is a development only dependency, it seems justified to keep it under a `devEngines` section of the `package.json`.

[playwright]: https://github.com/hotwired/turbo/pull/609