### PR TITLE
`[data-turbo-method="get"]` links: search params

### DIFF
--- a/src/observers/form_link_click_observer.ts
+++ b/src/observers/form_link_click_observer.ts
@@ -31,10 +31,16 @@ export class FormLinkClickObserver implements LinkClickObserverDelegate {
   }
 
   followedLinkToLocation(link: Element, location: URL): void {
-    const action = location.href
     const form = document.createElement("form")
+
+    const type = "hidden"
+    for (const [name, value] of location.searchParams) {
+      form.append(Object.assign(document.createElement("input"), { type, name, value }))
+    }
+
+    const action = Object.assign(location, { search: "" })
     form.setAttribute("data-turbo", "true")
-    form.setAttribute("action", action)
+    form.setAttribute("action", action.href)
     form.setAttribute("hidden", "")
 
     const method = link.getAttribute("data-turbo-method")

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="html">
+<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end">
   <head>
     <meta charset="utf-8">
     <meta name="csp-nonce" content="123">
@@ -45,6 +45,7 @@
       <p><a id="same-origin-download-link" href="/intentionally_missing_fake_download.html" download="x.html">Same-origin download link</a></p>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
+      <p><a id="same-origin-get-link-form" href="/src/tests/fixtures/navigation.html?a=one&b=two" data-turbo-method="get">Same-origin data-turbo-method=get link</a></p>
       <p><a id="same-origin-replace-post-link" href="/__turbo/redirect" data-turbo-method="post" data-turbo-action="replace">Same-origin data-turbo-action=replace link with post method</a></p>
       <p><a id="link-to-disabled-frame" href="/src/tests/fixtures/frames/hello.html" data-turbo-frame="hello">Disabled turbo-frame</a></p>
       <p><a id="autofocus-link" href="/src/tests/fixtures/autofocus.html">autofocus.html link</a></p>

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -2,6 +2,7 @@ import { test } from "@playwright/test"
 import { assert } from "chai"
 import {
   clickWithoutScrolling,
+  getSearchParam,
   hash,
   hasSelector,
   isScrolledToSelector,
@@ -134,6 +135,17 @@ test("test following a same-origin unannotated form[method=GET]", async ({ page 
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
+})
+
+test("test following a same-origin data-turbo-method=get link", async ({ page }) => {
+  await page.click("#same-origin-get-link-form")
+  await nextEventNamed(page, "turbo:submit-start")
+  await nextEventNamed(page, "turbo:submit-end")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(getSearchParam(page.url(), "a"), "one")
+  assert.equal(getSearchParam(page.url(), "b"), "two")
 })
 
 test("test following a same-origin data-turbo-action=replace link", async ({ page }) => {


### PR DESCRIPTION
Closes [hotwired/turbo#820][]
Follow-up to [hotwired/turbo#461][]

[hotwired/turbo#820]: https://github.com/hotwired/turbo/issues/820
[hotwired/turbo#461]: https://github.com/hotwired/turbo/pull/461

The background
---

According to the HTML Specification's [§ 4.10.21.3 Form submission algorithm][] section, submissions transmitted as `GET` requests [mutate the `[action]` URL][mutate], overriding any search parameters already encoded into the `[action]` value:

> [Mutate action URL][algorithm]
> ---
>
> Let <var>pairs</var> be the result of converting to a list of
> name-value pairs with <var>entry list</var>.
>
> Let <var>query</var> be the result of running the
> `application/x-www-form-urlencoded` serializer with <var>pairs</var>
> and <var>encoding</var>.
>
> Set <Var>parsed action</var>'s query component to <var>query</var>.
>
> Plan to navigate to <var>parsed action</var>.

[§ 4.10.21.3 Form submission algorithm]: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm
[algorithm]: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-mutate-action
[mutate]: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#form-submission-algorithm:submit-mutate-action

Form submissions made with `POST` requests, on the other hand, encode _both_ the `[action]` value's query parameters and any additionally encoded body data:

> [Submit as entity body][post-submit]
> ---
>
> …
>
> Plan to navigate to a new request whose URL is <var>parsed
> action</var>, method is <var>method</var>, header list is
> « (`Content-Type`, mimeType) », and body is <var>body</var>.

[post-submit]: https://html.spec.whatwg.org/multipage/form-control-infrastructure.html#submit-body

The problem
---

When navigating through an `<a data-turbo-method="get">` with an `[href]` that contains search parameters, the `<form>` element that Turbo Drive constructs behind the scenes will unexpectedly omit the search parameters during the transformation from `<a>` to `<form>`.

For example:

```html
<a href="/path-with-search-params?a=one&b=two"
   data-turbo-method="get">
  Submits as a form[method=get]
</a>
```

Would be translated to something like:

```html
<form method="get" action="/path-with-search-params?a=one&b=two" hidden></form>
```

Then, when submitting the `<form>`, the browser omits the `?one&b=two`.

The solution
---

This commit extends the current `FormLinkClickObserver` implementation to loop over each entry in [URLSearchParams][] instance derived from the provided [URL][] instance and transforms the name-value pair into an [`<input type="hidden">`][input-hidden] element, which it appends to the `<form>`.

Once that translation is complete, it removes any search parameters from the form's `[action]` attribute to avoid duplicate entries in the form's data.

While this change resolves the underlying issue, it's worth emphasizing that declaring `[data-turbo-method="get"]` on an `<a>` element is redundant, and should be avoided in the first place. Even though that pattern should be avoided, this commit aims to prevent surprising behavior whenever it occurs.

[URLSearchParams]: https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
[URL]: https://developer.mozilla.org/en-US/docs/Web/API/URL
[input-hidden]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/hidden