### PR TITLE
Add cancelable turbo:frame-click event

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -29,7 +29,7 @@ import { FrameRenderer } from "./frame_renderer"
 import { session } from "../index"
 import { isAction, Action } from "../types"
 import { VisitOptions } from "../drive/visit"
-import { TurboBeforeFrameRenderEvent } from "../session"
+import { TurboBeforeFrameRenderEvent, TurboFrameClickEvent } from "../session"
 import { StreamMessage } from "../streams/stream_message"
 import { PageSnapshot } from "../drive/page_snapshot"
 
@@ -215,8 +215,10 @@ export class FrameController
 
   // Link interceptor delegate
 
-  shouldInterceptLinkClick(element: Element, _location: string, _event: MouseEvent) {
-    return this.shouldInterceptNavigation(element)
+  shouldInterceptLinkClick(element: Element, location: string, event: MouseEvent) {
+    return (
+      this.shouldInterceptNavigation(element) && this.frameAllowsVisitingLocation(element, expandURL(location), event)
+    )
   }
 
   linkClickIntercepted(element: Element, location: string) {
@@ -555,6 +557,16 @@ export class FrameController
     const meta = this.element.ownerDocument.querySelector<HTMLMetaElement>(`meta[name="turbo-root"]`)
     const root = meta?.content ?? "/"
     return expandURL(root)
+  }
+
+  private frameAllowsVisitingLocation(target: Element, { href: url }: URL, originalEvent: MouseEvent): boolean {
+    const event = dispatch<TurboFrameClickEvent>("turbo:frame-click", {
+      target,
+      detail: { url, originalEvent },
+      cancelable: true,
+    })
+
+    return !event.defaultPrevented
   }
 
   private isIgnoringChangesTo(attributeName: FrameElementObservedAttribute): boolean {

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -19,6 +19,7 @@ export {
   TurboBeforeRenderEvent,
   TurboBeforeVisitEvent,
   TurboClickEvent,
+  TurboFrameClickEvent,
   TurboBeforeFrameRenderEvent,
   TurboFrameLoadEvent,
   TurboFrameRenderEvent,

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -29,6 +29,7 @@ export type TurboBeforeCacheEvent = CustomEvent
 export type TurboBeforeRenderEvent = CustomEvent<{ newBody: HTMLBodyElement } & PageViewRenderOptions>
 export type TurboBeforeVisitEvent = CustomEvent<{ url: string }>
 export type TurboClickEvent = CustomEvent<{ url: string; originalEvent: MouseEvent }>
+export type TurboFrameClickEvent = CustomEvent<{ url: string; originalEvent: MouseEvent }>
 export type TurboFrameLoadEvent = CustomEvent
 export type TurboBeforeFrameRenderEvent = CustomEvent<{ newFrame: FrameElement } & FrameViewRenderOptions>
 export type TurboFrameRenderEvent = CustomEvent<{ fetchResponse: FetchResponse }>

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="html" data-skip-event-details="turbo:click turbo:before-render">
+<html id="html" data-skip-event-details="turbo:click turbo:frame-click turbo:before-render">
   <head>
     <meta charset="utf-8">
     <title>Frame</title>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -1,4 +1,4 @@
-(function(eventNames) {
+;(function (eventNames) {
   function serializeToChannel(object, visited = new Set()) {
     const returned = {}
 
@@ -10,7 +10,7 @@
       } else if (value instanceof Element) {
         returned[key] = value.outerHTML
       } else if (typeof value == "object") {
-        if (visited.has(value))  {
+        if (visited.has(value)) {
           returned[key] = "skipped to prevent infinitely recursing"
         } else {
           visited.add(value)
@@ -39,15 +39,16 @@
   }
   window.mutationLogs = []
 
-   new MutationObserver((mutations) => {
-     for (const { attributeName, target } of mutations.filter(({ type }) => type == "attributes")) {
-       if (target instanceof Element) {
-         mutationLogs.push([attributeName, target.id, target.getAttribute(attributeName)])
-       }
-     }
-   }).observe(document, { subtree: true, childList: true, attributes: true })
+  new MutationObserver((mutations) => {
+    for (const { attributeName, target } of mutations.filter(({ type }) => type == "attributes")) {
+      if (target instanceof Element) {
+        mutationLogs.push([attributeName, target.id, target.getAttribute(attributeName)])
+      }
+    }
+  }).observe(document, { subtree: true, childList: true, attributes: true })
 })([
   "turbo:click",
+  "turbo:frame-click",
   "turbo:before-stream-render",
   "turbo:before-cache",
   "turbo:before-render",
@@ -64,5 +65,5 @@
   "turbo:frame-load",
   "turbo:frame-render",
   "turbo:frame-missing",
-  "turbo:reload"
+  "turbo:reload",
 ])

--- a/src/tests/helpers/page.ts
+++ b/src/tests/helpers/page.ts
@@ -14,7 +14,7 @@ export function attributeForSelector(page: Page, selector: string, attributeName
   return page.locator(selector).getAttribute(attributeName)
 }
 
-type CancellableEvent = "turbo:click" | "turbo:before-visit"
+type CancellableEvent = "turbo:click" | "turbo:before-visit" | "turbo:frame-click"
 
 export function cancelNextEvent(page: Page, eventName: CancellableEvent): Promise<void> {
   return page.evaluate(


### PR DESCRIPTION
Similar to `turbo:click`, `turbo:frame-click` indicates when a frame link was clicked. The event can be canceled to let the browser fallback to the default click.