### PR TITLE
Fix `getElementForAnchor` for non-URLsafe anchors

### DIFF
--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -18,7 +18,10 @@ export class Snapshot<E extends Element = Element> {
   }
 
   getElementForAnchor(anchor: string | undefined) {
-    return anchor ? this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`) : null
+    if (!anchor) return null
+
+    const decoded = decodeURIComponent(anchor)
+    return this.element.querySelector(`[id='${anchor}'], [id='${decoded}'], a[name='${anchor}'], a[name='${decoded}']`)
   }
 
   get isConnected() {


### PR DESCRIPTION
Currently, Turbo directly extracts safely encoded anchors from an url object. Thus, if the anchor contains non-URLsafe characters, Turbo will never be able to find the corresponding element.

I am able to fix this issue by adding decoded anchor string to the CSS selectors.

The fix attempts to mimic vanilla browser behaviours, that is, when an non-URLsafe anchor is clicked, the browser would first try to find an element with an id of the safely encoded anchor, and if not found, the browser would then directly look for the element with an id of the unsafe anchor string.