### PR TITLE
Fix issue #604

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -354,7 +354,7 @@ export class FrameController
   private async visit(url: URL) {
     const request = new FetchRequest(this, FetchMethod.get, url, new URLSearchParams(), this.element)
 
-    this.currentFetchRequest?.cancel()
+    this.cancelInFlightNavigation()
     this.currentFetchRequest = request
 
     return new Promise<void>((resolve) => {
@@ -367,8 +367,32 @@ export class FrameController
     })
   }
 
+  private cancelInFlightNavigation(frame?: FrameElement) {
+    if (!this.currentFetchRequest) return
+
+    this.currentFetchRequest.cancel()
+    this.currentFetchRequest = null
+
+    if (!frame) return
+
+    // Restore the frame attributes to their previous state, ensuring that the canceled
+    // request won't be cached.
+    this.ignoringChangesToAttribute("src", () => {
+      frame.src = frame.previousSrc
+      clearBusyState(frame)
+    })
+
+    if (frame.previousSrc) {
+      this.ignoringChangesToAttribute("complete", () => {
+        frame.setAttribute("complete", "")
+      })
+    }
+  }
+
   private navigateFrame(element: Element, url: string, submitter?: HTMLElement) {
     const frame = this.findFrameElement(element, submitter)
+
+    this.cancelInFlightNavigation(frame)
     this.pageSnapshot = PageSnapshot.fromElement(frame).clone()
 
     frame.delegate.proposeVisitIfNavigatedWithAction(frame, element, submitter)
@@ -543,6 +567,7 @@ export class FrameController
     this.ignoringChangesToAttribute("complete", () => {
       if (value) {
         this.element.setAttribute("complete", "")
+        this.element.previousSrc = this.element.src
       } else {
         this.element.removeAttribute("complete")
       }

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -46,6 +46,7 @@ export class FrameElement extends HTMLElement {
 
   loaded: Promise<void> = Promise.resolve()
   readonly delegate: FrameElementDelegate
+  previousSrc: string | null = null
 
   static get observedAttributes(): FrameElementObservedAttribute[] {
     return ["disabled", "complete", "loading", "src"]


### PR DESCRIPTION
Closes https://github.com/hotwired/turbo/issues/604

When quickly clicking between frames, even though the fetch request is canceled, the page's HTML is mutated, setting a new `src` to the frame element. This change will cause the `pageSnapshot` to be incorrect, so when we navigate back, the `turbo-frame` will have an incorrect `src` causing a new fetch and the bug shown in the issue.

This PR updates frames to know what was their `previousSrc` so they can revert back in case the request is canceled.