### PR TITLE
Respect `turbo-visit-control` for frame requests

### DIFF
--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -96,7 +96,8 @@
 
     <turbo-frame id="missing">
       <a id="missing-frame-link" href="/src/tests/fixtures/frames/frame.html">Missing frame</a>
-      <a id="missing-page-link" href="/missing.html">404</a>
+      <a id="missing-page-link" href="/missing.html">Missing page</a>
+      <a id="unvisitable-page-link" href="/src/tests/fixtures/frames/unvisitable.html">Unvisitable page</a>
     </turbo-frame>
 
     <turbo-frame id="body-script" target="body-script">

--- a/src/tests/fixtures/frames/unvisitable.html
+++ b/src/tests/fixtures/frames/unvisitable.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Frame</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <meta name="turbo-visit-control" content="reload" />
+  </head>
+  <body>
+    <h1>Unvisitable page loaded</h1>
+
+    <turbo-frame id="missing">
+      <h1>Frame content</h1>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -161,7 +161,16 @@ test("successfully following a link to a page without a matching frame shows an 
   assert.match(await page.innerText("#missing"), /Content missing/)
 
   assert.exists(error)
-  assert.equal(error!.message, `The response (200) did not contain the expected <turbo-frame id="missing">`)
+  assert.include(error!.message, `The response (200) did not contain the expected <turbo-frame id="missing">`)
+})
+
+test("successfully following a link to a page with `turbo-visit-control` `reload` performs a full page reload", async ({
+  page,
+}) => {
+  await page.click("#unvisitable-page-link")
+  await page.getByText("Unvisitable page loaded").waitFor()
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/unvisitable.html")
 })
 
 test("failing to follow a link to a page without a matching frame dispatches a turbo:frame-missing event", async ({
@@ -184,7 +193,7 @@ test("failing to follow a link to a page without a matching frame shows an error
   assert.match(await page.innerText("#missing"), /Content missing/)
 
   assert.exists(error)
-  assert.equal(error!.message, `The response (404) did not contain the expected <turbo-frame id="missing">`)
+  assert.include(error!.message, `The response (404) did not contain the expected <turbo-frame id="missing">`)
 })
 
 test("test the turbo:frame-missing event following a link to a page without a matching frame can be handled", async ({


### PR DESCRIPTION
Turbo normally performs a fill page reload whenever a response contains the appropriate `turbo-visit-control` meta tag:

    <meta name="turbo-visit-control" content="reload">

Such responses are considered "not visitable".

For frame requests, we have previously been ignoring any `turbo-visit-control` set in the response, and instead treating all valid frame responses as "visitable".

This commit changes this behaviour so that `turbo-visit-control` will be treated consistently for both frame and non-frame requests.

As well as being more consistent, this provides a useful escape hatch for situations where a frame request redirects to something that should be a full page reload, but which would be prevented due to that content missing the expected frame. The class example of this is when an expired session causes a frame request to be redirected to a login page. By including `turbo-visit-control` on that login page, we can ensure that it is always rendered as a full page, and never hidden by a failed frame request.