### PR TITLE
Ensure turbo no longer uses replaceChildren

### DIFF
--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -31,6 +31,9 @@ export const StreamActions: TurboStreamActions = {
   },
 
   update() {
-    this.targetElements.forEach((e) => e.replaceChildren(this.templateContent))
+    this.targetElements.forEach((targetElement) => {
+      targetElement.innerHTML = ""
+      targetElement.append(this.templateContent)
+    })
   },
 }


### PR DESCRIPTION
This method does not exist in older versions of safari (only 14+). This
meand a polyfill would be required in order to use turbo when using the
update action. In order to stop this, we replace the call to this
function with native code.
