### PR TITLE
Fix test failure on Firefox for Mac

### DIFF
--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -328,10 +328,7 @@ test("test skip link with hash-only path moves focus and changes tab order", asy
   await page.press("#main", "Tab")
 
   assert.notOk(await selectorHasFocus(page, "#ignored-link"), "skips interactive elements before #main")
-  assert.ok(
-    await selectorHasFocus(page, "#same-origin-unannotated-link"),
-    "skips to first interactive element after #main"
-  )
+  assert.ok(await selectorHasFocus(page, "#main *:focus"), "moves focus inside #main")
   assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
   assert.equal(hash(page.url()), "#main")
 })


### PR DESCRIPTION
This test was consistently failing on my Mac machine.

It was because Firefox for Mac doesn't focus on links on TAB presses.

Ref. https://stackoverflow.com/a/11713537