### PR TITLE
Fix `assert.equal` in frame tests

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,11 +12,12 @@
     "prettier"
   ],
   "rules": {
-    "prettier/prettier": ["error"],
-    "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/no-non-null-assertion": "off",
     "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-namespace": ["error", { "allowDeclarations": true }],
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
     "no-unused-vars": "off",
-    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }]
+    "prettier/prettier": ["error"]
   }
 }


### PR DESCRIPTION
The `assert.equal` matcher had been overridden for some tests to allow string comparisons to act on trimmed versions of the strings. Unfortunately the overridden matcher was faulty, in that it didn't fail when the values differed. That is, `assert.equal(1, 2)` was passing rather than failing. As a result, there are a few tests that have failures that were not being reported.

This change addresses this by:

- Restoring the original `assert.equal`
- Adding a new `assert.equalIgnoringWhitespace` so we can be explicit about the cases where we want that behaviour
- Fixing a few existing test failures that had been hidden by the faulty `assert.equal`

**Note:** There are still a couple of test failures here that'll need to be fixed before this can be merged.