### PR TITLE
Add test to exercise error delegation on form requests

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -118,7 +118,8 @@ export class Navigator {
   }
 
   formSubmissionErrored(formSubmission: FormSubmission, error: Error) {
-    console.error(error)
+    // should we rescue the type error in here and render the error page?
+    console.error(error, formSubmission)
   }
 
   formSubmissionFinished(formSubmission: FormSubmission) {

--- a/src/tests/fixtures/visit.html
+++ b/src/tests/fixtures/visit.html
@@ -15,6 +15,9 @@
       <p><a id="same-origin-link" href="/src/tests/fixtures/one.html">Same-origin link</a></p>
       <p><a id="same-origin-link-search-params" href="/src/tests/fixtures/one.html?key=value">Same-origin link with ?key=value</a></p>
       <p><a id="sample-response" href="/src/tests/fixtures/one.html">Sample response</a></p>
+      <form action="/__turbo/bad_https_redirect" method="get" data-turbo="true">
+        <input id="bad-https-link" type="submit" value="Form submit with bad HTTPS redirect" />
+      </form>
       <p><a id="same-page-link" href="/src/tests/fixtures/visit.html">Same page link</a></p>
       <hr class="push-below-fold">
       <p><a id="below-the-fold-link" href="/src/tests/fixtures/one.html">one.html</a></p>

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -211,12 +211,12 @@ test("test can scroll to element after history-initiated turbo:visit", async ({ 
   assert(await isScrolledToSelector(page, "#" + id), "scrolls after history-initiated turbo:load")
 })
 
-test("test Visit with network error", async ({ page }) => {
+test("test visit with a network error (e.g. https cert failure)", async ({ page }) => {
   await page.evaluate(() => {
     addEventListener("turbo:fetch-request-error", (event: Event) => event.preventDefault())
   })
-  await page.context().setOffline(true)
-  await page.click("#same-origin-link")
+
+  await page.click("#bad-https-link")
   await nextEventNamed(page, "turbo:fetch-request-error")
 })
 

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -70,6 +70,10 @@ router.get("/delayed_response", (request, response) => {
   setTimeout(() => response.status(200).sendFile(fixture), 1000)
 })
 
+router.get("/bad_https_redirect", (request, response) => {
+  response.redirect('https://expired.badssl.com/')
+})
+
 router.post("/messages", (request, response) => {
   const params = { ...request.body, ...request.query }
   const { content, id, status, type, target, targets } = params


### PR DESCRIPTION
The issue this PR is trying to change: Turbo form submits a request to a server which responds with a redirect containing either a malformed or invalid HTTPS cert. As a result no feedback is received and it's not clear that there was an error at all.

I've added a test replicating this behavior and replaced a slow/intermittent test exercising a similar network failure state.

There's a pending change in here which I'd like to confirm with the turbo contributors before starting work on - If the form response includes a 302 redirect, would you expect it to follow the redirect directly so that the user sees the error or is there a design decision to swallow the error inside the turbo frame and have devs handle this themselves by using the `turbo:fetch-request-error` event.

cc @benjichen16