### PR TITLE
Add support for defining the matching frame from the caller

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -370,8 +370,10 @@ export class FrameController
 
     frame.delegate.proposeVisitIfNavigatedWithAction(frame, element, submitter)
 
+    const srcFrame = element.getAttribute("data-turbo-src-frame")
     this.withCurrentNavigationElement(element, () => {
       frame.src = url
+      if (srcFrame) frame.setAttribute("data-turbo-src-frame", srcFrame)
     })
   }
 
@@ -447,7 +449,7 @@ export class FrameController
 
   async extractForeignFrameElement(container: ParentNode): Promise<FrameElement | null> {
     let element
-    const id = CSS.escape(this.id)
+    const id = CSS.escape(this.element.getAttribute('data-turbo-src-frame') || this.id)
 
     try {
       element = activateElement(container.querySelector(`turbo-frame#${id}`), this.sourceURL)

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -124,6 +124,10 @@
       <input id="outer-frame-submit" type="submit" value="Outer form submit">
     </form>
 
+    <a id="src-frame-link" href="/src/tests/fixtures/frames/part.html" data-turbo-frame="src-frame" data-turbo-src-frame="part">Src frame link</a>
+    <turbo-frame id="src-frame">
+    </turbo-frame>
+
     <hr class="push-off-screen">
     <input id="below-the-fold-input">
     <a id="below-the-fold-link-frame-action" data-turbo-action="advance" data-turbo-frame="frame" href="/src/tests/fixtures/frames/frame.html">Navigate #frame</a>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -299,6 +299,14 @@ test("test following a link that declares data-turbo-frame within a frame whose 
   assert.notOk(await hasSelector(page, "#nested-child"))
 })
 
+test("test following a link that declares data-turbo-src-frame tries to match this frame in the respsone", async ({ page }) => {
+  await page.click("#src-frame-link")
+  await nextBeat()
+
+  const frameText = await page.textContent("#src-frame h2")
+  assert.equal(frameText, "Frames: #frame-part")
+})
+
 test("test following a form within a nested frame with form target top", async ({ page }) => {
   await page.click("#nested-child-navigate-form-top-submit")
   await nextBeat()


### PR DESCRIPTION
Sometimes you to want define which frame should be matched in the response, other than the one defined in `data-turbo-frame`.

Let's say we have two forms for creating posts and authors:

```html
<!-- GET posts/new -->
<turbo-frame id="new_post">
  <form ...
</turbo-frame>

<!-- GET authors/new -->
<turbo-frame id="new_author">
  <form ...
</turbo-frame>
```
If we want to open them both in a modal we could do the following without having to change the responses:

```html
<turbo-frame id="modal">
</turbo-frame>

<a href="posts/new"   data-turbo-frame="modal" data-turbo-src-frame="new_post"  >New post   modal</a>
<a href="authors/new" data-turbo-frame="modal" data-turbo-src-frame="new_author">New author modal</a>
```

Instead trying to match a frame called "modal" in the response it will try to match what is defined in `data-turbo-src-frame`, in this case "new_post" or "new_author".

I'm not sure about the attribute name. Maybe something like `data-turbo-matching-frame` would be clearer.

Another implementation could be using the anchor part of the URL. But that might be too magical and have bigger implications:

```html
<a href="posts/new#new_post"  data-turbo-frame="modal">New post modal</a>
```