### PR TITLE
Fix failing Firefox test

### DIFF
--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -15,7 +15,7 @@
 
     <a href="#ignored-link" id="ignored-link">Skipped Content</a>
 
-    <section id="main" style="height: 200vh">
+    <section id="main">
       <h1>Navigation</h1>
       <p><a id="same-origin-unannotated-link" href="/src/tests/fixtures/one.html">Same-origin unannotated link</a></p>
       <p><a id="same-origin-unannotated-link-search-params" href="/src/tests/fixtures/one.html?key=value">Same-origin unannotated link ?key=value</a></p>

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -88,6 +88,7 @@ test("test reloads when tracked elements change due to failed form submission", 
   })
 
   await page.click("#tracked-asset-change-form button")
+  await nextBeat()
 
   const reason = await page.evaluate(() => localStorage.getItem("reason"))
   const unloaded = await page.evaluate(() => localStorage.getItem("unloaded"))


### PR DESCRIPTION
Some tests that visit the `navigation.html` fixture exercise scroll
behavior by visiting links and other content that is below the fold. The
`style="height: 200vh"` value declared on the page's `<section>` element
is arbitrary, but double the screen size to force content below the
fold.

Unluckily, it cuts off _right_ at the beginning of the new `<iframe>`
elements in Firefox browsers, which obscures the `<a>` element and
prevents link clicks.

To resolve that issue, this commit removes the `[style]` attribute,
since the content is long enough to be scrollable.
