### PR TITLE
Correct `Render<E>` method signature argument order

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "access": "public"
   },
   "devDependencies": {
-    "@playwright/test": "^1.22.2",
+    "@playwright/test": "^1.28.0",
     "@rollup/plugin-node-resolve": "13.1.3",
     "@rollup/plugin-typescript": "^8.5.0",
     "@types/multer": "^1.4.5",

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -7,7 +7,7 @@ type ResolvingFunctions<T = unknown> = {
   reject(reason?: any): void
 }
 
-export type Render<E> = (newElement: E, currentElement: E) => void
+export type Render<E> = (currentElement: E, newElement: E) => void
 
 export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapshot<E>> implements BardoDelegate {
   readonly currentSnapshot: S

--- a/yarn.lock
+++ b/yarn.lock
@@ -278,13 +278,13 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
-"@playwright/test@^1.22.2":
-  version "1.22.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.22.2.tgz#b848f25f8918140c2d0bae8e9227a40198f2dd4a"
-  integrity sha512-cCl96BEBGPtptFz7C2FOSN3PrTnJ3rPpENe+gYCMx4GNNDlN4tmo2D89y13feGKTMMAIVrXfSQ/UmaQKLy1XLA==
+"@playwright/test@^1.28.0":
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.28.1.tgz#e5be297e024a3256610cac2baaa9347fd57c7860"
+  integrity sha512-xN6spdqrNlwSn9KabIhqfZR7IWjPpFK1835tFNgjrlysaSezuX8PYUwaz38V/yI8TJLG9PkAMEXoHRXYXlpTPQ==
   dependencies:
     "@types/node" "*"
-    playwright-core "1.22.2"
+    playwright-core "1.28.1"
 
 "@rollup/plugin-node-resolve@13.1.3":
   version "13.1.3"
@@ -2164,10 +2164,10 @@ platform@^1.3.3, platform@~1.3.6:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-playwright-core@1.22.2:
-  version "1.22.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.22.2.tgz#ed2963d79d71c2a18d5a6fd25b60b9f0a344661a"
-  integrity sha512-w/hc/Ld0RM4pmsNeE6aL/fPNWw8BWit2tg+TfqJ3+p59c6s3B6C8mXvXrIPmfQEobkcFDc+4KirNzOQ+uBSP1Q==
+playwright-core@1.28.1:
+  version "1.28.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.28.1.tgz#8400be9f4a8d1c0489abdb9e75a4cc0ffc3c00cb"
+  integrity sha512-3PixLnGPno0E8rSBJjtwqTwJe3Yw72QwBBBxNoukIj3lEeBNXwbNiKrNuB1oyQgTBw5QHUhNO3SteEtHaMK6ag==
 
 prelude-ls@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
Closes [hotwired/turbo#812][]

The order of the arguments in the `Render` signature are incorrect, and [were introduced in that incorrect order][incorrect].

Luckily, the default implementations and the tests that exercise that feature are in the correct order.

The signature's argument order was inspired by
[morphdom's](https://github.com/patrick-steele-idem/morphdom#usage), with the latter argument serving as overrides for the prior argument.

Custom rendering isn't yet covered by Turbo's documentation website, so we have an opportunity to document it thoroughly and correctly, starting with TypeScript's understanding of the interface.

[hotwired/turbo#812]: https://github.com/hotwired/turbo/issues/812
[incorrect]: https://github.com/hotwired/turbo/pull/431/files#diff-d554b20c605a72c68b2d429ff9915cca4afa8e118026f56ede93382d130382a7R11