### PR TITLE
Allow for listening to turbo events raised from within the Shadow DOM

### DIFF
--- a/src/tests/fixtures/frame_navigation.html
+++ b/src/tests/fixtures/frame_navigation.html
@@ -10,6 +10,10 @@
     <div id="container">
       <a id="outside" href="/src/tests/fixtures/frame_navigation.html" data-turbo-frame="frame">Outside Frame</a>
 
+      <custom-link-element id="outside-in-shadow-dom" link="/src/tests/fixtures/frame_navigation.html" data-turbo-frame="frame">
+        Outside Frame in Shadow DOM
+      </custom-link-element>
+
       <turbo-frame id="frame">
         <h2>Frame Navigation</h2>
 

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -6,22 +6,6 @@
     <title>Turbo</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
-    <script>
-      class CustomLinkElement extends HTMLElement {
-        constructor() {
-          super()
-          this.attachShadow({ mode: 'open' })
-        }
-        connectedCallback() {
-          this.shadowRoot.innerHTML = `
-            <a href="${this.getAttribute('link')}">
-              ${this.getAttribute('text')}
-            </a>
-          `
-        }
-      }
-      window.customElements.define('custom-link-element', CustomLinkElement)
-    </script>
     <meta name="referrer" content="origin-when-cross-origin">
   </head>
   <body>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -66,3 +66,17 @@
   "turbo:frame-missing",
   "turbo:reload"
 ])
+
+window.customElements.define('custom-link-element', class extends HTMLElement {
+  constructor() {
+    super()
+    this.attachShadow({ mode: 'open' })
+  }
+  connectedCallback() {
+    this.shadowRoot.innerHTML = `
+      <a href="${this.getAttribute('link')}">
+        ${this.getAttribute('text')}
+      </a>
+    `
+  }
+})

--- a/src/tests/functional/frame_navigation_tests.ts
+++ b/src/tests/functional/frame_navigation_tests.ts
@@ -23,6 +23,13 @@ test("test frame navigation with exterior link", async ({ page }) => {
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
+test("test frame navigation with exterior link in Shadow DOM", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
+  await page.click("#outside-in-shadow-dom")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+})
+
 test("test frame navigation emits fetch-request-error event when offline", async ({ page }) => {
   await page.goto("/src/tests/fixtures/tabs.html")
   await page.context().setOffline(true)

--- a/src/util.ts
+++ b/src/util.ts
@@ -41,6 +41,7 @@ export function dispatch<T extends CustomEvent>(
   const event = new CustomEvent<T["detail"]>(eventName, {
     cancelable,
     bubbles: true,
+    composed: true,
     detail,
   })
 


### PR DESCRIPTION
Fixes #801.

This issue seems to be caused by the fact that events fired from inside the Shadow DOM won't propagate across the shadow DOM boundary into the standard DOM.

Normally, the turbo frame listens to the `turbo:click` event in the `LinkInterceptor`:

https://github.com/hotwired/turbo/blob/27384ecf1a22afacccc96cf01864fc6a82fa8cc0/src/core/frames/link_interceptor.ts#L20

And a link click will fire a `turbo:click` event that is eventually handled by the turbo frame link interceptor:

https://github.com/hotwired/turbo/blob/27384ecf1a22afacccc96cf01864fc6a82fa8cc0/src/core/session.ts#L329-L333

However, when the target link is in the shadow DOM, like declared in this PR, the event wouldn't reach the turbo frame link interceptor.

This could be fixed by specifying `composed: true`, so the event will bubble up regardless of where the element is located.