### PR TITLE
Rename header for preload requests

### DIFF
--- a/src/core/drive/preloader.ts
+++ b/src/core/drive/preloader.ts
@@ -42,7 +42,7 @@ export class Preloader {
     }
 
     try {
-      const response = await fetch(location.toString(), { headers: { "x-purpose": "preview", Accept: "text/html" } })
+      const response = await fetch(location.toString(), { headers: { "Sec-Purpose": "prefetch", Accept: "text/html" } })
       const responseText = await response.text()
       const snapshot = PageSnapshot.fromHTMLString(responseText)
 

--- a/src/core/drive/preloader.ts
+++ b/src/core/drive/preloader.ts
@@ -42,7 +42,7 @@ export class Preloader {
     }
 
     try {
-      const response = await fetch(location.toString(), { headers: { "VND.PREFETCH": "true", Accept: "text/html" } })
+      const response = await fetch(location.toString(), { headers: { "x-purpose": "preview", Accept: "text/html" } })
       const responseText = await response.text()
       const snapshot = PageSnapshot.fromHTMLString(responseText)
 


### PR DESCRIPTION
This PR renames header and value for preloaded requests to `x-purpose: preview`. See discussion in #924.