### PR TITLE
Check last rendered location for same-page visits

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -17,7 +17,6 @@ export class Navigator {
   readonly delegate: NavigatorDelegate
   formSubmission?: FormSubmission
   currentVisit?: Visit
-  lastVisit?: Visit
 
   constructor(delegate: NavigatorDelegate) {
     this.delegate = delegate
@@ -34,7 +33,6 @@ export class Navigator {
   }
 
   startVisit(locatable: Locatable, restorationIdentifier: string, options: Partial<VisitOptions> = {}) {
-    this.lastVisit = this.currentVisit
     this.stop()
     this.currentVisit = new Visit(this, expandURL(locatable), restorationIdentifier, {
       referrer: this.location,
@@ -142,13 +140,12 @@ export class Navigator {
 
   locationWithActionIsSamePage(location: URL, action?: Action): boolean {
     const anchor = getAnchor(location)
-    const lastLocation = this.lastVisit?.location || this.view.lastRenderedLocation
-    const currentAnchor = getAnchor(lastLocation)
+    const currentAnchor = getAnchor(this.view.lastRenderedLocation)
     const isRestorationToTop = action === "restore" && typeof anchor === "undefined"
 
     return (
       action !== "replace" &&
-      getRequestURL(location) === getRequestURL(lastLocation) &&
+      getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
       (isRestorationToTop || (anchor != null && anchor !== currentAnchor))
     )
   }


### PR DESCRIPTION
In [#595][] the logic for determining whether a visit is a "same page" visit was changed. Previously we were comparing the new location with the current location. In #595 we began comparing with the location of the last visit that was started.

This works great when all the visits are web visits. However, it introduced some problems with apps using the native adapters. In native apps, navigations can be a combination of native screens and WebView navigations, which means that we can't rely on the last visit having been sent.

This manifests as failing navigations in certain situations, such as navigating back from a native modal to a WebView. It also caused some problems restoring scroll positions when navigating back from one WebView to another.

Restoring the original logic prevents these problems.

[#595]: https://github.com/hotwired/turbo/pull/595

This reverts commit 2e344b35d983fca636e064bc5ee1801c16908a04.