### PR TITLE
implement data-turbo-progress-bar on html elements feature

### DIFF
--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -1,5 +1,5 @@
 import { Action } from "../types"
-import { getVisitAction } from "../../util"
+import { getVisitAction, getProgressBarValue } from "../../util"
 import { FetchMethod } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { FormSubmission } from "./form_submission"
@@ -92,8 +92,10 @@ export class Navigator {
 
         const { statusCode, redirected } = fetchResponse
         const action = this.getActionForFormSubmission(formSubmission)
+        const withProgressBar = this.getProgressBarForFormSubmission(formSubmission)
         const visitOptions = {
           action,
+          withProgressBar,
           shouldCacheSnapshot,
           response: { statusCode, responseHTML, redirected },
         }
@@ -166,5 +168,11 @@ export class Navigator {
 
   getActionForFormSubmission({ submitter, formElement }: FormSubmission): Action {
     return getVisitAction(submitter, formElement) || "advance"
+  }
+
+  // Private
+
+  getProgressBarForFormSubmission({ submitter, formElement }: FormSubmission): boolean {
+    return getProgressBarValue(submitter, formElement)
   }
 }

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -52,6 +52,7 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
+  withProgressBar: boolean
 }
 
 const defaultOptions: VisitOptions = {
@@ -62,6 +63,7 @@ const defaultOptions: VisitOptions = {
   updateHistory: true,
   shouldCacheSnapshot: true,
   acceptsStreamResponse: false,
+  withProgressBar: false,
 }
 
 export type VisitResponse = {
@@ -86,6 +88,7 @@ export class Visit implements FetchRequestDelegate {
   readonly visitCachedSnapshot: (snapshot: Snapshot) => void
   readonly willRender: boolean
   readonly updateHistory: boolean
+  readonly withProgressBar: boolean
 
   followedRedirect = false
   frame?: number
@@ -125,6 +128,7 @@ export class Visit implements FetchRequestDelegate {
       updateHistory,
       shouldCacheSnapshot,
       acceptsStreamResponse,
+      withProgressBar,
     } = {
       ...defaultOptions,
       ...options,
@@ -142,6 +146,7 @@ export class Visit implements FetchRequestDelegate {
     this.scrolled = !willRender
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
+    this.withProgressBar = withProgressBar
   }
 
   get adapter() {

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -52,7 +52,7 @@ export type VisitOptions = {
   shouldCacheSnapshot: boolean
   frame?: string
   acceptsStreamResponse: boolean
-  withProgressBar: boolean
+  withProgressBar: boolean | null
 }
 
 const defaultOptions: VisitOptions = {
@@ -63,7 +63,7 @@ const defaultOptions: VisitOptions = {
   updateHistory: true,
   shouldCacheSnapshot: true,
   acceptsStreamResponse: false,
-  withProgressBar: false,
+  withProgressBar: null,
 }
 
 export type VisitResponse = {
@@ -88,7 +88,7 @@ export class Visit implements FetchRequestDelegate {
   readonly visitCachedSnapshot: (snapshot: Snapshot) => void
   readonly willRender: boolean
   readonly updateHistory: boolean
-  readonly withProgressBar: boolean
+  readonly withProgressBar: boolean | null
 
   followedRedirect = false
   frame?: number

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -62,7 +62,7 @@ export class FrameController
   private hasBeenLoaded = false
   private ignoredAttributes: Set<FrameElementObservedAttribute> = new Set()
   private action: Action | null = null
-  private withProgressBar = false
+  private withProgressBar: boolean | null = null
   readonly restorationIdentifier: string
   private previousFrameElement?: FrameElement
   private currentNavigationElement?: Element
@@ -400,7 +400,7 @@ export class FrameController
           }
 
           if (this.action) options.action = this.action
-          if (this.withProgressBar) options.withProgressBar = this.withProgressBar
+          if (this.withProgressBar != null) options.withProgressBar = this.withProgressBar
 
           session.visit(frame.src, options)
         }

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -16,6 +16,7 @@ import {
   uuid,
   getHistoryMethodForAction,
   getVisitAction,
+  getProgressBarValue,
 } from "../../util"
 import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
@@ -61,6 +62,7 @@ export class FrameController
   private hasBeenLoaded = false
   private ignoredAttributes: Set<FrameElementObservedAttribute> = new Set()
   private action: Action | null = null
+  private withProgressBar = false
   readonly restorationIdentifier: string
   private previousFrameElement?: FrameElement
   private currentNavigationElement?: Element
@@ -377,6 +379,7 @@ export class FrameController
 
   proposeVisitIfNavigatedWithAction(frame: FrameElement, element: Element, submitter?: HTMLElement) {
     this.action = getVisitAction(submitter, element, frame)
+    this.withProgressBar = getProgressBarValue(submitter, element, frame)
 
     if (this.action) {
       const pageSnapshot = PageSnapshot.fromElement(frame).clone()
@@ -397,6 +400,7 @@ export class FrameController
           }
 
           if (this.action) options.action = this.action
+          if (this.withProgressBar) options.withProgressBar = this.withProgressBar
 
           session.visit(frame.src, options)
         }

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -36,7 +36,10 @@ export class BrowserAdapter implements Adapter {
 
   visitRequestStarted(visit: Visit) {
     this.progressBar.setValue(0)
-    if (visit.hasCachedSnapshot() || visit.action != "restore") {
+
+    if (visit.withProgressBar) {
+      this.showProgressBar()
+    } else if (visit.hasCachedSnapshot() || visit.action != "restore") {
       this.showVisitProgressBarAfterDelay()
     } else {
       this.showProgressBar()

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -39,6 +39,10 @@ export class BrowserAdapter implements Adapter {
 
     if (visit.withProgressBar) {
       this.showProgressBar()
+    } else if (visit.action === "advance" && visit.withProgressBar == false) {
+      this.showVisitProgressBarAfterDelay()
+    } else if (visit.action === "advance") {
+      this.showProgressBar()
     } else if (visit.hasCachedSnapshot() || visit.action != "restore") {
       this.showVisitProgressBarAfterDelay()
     } else {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -200,8 +200,8 @@ export class Session
 
   followedLinkToLocation(link: Element, location: URL) {
     const action = this.getActionForLink(link)
-    const withProgressBar = this.getProgressBarForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
+    const withProgressBar = getProgressBarValue(link)
 
     this.visit(location.href, { action, acceptsStreamResponse, withProgressBar })
   }
@@ -436,10 +436,6 @@ export class Session
 
   getActionForLink(link: Element): Action {
     return getVisitAction(link) || "advance"
-  }
-
-  getProgressBarForLink(link: Element): boolean {
-    return getProgressBarValue(link)
   }
 
   get snapshot() {

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -14,7 +14,14 @@ import { StreamMessage } from "./streams/stream_message"
 import { StreamMessageRenderer } from "./streams/stream_message_renderer"
 import { StreamObserver } from "../observers/stream_observer"
 import { Action, Position, StreamSource } from "./types"
-import { clearBusyState, dispatch, findClosestRecursively, getVisitAction, markAsBusy } from "../util"
+import {
+  clearBusyState,
+  dispatch,
+  findClosestRecursively,
+  getVisitAction,
+  markAsBusy,
+  getProgressBarValue,
+} from "../util"
 import { PageView, PageViewDelegate, PageViewRenderOptions } from "./drive/page_view"
 import { Visit, VisitOptions } from "./drive/visit"
 import { PageSnapshot } from "./drive/page_snapshot"
@@ -193,9 +200,10 @@ export class Session
 
   followedLinkToLocation(link: Element, location: URL) {
     const action = this.getActionForLink(link)
+    const withProgressBar = this.getProgressBarForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
 
-    this.visit(location.href, { action, acceptsStreamResponse })
+    this.visit(location.href, { action, acceptsStreamResponse, withProgressBar })
   }
 
   // Navigator delegate
@@ -428,6 +436,10 @@ export class Session
 
   getActionForLink(link: Element): Action {
     return getVisitAction(link) || "advance"
+  }
+
+  getProgressBarForLink(link: Element): boolean {
+    return getProgressBarValue(link)
   }
 
   get snapshot() {

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -20,6 +20,11 @@
         <input type="hidden" name="greeting" value="Hello from a redirect">
         <input id="standard-post-form-submit" type="submit" value="form[method=post]">
       </form>
+      <form action="/__turbo/redirect" method="post" class="redirect" data-turbo-progress-bar="true">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
+        <input type="hidden" name="greeting" value="Hello from a redirect">
+        <input id="turbo-progress-bar-post-form-submit" type="submit" value="form[method=post]">
+      </form>
       <form action="/__turbo/redirect" method="get" class="redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
         <input type="hidden" name="greeting" value="Hello from a redirect">

--- a/src/tests/fixtures/frame_navigation.html
+++ b/src/tests/fixtures/frame_navigation.html
@@ -22,6 +22,23 @@
         <a id="top" href="/src/tests/fixtures/frame_navigation.html" data-turbo-frame="_top">Top</a>
       </turbo-frame>
 
+      <turbo-frame id="progress-bar-frame" data-turbo-action="advance">
+        <a id="with-progress-bar" href="/src/tests/fixtures/frame_navigation.html">Enabled for action advance by default</a>
+      </turbo-frame>
+
+      <turbo-frame id="progress-bar-frame-with-action" data-turbo-progress-bar="true" data-turbo-action="replace">
+        <a id="with-explicit-progress-bar" href="/src/tests/fixtures/frame_navigation.html">Can be enabled explicitly for other actions</a>
+      </turbo-frame>
+
+      <turbo-frame id="no-progress-bar-frame" data-turbo-progress-bar="false" data-turbo-action="advance">
+        <a id="no-progress-bar" href="/src/tests/fixtures/frame_navigation.html">Explicitly disabled by progress bar attr</a>
+      </turbo-frame>
+
+      <turbo-frame id="no-progress-bar-frame-no-action" data-turbo-progress-bar="true">
+        <a id="no-progress-bar" href="/src/tests/fixtures/frame_navigation.html">Has no effect if action not specified</a>
+      </turbo-frame>
+
+
       <div style="height: calc(100vh*2);"></div>
 
       <turbo-frame id="eager-loaded-frame" src="/src/tests/fixtures/frames/frame_for_eager.html" loading="lazy"

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -18,6 +18,7 @@
     <section id="main" style="height: 200vh">
       <h1>Navigation</h1>
       <p><a id="same-origin-unannotated-link" href="/src/tests/fixtures/one.html">Same-origin unannotated link</a></p>
+      <p><a id="same-origin-unannotated-link-with-disabled-progress-bar" href="/src/tests/fixtures/one.html" data-turbo-progress-bar="false">Same-origin unannotated link with disabled progress bar</a></p>
       <p><a id="same-origin-unannotated-link-search-params" href="/src/tests/fixtures/one.html?key=value">Same-origin unannotated link ?key=value</a></p>
       <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button>Same-origin unannotated form</button></form></p>
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -23,6 +23,7 @@
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>
       <p><form id="same-origin-replace-form-get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>
       <p><form id="same-origin-replace-form-submitter-get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin data-turbo-action=replace form</button></form></p>
+      <p><a id="explicit-turbo-progress-bar" href="/__turbo/with_progress_bar" data-turbo-progress-bar="true">Explicit progress bar</a></p>
       <form id="same-origin-replace-form-post" method="post" action="/__turbo/redirect" data-turbo-action="replace">
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
         <button>Same-origin form[method="post"][data-turbo-action="replace"]</button>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -111,6 +111,21 @@ test("test standard form submission does not render a progress bar before expiri
   assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "does not show progress bar before delay")
 })
 
+test("test standard form with data-turbo-progress-bar submission renders a progress bar before expiring the delay", async ({
+  page,
+}) => {
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(500))
+  page.click("#turbo-progress-bar-post-form-submit")
+
+  await waitUntilSelector(page, ".turbo-progress-bar")
+  assert.ok(await hasSelector(page, ".turbo-progress-bar"), "displays progress bar")
+
+  await nextBody(page)
+  await waitUntilNoSelector(page, ".turbo-progress-bar")
+
+  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
+})
+
 test("test standard form submission with redirect response", async ({ page }) => {
   await page.click("#standard form.redirect input[type=submit]")
   await nextBody(page)

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -67,9 +67,22 @@ test("test navigating link with data-turbo-progress-bar renders a progress bar b
 
 test("test navigating does not render a progress bar before expiring the delay", async ({ page }) => {
   await page.evaluate(() => window.Turbo.setProgressBarDelay(1000))
-  await page.click("#same-origin-unannotated-link")
+  await page.click("#same-origin-unannotated-link-with-disabled-progress-bar")
 
   assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "does not show progress bar before delay")
+})
+
+test("test navigating renders a progress bar before expiring the delay", async ({ page }) => {
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(1000))
+  await page.click("#same-origin-unannotated-link")
+
+  await waitUntilSelector(page, ".turbo-progress-bar")
+  assert.ok(await hasSelector(page, ".turbo-progress-bar"), "displays progress bar")
+
+  await nextEventNamed(page, "turbo:load")
+  await waitUntilNoSelector(page, ".turbo-progress-bar")
+
+  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
 })
 
 test("test after loading the page", async ({ page }) => {

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -44,6 +44,27 @@ test("test navigating renders a progress bar", async ({ page }) => {
   assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
 })
 
+test("test navigating link with data-turbo-progress-bar renders a progress bar before expiring the delay", async ({
+  page,
+}) => {
+  assert.equal(
+    await page.locator("style").evaluate((style) => style.nonce),
+    "123",
+    "renders progress bar stylesheet inline with nonce"
+  )
+
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(1000))
+  await page.click("#explicit-turbo-progress-bar")
+
+  await waitUntilSelector(page, ".turbo-progress-bar")
+  assert.ok(await hasSelector(page, ".turbo-progress-bar"), "displays progress bar")
+
+  await nextEventNamed(page, "turbo:load")
+  await waitUntilNoSelector(page, ".turbo-progress-bar")
+
+  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
+})
+
 test("test navigating does not render a progress bar before expiring the delay", async ({ page }) => {
   await page.evaluate(() => window.Turbo.setProgressBarDelay(1000))
   await page.click("#same-origin-unannotated-link")

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -70,6 +70,11 @@ router.get("/delayed_response", (request, response) => {
   setTimeout(() => response.status(200).sendFile(fixture), 1000)
 })
 
+router.get("/with_progress_bar", (request, response) => {
+  const fixture = path.join(__dirname, "../../src/tests/fixtures/one.html")
+  setTimeout(() => response.status(200).sendFile(fixture), 300)
+})
+
 router.post("/messages", (request, response) => {
   const params = { ...request.body, ...request.query }
   const { content, id, status, type, target, targets } = params

--- a/src/util.ts
+++ b/src/util.ts
@@ -159,16 +159,20 @@ export function isAction(action: any): action is Action {
   return action == "advance" || action == "replace" || action == "restore"
 }
 
+function isProgressBar(progressBar: any): boolean {
+  return progressBar == "true" || progressBar == "false"
+}
+
 export function getVisitAction(...elements: (Element | undefined)[]): Action | null {
   const action = getAttribute("data-turbo-action", ...elements)
 
   return isAction(action) ? action : null
 }
 
-export function getProgressBarValue(...elements: (Element | undefined)[]): boolean {
+export function getProgressBarValue(...elements: (Element | undefined)[]): boolean | null {
   const progressBar = getAttribute("data-turbo-progress-bar", ...elements)
 
-  return progressBar == "true"
+  return isProgressBar(progressBar) ? progressBar == "true" : null
 }
 
 export function getMetaElement(name: string): HTMLMetaElement | null {

--- a/src/util.ts
+++ b/src/util.ts
@@ -165,6 +165,12 @@ export function getVisitAction(...elements: (Element | undefined)[]): Action | n
   return isAction(action) ? action : null
 }
 
+export function getProgressBarValue(...elements: (Element | undefined)[]): boolean {
+  const progressBar = getAttribute("data-turbo-progress-bar", ...elements)
+
+  return progressBar == "true"
+}
+
 export function getMetaElement(name: string): HTMLMetaElement | null {
   return document.querySelector(`meta[name="${name}"]`)
 }


### PR DESCRIPTION
Closes #540 

PR implements `data-turbo-progress-bar` feature. When added to element, we will always show progress bar on page load, applies for both `a` and `form` html elements. Adding to element `data-turbo-progress-bar="true"` will trigger this behavior.