### PR TITLE
Proposal: pass isPreview value into the event detail in render events

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -288,7 +288,11 @@ export class FrameController
 
   // View delegate
 
-  allowsImmediateRender({ element: newFrame }: Snapshot<FrameElement>, options: ViewRenderOptions<FrameElement>) {
+  allowsImmediateRender(
+    { element: newFrame }: Snapshot<FrameElement>,
+    _isPreview: boolean,
+    options: ViewRenderOptions<FrameElement>
+  ) {
     const event = dispatch<TurboBeforeFrameRenderEvent>("turbo:before-frame-render", {
       target: this.element,
       detail: { newFrame, ...options },

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -10,7 +10,7 @@ export interface ViewRenderOptions<E> {
 }
 
 export interface ViewDelegate<E extends Element, S extends Snapshot<E>> {
-  allowsImmediateRender(snapshot: S, options: ViewRenderOptions<E>): boolean
+  allowsImmediateRender(snapshot: S, isPreview: boolean, options: ViewRenderOptions<E>): boolean
   preloadOnLoadLinksForView(element: Element): void
   viewRenderedSnapshot(snapshot: S, isPreview: boolean): void
   viewInvalidated(reason: ReloadReason): void
@@ -91,7 +91,7 @@ export abstract class View<
 
         const renderInterception = new Promise((resolve) => (this.resolveInterceptionPromise = resolve))
         const options = { resume: this.resolveInterceptionPromise, render: this.renderer.renderElement }
-        const immediateRender = this.delegate.allowsImmediateRender(snapshot, options)
+        const immediateRender = this.delegate.allowsImmediateRender(snapshot, isPreview, options)
         if (!immediateRender) await renderInterception
 
         await this.renderSnapshot(renderer)

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -36,6 +36,16 @@ test("test triggers before-render and render events", async ({ page }) => {
   assert.equal(await newBody, await page.evaluate(() => document.body.outerHTML))
 })
 
+test("test includes isPreview in render event details", async ({ page }) => {
+  await page.click("#same-origin-link")
+
+  const { isPreview } = await nextEventNamed(page, "turbo:before-render")
+  assert.equal(isPreview, false)
+
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await isPreview, false)
+})
+
 test("test triggers before-render and render events for error pages", async ({ page }) => {
   await page.click("#nonexistent-link")
   const { newBody } = await nextEventNamed(page, "turbo:before-render")


### PR DESCRIPTION
Passes the renderer's `isPreview` attribute into the event detail on `'turbo:before-render'` and `'turbo:render'` events.

`isPreview` signifies whether the content currently being rendered is from the turbo cache or not, and this bit of information is very useful for any listeners that might want to act on those two events differently for cached or non-cached content.

Eg, the following listeners:
```ruby
document.addEventListener("turbo:before-render", (event) => {
  console.log("turbo:before-render")
  console.log(event.detail)
})

document.addEventListener("turbo:render", (event) => {
  console.log("turbo:render")
  console.log(event.detail)
})
```
now produce these event details (when navigating to a page that has a cache entry, both events fire twice):
![Screenshot from 2023-05-24 13-35-12](https://github.com/hotwired/turbo/assets/9029026/8ba80590-9733-4051-895e-0263dedc1a14)

So it's now possible to do things like...
```ruby
document.addEventListener("turbo:before-render", (event) => {
  if (event.detail.isPreview) {
    resetTheThings()
    modifyTurboCachedContent(event.detail.newBody)
  } else {
    modifyFinalContent(event.detail.body)
  }
})
```