### PR TITLE
Export Preloader to use preloadURL dynamically

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -9,11 +9,12 @@ import { PageRenderer } from "./drive/page_renderer"
 import { PageSnapshot } from "./drive/page_snapshot"
 import { FrameRenderer } from "./frames/frame_renderer"
 import { FormSubmission } from "./drive/form_submission"
+import { Preloader } from "./drive/preloader"
 
 const session = new Session()
 const cache = new Cache(session)
 const { navigator } = session
-export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer }
+export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer, Preloader }
 export type {
   TurboBeforeCacheEvent,
   TurboBeforeRenderEvent,


### PR DESCRIPTION
# Why?
I am currently testing the preloader's capabilities and found that it could be beneficial to call `preloadURL` dynamically, for example

- using an `IntersectionObserver`, like https://github.com/GoogleChromeLabs/quicklink, for example.
- using `mouseover` events, like https://instant.page/
- using `MutationObservers`, (e.g. in Stimulus controllers) that listen for a certain data attribute to be set,
- or even in other custom web components