### PR TITLE
`resume()` does not require `value`

### DIFF
--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -5,7 +5,7 @@ import { Position } from "./types"
 import { getAnchor } from "./url"
 
 export interface ViewRenderOptions<E> {
-  resume: (value: any) => void
+  resume: (value?: any) => void
   render: Render<E>
 }
 

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -5,7 +5,7 @@ import { dispatch } from "../util"
 export type TurboBeforeFetchRequestEvent = CustomEvent<{
   fetchOptions: RequestInit
   url: URL
-  resume: (value: any) => void
+  resume: (value?: any) => void
 }>
 export type TurboBeforeFetchResponseEvent = CustomEvent<{
   fetchResponse: FetchResponse


### PR DESCRIPTION
[**Pausing Requests**](https://turbo.hotwired.dev/handbook/drive#pausing-requests) documents `resume()` usage without requiring a value, but TypeScript disagrees.
> TS2554: Expected 1 arguments, but got 0.

Workaround is to call `resume(undefined)`, but more representative types would be better. The signature matches the `Promise` callback's `resolve` parameter here, where you'll note the `await`ed result is discarded:
https://github.com/hotwired/turbo/blob/f04a21c9418bc384f5cdafaf9d2ed21caafbf438/src/core/view.ts#L92-L95

A similar pattern is found here, where again the resolved value is discarded:
https://github.com/hotwired/turbo/blob/f04a21c9418bc384f5cdafaf9d2ed21caafbf438/src/http/fetch_request.ts#L172-L182

------------------------------------

The other option would be to remove the `resume()` parameter, but technically that's a breaking change for TypeScript users using `resume(undefined)`. Easy enough to fix, of course. That could look something like:

```diff
@@ -7,3 +7,3 @@ import { getAnchor } from "./url"
 export interface ViewRenderOptions<E> {
-  resume: (value: any) => void
+  resume: () => void
   render: Render<E>
@@ -30,3 +30,3 @@ export abstract class View<
   private resolveRenderPromise = (_value: any) => {}
-  private resolveInterceptionPromise = (_value: any) => {}
+  private resolveInterceptionPromise = () => {}
 
@@ -91,3 +91,3 @@ export abstract class View<
 
-        const renderInterception = new Promise((resolve) => (this.resolveInterceptionPromise = resolve))
+        const renderInterception = new Promise((resolve) => (this.resolveInterceptionPromise = resolve as () => void))
         const options = { resume: this.resolveInterceptionPromise, render: this.renderer.renderElement }
```