### PR TITLE
Allow remote content to have different ID

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -466,8 +466,8 @@ export class FrameController
 
   async extractForeignFrameElement(container: ParentNode): Promise<FrameElement | null> {
     let element
-    const id = CSS.escape(this.id)
-
+    const id = CSS.escape(this.foreignId)
+    
     try {
       element = activateElement(container.querySelector(`turbo-frame#${id}`), this.sourceURL)
       if (element) {
@@ -526,6 +526,10 @@ export class FrameController
 
   get id() {
     return this.element.id
+  }
+
+  get foreignId() {
+    return this.element.foreignId
   }
 
   get enabled() {

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -81,6 +81,25 @@ export class FrameElement extends HTMLElement {
   }
 
   /**
+   * Gets the id of the foreign turbo_frame. Defaults to the current id
+   */
+  get foreignId() : string {
+    return this.getAttribute('foreign-id') || this.id
+  }
+
+
+  /**
+   * Sets the id of the foreign turbo_frame
+   */
+  set foreignId(value: string | null) {
+    if (value) {
+      this.setAttribute("foreign-id", value)
+    } else {
+      this.removeAttribute("foreign-id")
+    }
+  }
+
+  /**
    * Gets the URL to lazily load source HTML from
    */
   get src() {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -100,6 +100,10 @@
       <a id="unvisitable-page-link" href="/src/tests/fixtures/frames/unvisitable.html">Unvisitable page</a>
     </turbo-frame>
 
+    <turbo-frame id="different-id" foreign-id="hello">
+        <a href="/src/tests/fixtures/frames/hello.html">Load partial with a different id</a>
+    </turbo-frame>
+
     <turbo-frame id="body-script" target="body-script">
       <a id="body-script-link" href="/src/tests/fixtures/frames/body_script.html">Load body-script</a>
     </turbo-frame>

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -262,6 +262,15 @@ test("test following a link to a page with a matching frame does not dispatch a 
   )
 })
 
+test("test that you can specify the foreign turbo_frame id", async ({
+  page,
+}) => {
+  await page.click('#different-id a')
+  await nextBeat()
+
+  assert.match(await page.innerText("#different-id"), /Hello from a frame/)
+})
+
 test("test following a link within a frame with a target set navigates the target frame", async ({ page }) => {
   await page.click("#hello a")
   await nextBeat()


### PR DESCRIPTION
This lets you specify the id of the foreign turbo_frame tag. By default this will match the id of this turbo_frame.

This is useful if you are loading multiple turbo_frames from the same endpoint on a single page, maybe with different parameters without having duplicate IDs on the page

This would resolve #151 .

```html
<turbo-frame id="pinned_items" foreign-id="items" src="/items?pinned=1"></turbo-frame>
<turbo-frame id="items" foreign-id="items" src="/items"></turbo-frame>
<turbo-frame id="items" src="/items"></turbo-frame> <!-- equivalent to previous turbo-frame -->
```

