### PR TITLE
Fix navigation to the turbo-root not using Turbo Drive

### DIFF
--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -59,9 +59,5 @@ function getLastPathComponent(url: URL) {
 }
 
 function getPrefix(url: URL) {
-  return addTrailingSlash(url.origin + url.pathname)
-}
-
-function addTrailingSlash(value: string) {
-  return value.endsWith("/") ? value : value + "/"
+  return url.origin + url.pathname;
 }

--- a/src/tests/fixtures/root/index.html
+++ b/src/tests/fixtures/root/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="turbo-root" content="/src/tests/fixtures/root">
+  </head>
+  <body>
+    <section>
+      <h1>Root</h1>
+      <p><a id="link-page-inside" href="/src/tests/fixtures/root/page.html">Link to page inside root</a></p>
+      <p><a id="link-page-outside" href="/src/tests/fixtures/one.html">Link to page outside root</a></p>
+    </section>
+
+    <div id="messages"></div>
+  </body>
+</html>

--- a/src/tests/fixtures/root/page.html
+++ b/src/tests/fixtures/root/page.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="turbo-root" content="/src/tests/fixtures/root">
+  </head>
+  <body>
+    <section>
+      <h1>Root</h1>
+      <p><a id="link-root" href="/src/tests/fixtures/root">Link to root</a></p>
+    </section>
+
+    <div id="messages"></div>
+  </body>
+</html>

--- a/src/tests/functional/root_tests.ts
+++ b/src/tests/functional/root_tests.ts
@@ -1,0 +1,27 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBody, pathname, visitAction } from "../helpers/page"
+
+test("test visiting a location inside the root", async ({ page }) => {
+  page.goto("/src/tests/fixtures/root/index.html")
+  page.click("#link-page-inside")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/root/page.html")
+  assert.notEqual(await visitAction(page), "load")
+})
+
+test("test visiting the root itself", async ({ page }) => {
+  page.goto("/src/tests/fixtures/root/page.html")
+  page.click("#link-root")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/root/")
+  assert.notEqual(await visitAction(page), "load")
+})
+
+test("test visiting a location outside the root", async ({ page }) => {
+  page.goto("/src/tests/fixtures/root/index.html")
+  page.click("#link-page-outside")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "load")
+})


### PR DESCRIPTION
Fixes #912 by simply not adding a trailing slash to the root URL prefix.

I'm not sure if this is the best way to fix this issue, but it makes the test case pass and doesn't break any other tests.