### PR TITLE
Add MutationObserver to Turbo Drive Preloader

### DIFF
--- a/src/core/drive/preloader.js
+++ b/src/core/drive/preloader.js
@@ -5,6 +5,13 @@ export class Preloader {
 
   constructor(delegate) {
     this.delegate = delegate
+    this.preloadLinkObserver = new MutationObserver((mutationList, observer) => {
+      mutationList.forEach((mutation) => {
+        if (mutation.attributeName !== "data-turbo-preload" || mutation.target.tagName !== "A") return
+
+        this.preloadURL(mutation.target)
+      })
+    })
   }
 
   get snapshotCache() {
@@ -15,9 +22,11 @@ export class Preloader {
     if (document.readyState === "loading") {
       return document.addEventListener("DOMContentLoaded", () => {
         this.preloadOnLoadLinksForView(document.body)
+        this.observeLinksForView(document.body)
       })
     } else {
       this.preloadOnLoadLinksForView(document.body)
+      this.observeLinksForView(document.body)
     }
   }
 
@@ -25,6 +34,13 @@ export class Preloader {
     for (const link of element.querySelectorAll(this.selector)) {
       this.preloadURL(link)
     }
+  }
+
+  observeLinksForView(element) {
+    this.preloadLinkObserver.observe(element, {
+      attributes: true,
+      subtree: true
+    })
   }
 
   async preloadURL(link) {

--- a/src/tests/fixtures/dynamic_preloading.html
+++ b/src/tests/fixtures/dynamic_preloading.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+
+<head>
+  <meta charset="utf-8">
+  <title>Preloading Page</title>
+  <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+</head>
+
+<body>
+  <a href="/src/tests/fixtures/preloaded.html" id="preload_anchor">
+    Visit preloaded page
+  </a>
+</body>
+
+</html>

--- a/src/tests/functional/preloader_tests.js
+++ b/src/tests/functional/preloader_tests.js
@@ -51,3 +51,22 @@ test("test navigates to preloaded snapshot from frame", async ({ page }) => {
     })
   )
 })
+
+test("test preloads snapshot after adding data-turbo-preload attribute at runtime", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/dynamic_preloading.html")
+  await nextBeat()
+
+  await page.evaluate(async () => {
+    document.querySelector("#preload_anchor").setAttribute("data-turbo-preload", "true")
+  })
+  await nextBeat()
+
+  assert.ok(
+    await page.evaluate(async () => {
+      const preloadedUrl = new URL("http://localhost:9000/src/tests/fixtures/preloaded.html")
+      const cache = window.Turbo.session.preloader.snapshotCache
+
+      return await cache.has(preloadedUrl)
+    })
+  )
+})


### PR DESCRIPTION
Alternative to #910 

@domchristie and @marcoroth both pointed out in private conversations that exposing the preloader as public API could lead to a lot of maintenance overhead

so I took a spike at rather enhancing it with a `MutationObserver` that preloads links of anchor elements (and only those) when `data-turbo-preload` is added to them dynamically.

Let me know what you think!