### PR TITLE
Form submissions from frames should clear cache

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -266,12 +266,16 @@ export class FrameController
     const frame = this.findFrameElement(formSubmission.formElement, formSubmission.submitter)
 
     frame.delegate.proposeVisitIfNavigatedWithAction(frame, formSubmission.formElement, formSubmission.submitter)
-
     frame.delegate.loadResponse(response)
+
+    if (formSubmission.method !== FetchMethod.get) {
+      session.clearCache()
+    }
   }
 
   formSubmissionFailedWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse) {
     this.element.delegate.loadResponse(fetchResponse)
+    session.clearCache()
   }
 
   formSubmissionErrored(formSubmission: FormSubmission, error: Error) {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -116,6 +116,8 @@
     <a id="navigate-form-redirect" href="/src/tests/fixtures/frames/form-redirect.html" data-turbo-frame="form-redirect">Visit form-redirect.html</a>
     <turbo-frame id="form-redirect"></turbo-frame>
 
+    <a id="navigate-form-redirect-as-new" href="/src/tests/fixtures/frames/form-redirect.html">Visit form-redirect.html as new page</a>
+
     <turbo-frame id="part">
       <a id="frame-part" href="/src/tests/fixtures/frames/part.html">Load #part</a>
     </turbo-frame>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -1,4 +1,4 @@
-import { Page, test } from "@playwright/test"
+import { Page, test, expect } from "@playwright/test"
 import { assert, Assertion } from "chai"
 import {
   attributeForSelector,
@@ -875,6 +875,22 @@ test("test navigating a eager frame with a link[method=get] that does not fetch 
   assert.equal(await page.textContent("h1"), "Eager-loaded frame")
   assert.equal(await page.textContent("#eager-loaded-frame h2"), "Eager-loaded frame: Loaded")
   assert.equal(pathname(page.url()), "/src/tests/fixtures/page_with_eager_frame.html")
+})
+
+test("form submissions from frames clear snapshot cache", async ({ page }) => {
+  await page.evaluate(() => {
+    document.querySelector("h1")!.textContent = "Changed"
+  })
+
+  await expect(page.locator("h1")).toHaveText("Changed")
+
+  await page.click("#navigate-form-redirect-as-new")
+  await expect(page.locator("h1")).toHaveText("Page One Form")
+  await page.click("#submit-form")
+  await expect(page.locator("h2")).toHaveText("Form Redirected")
+  await page.goBack()
+
+  await expect(page.locator("h1")).not.toHaveText("Changed")
 })
 
 async function withoutChangingEventListenersCount(page: Page, callback: () => Promise<void>) {


### PR DESCRIPTION
Usually when submitting a form with a method other than `GET`, we clear the snapshot cache. This helps to avoid cases where we might show a stale view of some data that we just mutated.

Form submissions from inside frames were not doing this. But they ought to, for the same reason: they may have mutated some data that causes other recent pages to become stale.

To avoid this, we can clear the snapshot cache after processing a non-`GET` form, or after any failed form submission, to mirror what we do when the form is outside of any frames.