### PR TITLE
Wrap `noNext`-prefixed test helpers in assertions

### DIFF
--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -854,8 +854,7 @@ test("test link method form submission submits a single request", async ({ page 
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  await noNextEventNamed(page, "turbo:before-fetch-request")
-
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
   assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 1, "submits a single HTTP request")
 })
@@ -868,8 +867,8 @@ test("test link method form submission inside frame submits a single request", a
   await nextBeat()
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
-  await noNextEventNamed(page, "turbo:before-fetch-request")
 
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
   assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 1, "submits a single HTTP request")
 })
@@ -882,8 +881,8 @@ test("test link method form submission targetting frame submits a single request
   await nextBeat()
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
-  await noNextEventNamed(page, "turbo:before-fetch-request")
 
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
   assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 2, "submits a single HTTP request then follows a redirect")
 })
@@ -1068,7 +1067,9 @@ test("test turbo:before-fetch-response fires on the form element", async ({ page
 
 test("test POST to external action ignored", async ({ page }) => {
   await page.click("#submit-external")
-  await noNextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+
   await nextBody(page)
 
   assert.equal(page.url(), "https://httpbin.org/post")
@@ -1076,7 +1077,9 @@ test("test POST to external action ignored", async ({ page }) => {
 
 test("test POST to external action within frame ignored", async ({ page }) => {
   await page.click("#submit-external-within-ignored")
-  await noNextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+
   await nextBody(page)
 
   assert.equal(page.url(), "https://httpbin.org/post")
@@ -1084,7 +1087,9 @@ test("test POST to external action within frame ignored", async ({ page }) => {
 
 test("test POST to external action targetting frame ignored", async ({ page }) => {
   await page.click("#submit-external-target-ignored")
-  await noNextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+
   await nextBody(page)
 
   assert.equal(page.url(), "https://httpbin.org/post")

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -145,7 +145,9 @@ test("test successfully following a link to a page without a matching frame disp
   await page.click("#missing-frame-link")
   await nextEventOnTarget(page, "missing", "turbo:before-fetch-request")
   const { response } = await nextEventOnTarget(page, "missing", "turbo:frame-missing")
-  await noNextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+
   await nextEventNamed(page, "turbo:load")
 
   assert.ok(response, "dispatches turbo:frame-missing with event.detail.response")
@@ -164,8 +166,10 @@ test("test failing to follow a link to a page without a matching frame dispatche
   await page.click("#missing-page-link")
   await nextEventOnTarget(page, "missing", "turbo:before-fetch-request")
   const { response } = await nextEventOnTarget(page, "missing", "turbo:frame-missing")
-  await noNextEventNamed(page, "turbo:before-fetch-request")
-  await noNextEventNamed(page, "turbo:load")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+  assert.ok(await noNextEventNamed(page, "turbo:load"))
+
   await nextEventNamed(page, "turbo:render")
 
   assert.ok(response, "dispatches turbo:frame-missing with event.detail.response")
@@ -232,7 +236,9 @@ test("test following a link to a page with a matching frame does not dispatch a 
   page,
 }) => {
   await page.click("#link-frame")
-  await noNextEventNamed(page, "turbo:frame-missing")
+
+  assert.ok(await noNextEventNamed(page, "turbo:frame-missing"))
+
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
   const src = await attributeForSelector(page, "#frame", "src")
@@ -601,7 +607,8 @@ test("test navigating a frame with a form[method=get] that does not redirect sti
   await nextEventNamed(page, "turbo:before-fetch-response")
   await nextEventOnTarget(page, "frame", "turbo:frame-render")
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
-  await noNextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
 
   const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
 
@@ -670,8 +677,8 @@ test("test a turbo-frame that has been driven by a[data-turbo-action] can be nav
 
   await page.click("#hello a")
   await nextEventOnTarget(page, "hello", "turbo:frame-load")
-  await noNextEventNamed(page, "turbo:load")
 
+  assert.ok(await noNextEventNamed(page, "turbo:load"))
   assert.equal(await page.textContent("#hello h2"), "Frames: #hello")
   assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html")
 })

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -148,7 +148,8 @@ test("test changing [src] attribute on a [complete] frame with loading=lazy defe
   await nextEventNamed(page, "turbo:load")
   await page.goBack()
   await nextEventNamed(page, "turbo:load")
-  await noNextEventOnTarget(page, "hello", "turbo:frame-load")
+
+  assert.ok(await noNextEventOnTarget(page, "hello", "turbo:frame-load"))
 
   let src = new URL((await attributeForSelector(page, "#hello", "src")) || "")
 
@@ -156,8 +157,8 @@ test("test changing [src] attribute on a [complete] frame with loading=lazy defe
   assert.equal(src.pathname, "/src/tests/fixtures/frames/hello.html", "lazy frame retains [src]")
 
   await page.click("#link-lazy-frame")
-  await noNextEventOnTarget(page, "hello", "turbo:frame-load")
 
+  assert.ok(await noNextEventOnTarget(page, "hello", "turbo:frame-load"))
   assert.ok(await hasSelector(page, "#loading-lazy turbo-frame:not([complete])"), "lazy frame is not complete")
 
   await page.click("#loading-lazy summary")

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -370,7 +370,9 @@ test("test does not fire turbo:load twice after following a redirect", async ({ 
   page.click("#redirection-link")
 
   await nextBeat() // 301 redirect response
-  await noNextEventNamed(page, "turbo:load")
+
+  assert.ok(await noNextEventNamed(page, "turbo:load"))
+
   await nextBeat() // 200 response
   await nextBody(page)
   await nextEventNamed(page, "turbo:load")

--- a/src/tests/functional/ujs_tests.ts
+++ b/src/tests/functional/ujs_tests.ts
@@ -11,8 +11,8 @@ test("test clicking a [data-remote=true] anchor within a turbo-frame", async ({ 
     assert.equal(await page.textContent("#frame h2"), "Frames: #frame")
 
     await page.click("#frame a[data-remote=true]")
-    await noNextEventOnTarget(page, "frame", "turbo:frame-load")
 
+    assert.ok(await noNextEventOnTarget(page, "frame", "turbo:frame-load"))
     assert.equal(await page.textContent("#frame h2"), "Frames: #frame", "does not navigate the target frame")
   })
 })
@@ -22,8 +22,8 @@ test("test submitting a [data-remote=true] form within a turbo-frame", async ({ 
     assert.equal(await page.textContent("#frame h2"), "Frames: #frame")
 
     await page.click("#frame form[data-remote=true] button")
-    await noNextEventOnTarget(page, "frame", "turbo:frame-load")
 
+    assert.ok(await noNextEventOnTarget(page, "frame", "turbo:frame-load"))
     assert.equal(await page.textContent("#frame h2"), "Frame: Loaded", "navigates the target frame")
   })
 })


### PR DESCRIPTION
This is an entirely test-suite focused changeset.

The `noNextEventNamed`, `noNextEventOnTarget`, and
`noNextAttributeMutationNamed` test utility functions are named similarly to `nextEventNamed`, `nextEventOnTarget`, and `nextAttributeMutationNamed` helpers, but their behavior has one major subtle difference: they need to be wrapped in an assertion to fail.

For example, if a `noNextEventNamed(page, "turbo:load")` is invoked and there **is not** a `turbo:load` event to be read from the logs, the tests will wait indefinitely (until they time out). A timeout signals a failure, and the suite will fail. In the case of the `noNext`-prefixed versions, the absence of an entry in the logs will return `false` immediately. If the calling test does not make an assertion about the return value, it will continue along despite the false negative.

This commit finds all invocations of `noNext`-prefixed helpers, and wraps them in `assert.ok` calls.

It's a short term fix, but shipping a fix like this immediately will reduce the possibilities of introducing any false negatives into the suite.