### PR TITLE
Fix double fetch requests (render) for eager-loaded frames

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -258,7 +258,8 @@ export class Visit implements FetchRequestDelegate {
         if (this.shouldCacheSnapshot) this.cacheSnapshot()
         if (this.view.renderPromise) await this.view.renderPromise
         if (isSuccessful(statusCode) && responseHTML != null) {
-          await this.view.renderPage(PageSnapshot.fromHTMLString(responseHTML), false, this.willRender, this)
+          let willRender = this.hasReplaceAction() ? false : this.willRender
+          await this.view.renderPage(PageSnapshot.fromHTMLString(responseHTML), false, willRender, this)
           this.performScroll()
           this.adapter.visitRendered(this)
           this.complete()
@@ -313,13 +314,17 @@ export class Visit implements FetchRequestDelegate {
   }
 
   followRedirect() {
-    if (this.redirectedToLocation && !this.followedRedirect && this.response?.redirected) {
-      this.adapter.visitProposedToLocation(this.redirectedToLocation, {
+    if (this.hasReplaceAction()) {
+      this.adapter.visitProposedToLocation(this.redirectedToLocation!, {
         action: "replace",
         response: this.response,
       })
       this.followedRedirect = true
     }
+  }
+
+  hasReplaceAction() {
+    return this.redirectedToLocation && !this.followedRedirect && this.response?.redirected
   }
 
   goToSamePageAnchor() {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -258,7 +258,7 @@ export class Visit implements FetchRequestDelegate {
         if (this.shouldCacheSnapshot) this.cacheSnapshot()
         if (this.view.renderPromise) await this.view.renderPromise
         if (isSuccessful(statusCode) && responseHTML != null) {
-          let willRender = this.hasReplaceAction() ? false : this.willRender
+          const willRender = this.hasReplaceAction() ? false : this.willRender
           await this.view.renderPage(PageSnapshot.fromHTMLString(responseHTML), false, willRender, this)
           this.performScroll()
           this.adapter.visitRendered(this)


### PR DESCRIPTION
Closes #515 after 256418fee0178ee483d82cd9bb579bd5df5a151f with resolves the broken assertion issues in frame_test.ts (fixed by @seanpdoyle).

This decision use 'willRender' option false for the first action ("advance") when the second action ("replace") is created to prevent double rendering frames because when it is rendered two times and read 'src' attributes two times, it makes two fetch request for this frames.

I did not find a solution with 'turbo-frame[complite]' attribute because it still has a value 'false' before the second fetch request.

The previous decision (#516) used 'willRender' option false for the second act, and it has the bug, that was resolved in #674

After this MR next failed tests will be a success:
```
    [chrome] › frame_tests.ts:830:1 › test navigating a eager frame with a link[method=get] that does not fetch eager frame twice
    [firefox] › frame_tests.ts:830:1 › test navigating a eager frame with a link[method=get] that does not fetch eager frame twice
```
This issue can be reproduced on test fixtures page (http://localhost:9000/src/tests/fixtures/frames.html), after clicking the link ["Eager-loaded frame after GET redirect"](http://localhost:9000/__turbo/redirect?path=/src/tests/fixtures/page_with_eager_frame.html):

Before:
![image](https://user-images.githubusercontent.com/9513452/198100454-042a83bf-7a54-4e0b-b87b-bc6a5fc01c23.png)

After:
![image](https://user-images.githubusercontent.com/9513452/198100934-a667d649-b03c-4687-9f83-3da3b72c28c8.png)