### PR TITLE
Allow opt-in to breaking out of missing frames

### DIFF
--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -67,6 +67,10 @@ export class PageSnapshot extends Snapshot<HTMLBodyElement> {
     return this.getSetting("visit-control") != "reload"
   }
 
+  get frameEscapePaths() {
+    return this.getSetting("frame-escape-paths")?.split(/\s+/) || []
+  }
+
   // Private
 
   getSetting(name: string) {

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,1 @@
+export class TurboFrameMissingError extends Error {}

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -427,8 +427,8 @@ export class FrameController
   }
 
   private handleFrameMissingFromResponse(fetchResponse: FetchResponse) {
-    if (this.responsePermittedToBreakOutOfFrame(fetchResponse)) {
-      this.warnFrameMissingBreakout(fetchResponse)
+    if (this.responsePermittedToEscapeFrame(fetchResponse)) {
+      this.warnResponseEscapingFrame(fetchResponse)
       this.visitResponse(fetchResponse.response)
     } else {
       this.view.missing()
@@ -436,16 +436,16 @@ export class FrameController
     }
   }
 
-  private responsePermittedToBreakOutOfFrame(fetchResponse: FetchResponse) {
+  private responsePermittedToEscapeFrame(fetchResponse: FetchResponse) {
     const allowedPathsTag = this.element.ownerDocument.querySelector<HTMLMetaElement>(
-      `meta[name=turbo-frame-breakout-paths]`
+      `meta[name=turbo-frame-escape-paths]`
     )
     const allowedPaths = allowedPathsTag?.content?.split(/\s+/) || []
 
     return allowedPaths.includes(fetchResponse.location.pathname)
   }
 
-  private warnFrameMissingBreakout(fetchResponse: FetchResponse) {
+  private warnResponseEscapingFrame(fetchResponse: FetchResponse) {
     console.warn(this.frameMissingMessage(fetchResponse, "Performing a full-page visit."))
   }
 
@@ -453,7 +453,7 @@ export class FrameController
     throw new TurboFrameMissingError(
       this.frameMissingMessage(
         fetchResponse,
-        "To transform the response into a full-page visit, include its path in a turbo-frame-breakout-paths meta tag."
+        "To transform the response into a full-page visit, include its path in a turbo-frame-escape-paths meta tag."
       )
     )
   }

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -427,15 +427,15 @@ export class FrameController
   }
 
   private handleFrameMissingFromResponse(fetchResponse: FetchResponse) {
-    this.showFrameMissingError()
-    this.throwFrameMissingException(fetchResponse)
+    this.renderFrameMissingError()
+    this.throwFrameMissingError(fetchResponse)
   }
 
-  private showFrameMissingError() {
+  private renderFrameMissingError() {
     this.element.innerHTML = `<strong class="turbo-frame-error">Content missing</strong>`
   }
 
-  private throwFrameMissingException(fetchResponse: FetchResponse) {
+  private throwFrameMissingError(fetchResponse: FetchResponse) {
     const message = `The response (${fetchResponse.statusCode}) did not contain the expected <turbo-frame id="${this.element.id}">`
     throw new TurboFrameMissingError(message)
   }

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -32,6 +32,7 @@ import { VisitOptions } from "../drive/visit"
 import { TurboBeforeFrameRenderEvent } from "../session"
 import { StreamMessage } from "../streams/stream_message"
 import { PageSnapshot } from "../drive/page_snapshot"
+import { TurboFrameMissingError } from "../errors"
 
 type VisitFallback = (location: Response | Locatable, options: Partial<VisitOptions>) => Promise<void>
 export type TurboFrameMissingEvent = CustomEvent<{ response: Response; visit: VisitFallback }>
@@ -181,15 +182,9 @@ export class FrameController
           session.frameLoaded(this.element)
           this.fetchResponseLoaded(fetchResponse)
         } else if (this.willHandleFrameMissingFromResponse(fetchResponse)) {
-          console.warn(
-            `A matching frame for #${this.element.id} was missing from the response, transforming into full-page Visit.`
-          )
-          this.visitResponse(fetchResponse.response)
+          this.handleFrameMissingFromResponse(fetchResponse)
         }
       }
-    } catch (error) {
-      console.error(error)
-      this.view.invalidate()
     } finally {
       this.fetchResponseLoaded = () => {}
     }
@@ -264,7 +259,6 @@ export class FrameController
   }
 
   async requestFailedWithResponse(request: FetchRequest, response: FetchResponse) {
-    console.error(response)
     await this.loadResponse(response)
     this.resolveVisitPromise()
   }
@@ -430,6 +424,20 @@ export class FrameController
     })
 
     return !event.defaultPrevented
+  }
+
+  private handleFrameMissingFromResponse(fetchResponse: FetchResponse) {
+    this.showFrameMissingError()
+    this.throwFrameMissingException(fetchResponse)
+  }
+
+  private showFrameMissingError() {
+    this.element.innerHTML = `<strong class="turbo-frame-error">Content missing</strong>`
+  }
+
+  private throwFrameMissingException(fetchResponse: FetchResponse) {
+    const message = `The response (${fetchResponse.statusCode}) did not contain the expected <turbo-frame id="${this.element.id}">`
+    throw new TurboFrameMissingError(message)
   }
 
   private async visitResponse(response: Response): Promise<void> {

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -437,12 +437,7 @@ export class FrameController
   }
 
   private responsePermittedToEscapeFrame(fetchResponse: FetchResponse) {
-    const allowedPathsTag = this.element.ownerDocument.querySelector<HTMLMetaElement>(
-      `meta[name=turbo-frame-escape-paths]`
-    )
-    const allowedPaths = allowedPathsTag?.content?.split(/\s+/) || []
-
-    return allowedPaths.includes(fetchResponse.location.pathname)
+    return session.snapshot.frameEscapePaths.includes(fetchResponse.location.pathname)
   }
 
   private warnResponseEscapingFrame(fetchResponse: FetchResponse) {

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -427,12 +427,8 @@ export class FrameController
   }
 
   private handleFrameMissingFromResponse(fetchResponse: FetchResponse) {
-    this.renderFrameMissingError()
+    this.view.missing()
     this.throwFrameMissingError(fetchResponse)
-  }
-
-  private renderFrameMissingError() {
-    this.element.innerHTML = `<strong class="turbo-frame-error">Content missing</strong>`
   }
 
   private throwFrameMissingError(fetchResponse: FetchResponse) {

--- a/src/core/frames/frame_view.ts
+++ b/src/core/frames/frame_view.ts
@@ -5,8 +5,8 @@ import { View, ViewRenderOptions } from "../view"
 export type FrameViewRenderOptions = ViewRenderOptions<FrameElement>
 
 export class FrameView extends View<FrameElement> {
-  invalidate() {
-    this.element.innerHTML = ""
+  missing() {
+    this.element.innerHTML = `<strong class="turbo-frame-error">Content missing</strong>`
   }
 
   get snapshot() {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -96,6 +96,8 @@
 
     <turbo-frame id="missing">
       <a id="missing-frame-link" href="/src/tests/fixtures/frames/frame.html">Missing frame</a>
+      <a id="breakout-frame-link" href="/src/tests/fixtures/frames/breakout_frame.html">Missing frame with breakout</a>
+      <a id="breakout-redirect-link" href="/__turbo/redirect?path=/src/tests/fixtures/frames/breakout_frame.html">Missing frame with breakout (via redirect)</a>
       <a id="missing-page-link" href="/missing.html">404</a>
     </turbo-frame>
 

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset="utf-8">
     <title>Frame</title>
-    <meta name="turbo-frame-breakout-paths" content="/src/tests/fixtures/frames/breakout_frame.html /somewhere_else">
+    <meta name="turbo-frame-escape-paths" content="/src/tests/fixtures/frames/escape_frame.html /somewhere_else">
 
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
@@ -98,8 +98,8 @@
 
     <turbo-frame id="missing">
       <a id="missing-frame-link" href="/src/tests/fixtures/frames/frame.html">Missing frame</a>
-      <a id="breakout-frame-link" href="/src/tests/fixtures/frames/breakout_frame.html">Missing frame with breakout</a>
-      <a id="breakout-redirect-link" href="/__turbo/redirect?path=/src/tests/fixtures/frames/breakout_frame.html">Missing frame with breakout (via redirect)</a>
+      <a id="escape-frame-link" href="/src/tests/fixtures/frames/escape_frame.html">Missing frame with escape</a>
+      <a id="escape-redirect-link" href="/__turbo/redirect?path=/src/tests/fixtures/frames/escape_frame.html">Missing frame with escape (via redirect)</a>
       <a id="missing-page-link" href="/missing.html">404</a>
     </turbo-frame>
 

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -3,6 +3,8 @@
   <head>
     <meta charset="utf-8">
     <title>Frame</title>
+    <meta name="turbo-frame-breakout-paths" content="/src/tests/fixtures/frames/breakout_frame.html /somewhere_else">
+
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
     <script>

--- a/src/tests/fixtures/frames/breakout_frame.html
+++ b/src/tests/fixtures/frames/breakout_frame.html
@@ -4,7 +4,6 @@
     <meta charset="utf-8">
     <title>Breakout frame</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
-    <meta name="turbo-frame-missing" content="visit">
   </head>
   <body>
     <h1>Breakout frame</h1>

--- a/src/tests/fixtures/frames/breakout_frame.html
+++ b/src/tests/fixtures/frames/breakout_frame.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Breakout frame</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <meta name="turbo-frame-missing" content="visit">
+  </head>
+  <body>
+    <h1>Breakout frame</h1>
+  </body>
+</html>

--- a/src/tests/fixtures/frames/escape_frame.html
+++ b/src/tests/fixtures/frames/escape_frame.html
@@ -2,10 +2,10 @@
 <html>
   <head>
     <meta charset="utf-8">
-    <title>Breakout frame</title>
+    <title>Escape frame</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
   <body>
-    <h1>Breakout frame</h1>
+    <h1>Escape frame</h1>
   </body>
 </html>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -161,7 +161,7 @@ test("successfully following a link to a page without a matching frame shows an 
   assert.match(await page.innerText("#missing"), /Content missing/)
 
   assert.exists(error)
-  assert.equal(error!.message, `The response (200) did not contain the expected <turbo-frame id="missing">`)
+  assert.match(error!.message, /The response \(200\) did not contain the expected <turbo-frame id="missing">/)
 })
 
 test("failing to follow a link to a page without a matching frame dispatches a turbo:frame-missing event", async ({
@@ -184,7 +184,38 @@ test("failing to follow a link to a page without a matching frame shows an error
   assert.match(await page.innerText("#missing"), /Content missing/)
 
   assert.exists(error)
-  assert.equal(error!.message, `The response (404) did not contain the expected <turbo-frame id="missing">`)
+  assert.match(error!.message, /The response \(404\) did not contain the expected <turbo-frame id="missing">/)
+})
+
+test("following a link to a breakoutable page without a matching frame dispatches a turbo:frame-missing event", async ({
+  page,
+}) => {
+  await page.click("#breakout-frame-link")
+  const { response } = await nextEventOnTarget(page, "missing", "turbo:frame-missing")
+
+  assert.equal(200, response.status)
+})
+
+test("successfully following a link to a breakoutable page without a matching frame performs a visit", async ({
+  page,
+}) => {
+  await page.click("#breakout-frame-link")
+
+  await nextEventNamed(page, "turbo:render")
+
+  assert.equal(await page.innerText("h1"), "Breakout frame")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/breakout_frame.html")
+})
+
+test("successfully following a link via a redirect to a breakoutable page without a matching frame performs a visit", async ({
+  page,
+}) => {
+  await page.click("#breakout-redirect-link")
+
+  await nextEventNamed(page, "turbo:render")
+
+  assert.equal(await page.innerText("h1"), "Breakout frame")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/breakout_frame.html")
 })
 
 test("test the turbo:frame-missing event following a link to a page without a matching frame can be handled", async ({

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -187,35 +187,35 @@ test("failing to follow a link to a page without a matching frame shows an error
   assert.match(error!.message, /The response \(404\) did not contain the expected <turbo-frame id="missing">/)
 })
 
-test("following a link to a breakoutable page without a matching frame dispatches a turbo:frame-missing event", async ({
+test("following a link to an escapeable page without a matching frame dispatches a turbo:frame-missing event", async ({
   page,
 }) => {
-  await page.click("#breakout-frame-link")
+  await page.click("#escape-frame-link")
   const { response } = await nextEventOnTarget(page, "missing", "turbo:frame-missing")
 
   assert.equal(200, response.status)
 })
 
-test("successfully following a link to a breakoutable page without a matching frame performs a visit", async ({
+test("successfully following a link to an escapeable page without a matching frame performs a visit", async ({
   page,
 }) => {
-  await page.click("#breakout-frame-link")
+  await page.click("#escape-frame-link")
 
   await nextEventNamed(page, "turbo:render")
 
-  assert.equal(await page.innerText("h1"), "Breakout frame")
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/breakout_frame.html")
+  assert.equal(await page.innerText("h1"), "Escape frame")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/escape_frame.html")
 })
 
-test("successfully following a link via a redirect to a breakoutable page without a matching frame performs a visit", async ({
+test("successfully following a link via a redirect to an escapeable page without a matching frame performs a visit", async ({
   page,
 }) => {
-  await page.click("#breakout-redirect-link")
+  await page.click("#escape-redirect-link")
 
   await nextEventNamed(page, "turbo:render")
 
-  assert.equal(await page.innerText("h1"), "Breakout frame")
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/breakout_frame.html")
+  assert.equal(await page.innerText("h1"), "Escape frame")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/escape_frame.html")
 })
 
 test("test the turbo:frame-missing event following a link to a page without a matching frame can be handled", async ({


### PR DESCRIPTION
**This builds on #863.**

When a frame response is missing its expected `turbo-frame` element, we consider it an error. Normally this is what we want.
    
In certain specific cases, though, it's better if a response without a matching frame is treated as a full page instead. The classic example of this is a login page being rendered in response to an expired session.

To allow specific paths to be opted in to full reloads when they are returned in response to a missing frame, this adds support for an allowlist specified in a meta tag in the document:

    <meta name="turbo-frame-escape-paths" content="/sessions/new /sign_up">

When a response is missing its frame, we check if its path matches anything in that list. If so, we perform a full page visit.

This configuration is app-wide, and would typically be included in an application layout.

