### PR TITLE
Allow users to define an async custom render function

### DIFF
--- a/src/core/bardo.ts
+++ b/src/core/bardo.ts
@@ -9,14 +9,14 @@ export class Bardo {
   readonly permanentElementMap: PermanentElementMap
   readonly delegate: BardoDelegate
 
-  static preservingPermanentElements(
+  static async preservingPermanentElements(
     delegate: BardoDelegate,
     permanentElementMap: PermanentElementMap,
     callback: () => void
   ) {
     const bardo = new this(delegate, permanentElementMap)
     bardo.enter()
-    callback()
+    await callback()
     bardo.leave()
   }
 

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -36,7 +36,7 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
 
   async render() {
     if (this.willRender) {
-      this.replaceBody()
+      await this.replaceBody()
     }
   }
 
@@ -67,10 +67,10 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
     await newStylesheetElements
   }
 
-  replaceBody() {
-    this.preservingPermanentElements(() => {
+  async replaceBody() {
+    await this.preservingPermanentElements(async () => {
       this.activateNewBody()
-      this.assignNewBody()
+      await this.assignNewBody()
     })
   }
 
@@ -120,8 +120,8 @@ export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
     }
   }
 
-  assignNewBody() {
-    this.renderElement(this.currentElement, this.newElement)
+  async assignNewBody() {
+    await this.renderElement(this.currentElement, this.newElement)
   }
 
   get newHeadStylesheetElements() {

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -49,8 +49,8 @@ export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapsh
     }
   }
 
-  preservingPermanentElements(callback: () => void) {
-    Bardo.preservingPermanentElements(this, this.permanentElementMap, callback)
+  async preservingPermanentElements(callback: () => void) {
+    await Bardo.preservingPermanentElements(this, this.permanentElementMap, callback)
   }
 
   focusFirstAutofocusableElement() {


### PR DESCRIPTION
Since https://github.com/hotwired/turbo/pull/431, turbo allows users to customize the render function they want to use, but when an user defines an async function that requires some kind of wait, turbo's timing gets messed up and it fires events before the render actually happened.

With these changes, Turbo will correctly handle async render functions, properly waiting for it to finish before continuing the lifecycle.