### PR TITLE
Restore dev-builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,3 +39,7 @@ jobs:
 
     - name: Firefox Test
       run: yarn test:browser --project=firefox
+
+    - name: Publish dev build
+      run: .github/scripts/publish-dev-build '${{ secrets.DEV_BUILD_GITHUB_TOKEN }}'
+      if: ${{ github.event_name == 'push' }}


### PR DESCRIPTION
For some reason they were disabled in https://github.com/hotwired/turbo/commit/65be4bd76eb0167f077329289ee61283cc82d124, but they were quite helpful if you wanted to test new upcoming features before they get released.