### PR TITLE
Stub external request in external visit test

### DIFF
--- a/src/tests/functional/drive_tests.ts
+++ b/src/tests/functional/drive_tests.ts
@@ -15,9 +15,15 @@ test("test drive enabled by default; click normal link", async ({ page }) => {
 })
 
 test("test drive to external link", async ({ page }) => {
+  await page.route("https://example.com", async (route) => {
+    await route.fulfill({ body: "Hello from the outside world" })
+  })
+
   page.click("#drive_enabled_external")
   await nextBody(page)
+
   assert.equal(await page.evaluate(() => window.location.href), "https://example.com/")
+  assert.equal(await page.textContent("body"), "Hello from the outside world")
 })
 
 test("test drive enabled by default; click link inside data-turbo='false'", async ({ page }) => {


### PR DESCRIPTION
This test was failing locally due to the external request destroying the page execution context. Stubbing a response to the request allows it to complete without relying on an external request.