### PR TITLE
Make Turbo Frames' IntersectionObserver configurable

### DIFF
--- a/src/observers/appearance_observer.js
+++ b/src/observers/appearance_observer.js
@@ -4,7 +4,7 @@ export class AppearanceObserver {
   constructor(delegate, element) {
     this.delegate = delegate
     this.element = element
-    this.intersectionObserver = new IntersectionObserver(this.intersect)
+    this.intersectionObserver = new IntersectionObserver(this.intersect, readIntersectionObserverOptions(element))
   }
 
   start() {
@@ -27,4 +27,23 @@ export class AppearanceObserver {
       this.delegate.elementAppearedInViewport(this.element)
     }
   }
+}
+
+function readIntersectionObserverOptions(element) {
+  let options = {}
+
+  if (element.hasAttribute("data-intersection-root-selector"))
+    options["root"] = document.querySelector(element.getAttribute("data-intersection-root-selector"))
+
+  if (element.hasAttribute("data-intersection-root-margin"))
+    options["rootMargin"] = element.getAttribute("data-intersection-root-margin")
+
+  if (element.hasAttribute("data-intersection-threshold")) {
+    const threshold = JSON.parse(element.getAttribute("data-intersection-threshold"))
+
+    // only a single threshold value is allowed
+    if (typeof threshold === "number") options["threshold"] = threshold
+  }
+
+  return options
 }


### PR DESCRIPTION
This PR adds configuration options akin to those controlling the autoscroll behavior to `AppearanceObserver`.

Note that I allowed only one threshold value (which could be many, see https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API#thresholds, but that doesn't make sense here).

Note further that all those options are optional, and just fall back to the default if omitted.