### PR TITLE
Customize isHTML url pattern not only "htm|html|xhtml|php"

### DIFF
--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,3 +1,5 @@
+import { getMetaContent } from "../util";
+
 export type Locatable = URL | string
 
 export function expandURL(locatable: Locatable) {
@@ -25,7 +27,8 @@ export function getExtension(url: URL) {
 }
 
 export function isHTML(url: URL) {
-  return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml|php))$/)
+  const pattern = new RegExp(getMetaContent('turbo-html-url-pattern') || '^(?:|\.(?:htm|html|xhtml|php))$')
+  return !!getExtension(url).match(pattern)
 }
 
 export function isPrefixedBy(baseURL: URL, url: URL) {


### PR DESCRIPTION
I think this pattern can not only assume `.htm`, `.html`, `.xhtml`, `.php` is a HTML page, but also `.jsp`, `.asp`, `.whatever` ...

```javascript
export function isHTML(url: URL) {
  return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml|php))$/)
}
```

I found this issue when I'm integrating monaco-editor to edit source code online, url looks like `http://tanmer.lvh.me:3000/themes/-/ide/theme/1/edit/version/1/-/assets/cart-drawer.js` , this URL is not a javascript, it's a HTML page to edit cart-drawer.js

With this PR, I can customize my own pattern to identify HTML page:

```html
  <head>
    <meta name="turbo-html-url-pattern" content="\/-\/ide\/theme\/\d+\/edit\/version/\d+\/-\/"/>
  <./head>
```