### PR TITLE
Simplify `FetchRequestDelegate.prepareHeadersForRequest`

### DIFF
--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -1,4 +1,4 @@
-import { FetchRequest, FetchMethod, fetchMethodFromString, FetchRequestHeaders } from "../../http/fetch_request"
+import { FetchRequest, FetchMethod, fetchMethodFromString } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { expandURL } from "../url"
 import { dispatch, getAttribute, getMetaContent, hasAttribute } from "../../util"
@@ -149,11 +149,11 @@ export class FormSubmission {
 
   // Fetch request delegate
 
-  prepareHeadersForRequest(headers: FetchRequestHeaders, request: FetchRequest) {
+  prepareRequest(request: FetchRequest) {
     if (!request.isIdempotent) {
       const token = getCookieValue(getMetaContent("csrf-param")) || getMetaContent("csrf-token")
       if (token) {
-        headers["X-CSRF-Token"] = token
+        request.headers["X-CSRF-Token"] = token
       }
     }
 

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -1,5 +1,5 @@
 import { Adapter } from "../native/adapter"
-import { FetchMethod, FetchRequest, FetchRequestDelegate, FetchRequestHeaders } from "../../http/fetch_request"
+import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { History } from "./history"
 import { getAnchor } from "../url"
@@ -335,7 +335,7 @@ export class Visit implements FetchRequestDelegate {
 
   // Fetch request delegate
 
-  prepareHeadersForRequest(headers: FetchRequestHeaders, request: FetchRequest) {
+  prepareRequest(request: FetchRequest) {
     if (this.acceptsStreamResponse) {
       request.acceptResponseType(StreamMessage.contentType)
     }

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -4,7 +4,7 @@ import {
   FrameLoadingStyle,
   FrameElementObservedAttribute,
 } from "../../elements/frame_element"
-import { FetchMethod, FetchRequest, FetchRequestDelegate, FetchRequestHeaders } from "../../http/fetch_request"
+import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/appearance_observer"
 import {
@@ -238,14 +238,14 @@ export class FrameController
 
     this.formSubmission = new FormSubmission(this, element, submitter)
     const { fetchRequest } = this.formSubmission
-    this.prepareHeadersForRequest(fetchRequest.headers, fetchRequest)
+    this.prepareRequest(fetchRequest)
     this.formSubmission.start()
   }
 
   // Fetch request delegate
 
-  prepareHeadersForRequest(headers: FetchRequestHeaders, request: FetchRequest) {
-    headers["Turbo-Frame"] = this.id
+  prepareRequest(request: FetchRequest) {
+    request.headers["Turbo-Frame"] = this.id
 
     if (this.currentNavigationElement?.hasAttribute("data-turbo-stream")) {
       request.acceptResponseType(StreamMessage.contentType)

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -18,7 +18,7 @@ export type TurboFetchRequestErrorEvent = CustomEvent<{
 export interface FetchRequestDelegate {
   referrer?: URL
 
-  prepareHeadersForRequest?(headers: FetchRequestHeaders, request: FetchRequest): void
+  prepareRequest(request: FetchRequest): void
   requestStarted(request: FetchRequest): void
   requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse): void
   requestSucceededWithResponse(request: FetchRequest, response: FetchResponse): void
@@ -103,7 +103,7 @@ export class FetchRequest {
 
   async perform(): Promise<FetchResponse | void> {
     const { fetchOptions } = this
-    this.delegate.prepareHeadersForRequest?.(this.headers, this)
+    this.delegate.prepareRequest(this)
     await this.allowRequestToBeIntercepted(fetchOptions)
     try {
       this.delegate.requestStarted(this)


### PR DESCRIPTION
With the introduction of `FetchRequest.acceptResponseType()` in [hotwired/turbo#647][], the
`FetchRequestDelegate.prepareHeadersForRequest` callback interacts with more than just the `FetchRequestHeaders` instance passes as its first argument.

Additionally, every implementation of the `FetchRequestDelegate` interface implements the `prepareHeadersForRequest` method, so the fact that it's listed as optional and invoked with a guard clause are unnecessary.

This commit renames the method to `prepareRequest`, reduces the signature to a single `FetchRequest` argument, and no longer declares it as a conditional property on the interface.

[hotwired/turbo#647]: https://github.com/hotwired/turbo/pull/647/files#diff-d4ee4683f7121e24a87566ef6854ee6090ee723a5299430338f5602febea8c1f