### PR TITLE
Stop showing stale cache snapshot on same-page link click

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -2,7 +2,7 @@ import { Adapter } from "../native/adapter"
 import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
 import { FetchResponse } from "../../http/fetch_response"
 import { History } from "./history"
-import { getAnchor } from "../url"
+import { getAnchor, toCacheKey } from "../url"
 import { Snapshot } from "../snapshot"
 import { PageSnapshot } from "./page_snapshot"
 import { Action } from "../types"
@@ -293,11 +293,12 @@ export class Visit implements FetchRequestDelegate {
 
   loadCachedSnapshot() {
     const snapshot = this.getCachedSnapshot()
+    const isSameCacheKey = toCacheKey(this.location) === toCacheKey(this.view.lastRenderedLocation)
     if (snapshot) {
       const isPreview = this.shouldIssueRequest()
       this.render(async () => {
         this.cacheSnapshot()
-        if (this.isSamePage) {
+        if (isSameCacheKey) {
           this.adapter.visitRendered(this)
         } else {
           if (this.view.renderPromise) await this.view.renderPromise

--- a/src/tests/fixtures/timestamp.html
+++ b/src/tests/fixtures/timestamp.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <p>Hello $TIMESTAMP</p>
+    <p><a href="/__turbo/timestamp">Refresh</a></p>
+  </body>
+</html>

--- a/src/tests/fixtures/timestamp.html
+++ b/src/tests/fixtures/timestamp.html
@@ -6,7 +6,7 @@
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
   <body>
-    <p>Hello $TIMESTAMP</p>
-    <p><a href="/__turbo/timestamp">Refresh</a></p>
+    <p>Hello <span id="timestamp">$TIMESTAMP</span></p>
+    <p><a id="refresh" href="/__turbo/timestamp">Refresh</a></p>
   </body>
 </html>

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -67,6 +67,12 @@ router.get("/headers", (request, response) => {
     .send(template.replace("$HEADERS", JSON.stringify(request.headers, null, 4)))
 })
 
+router.get("/timestamp", (request, response) => {
+  const template = fs.readFileSync("src/tests/fixtures/timestamp.html").toString()
+  const timestamp = (new Date().getTime() / 1000).toString()
+  setTimeout(() => response.type("html").status(200).send(template.replaceAll("$TIMESTAMP", timestamp)), 500)
+})
+
 router.get("/delayed_response", (request, response) => {
   const fixture = path.join(__dirname, "../../src/tests/fixtures/one.html")
   setTimeout(() => response.status(200).sendFile(fixture), 1000)


### PR DESCRIPTION
Ran into a similar problem as #780 with a stale cache entry showing when using Turbo Drive and clicking a link to the current page. I've identified and fixed the stale cache bug, and added a new test to prevent regression. This new test fails on `main` and passes on my PR branch.

Here's a simple example with a page that shows the current timestamp, and has a link to itself:

**Before:**
[before.webm](https://user-images.githubusercontent.com/1057385/224182485-5217424a-7160-4592-9644-30482a475ca7.webm)
Notice how on the 2nd-and-beyond click (red flash), Turbo briefly previews an old cache entry, and the timestamp rolls backwards briefly! :open_mouth: 

Expectation: the timestamp should never roll backwards. 

**After:**
[after.webm](https://user-images.githubusercontent.com/1057385/224182498-dea20321-4b17-4086-b47f-999de39ab821.webm)
The timestamp increases monotonically without rolling back.

**Origin of caching bug:**

`Visit#loadCachedSnapshot` had a logic bug because it would `snapshot = getCachedSnapshot()` **before** it called `this.cacheSnapshot()` to preserve the old page. This is fine if you're clicking a link from one page to different page because they operate on different cache keys. However, if you're clicking a link to the current page itself, then the old and new pages have the same cache key (equivalent to the same request URL). The incorrect get-before-set results in getting an older version of the page than is currently being shown!

To fix the bug, there are a few options. One would be to reverse the order of cache operations, and synchronously save a new snapshot to the cache before loading it right back and showing it as a preview. Alternatively, one can simply skip the rendering of the preview in this case. The `if (this.isSamePage)` was attempting to do something like that, but I'm guessing the behavior of `isSamePage` conditions changed in a way that no longer makes sense to use it to see if there's this stale cache preview issue. So I've added an `isSameCacheKey` and use that to determine whether to skip rendering the cached snapshot.

I've also added a page http://localhost:9000/__turbo/timestamp so you can easily test it out.