### PR TITLE
Fix for SubmitEvent polyfill breaking requestSubmit() for newer Safari versions

### DIFF
--- a/src/polyfills/submit-event.ts
+++ b/src/polyfills/submit-event.ts
@@ -23,10 +23,14 @@ function clickCaptured(event: Event) {
   // Certain versions of Safari 15 have a bug where they won't
   // populate the submitter. This hurts TurboDrive's enable/disable detection.
   // See https://bugs.webkit.org/show_bug.cgi?id=229660
-  if ("SubmitEvent" in window && /Apple Computer/.test(navigator.vendor)) {
-    prototype = window.SubmitEvent.prototype
-  } else if ("SubmitEvent" in window) {
-    return // polyfill not needed
+  if ("SubmitEvent" in window) {
+    const prototypeOfSubmitEvent = window.SubmitEvent.prototype
+
+    if (/Apple Computer/.test(navigator.vendor) && !("submitter" in prototypeOfSubmitEvent)) {
+      prototype = prototypeOfSubmitEvent
+    } else {
+      return // polyfill not needed
+    }
   }
 
   addEventListener("click", clickCaptured, true)

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -312,6 +312,11 @@
       <select id="external-select" form="form-with-external-inputs" name="greeting">
         <option selected>Hello from a replace Visit</option>
       </select>
+      <form id="form-with-buttons-triggered-by-js" action="/__turbo/redirect" data-turbo-frame="_top" method="post">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <button type="submit" formaction="/src/tests/fixtures/frames/hello.html" formmethod="get" id="button-triggered-by-js" data-turbo-action="replace" data-turbo-frame="hello">Navigate other Frame with GET</button>
+        <button type="button" onclick="this.form.requestSubmit(document.getElementById('button-triggered-by-js'))" id="request-submit-trigger">Trigger Navigate other Frame with GET</button>
+      </form>
     </turbo-frame>
     <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-outside-frame">Method link outside frame</a><br />
     <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-outside-frame">Stream link outside frame</a>

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -234,6 +234,15 @@ test("test standard GET HTMLFormElement.requestSubmit() with Turbo Action", asyn
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a replace Visit", "encodes <form> into request")
 })
 
+test("test GET HTMLFormElement.requestSubmit() triggered by javascript", async ({ page }) => {
+  await page.click("#request-submit-trigger")
+
+  await nextEventNamed(page, "turbo:load")
+
+  assert.notEqual(pathname(page.url()), "/src/tests/fixtures/one.html", "SubmitEvent was triggered without a submitter")
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "navigates #hello turbo frame")
+})
+
 test("test standard GET form submission with [data-turbo-stream] declared on the form", async ({ page }) => {
   await page.click("#standard-get-form-with-stream-opt-in-submit")
 


### PR DESCRIPTION
This PR addresses an issue where the current polyfill for SubmitEvent is not functioning as expected on the newer versions of Safari. It appears that the original webkit issue the polyfill was meant to address has been resolved, and the polyfill is now introducing undesired behavior.

Specifically, this issue is observed when invoking the requestSubmit() method with a submitter as an argument in Safari 16.5. According to the current behavior, the submitter argument seems to be ignored (ref https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement/requestSubmit).

In an attempt to correct this, I've made adjustments to the polyfill logic and added a browser test to confirm the fix. The test fails when executed in the webkit environment with the old polyfill but passes successfully with the revised version in this PR. The command used to run the test is as follows:

```bash
yarn test:browser src/tests/functional/form_submission_tests.ts:237 --project=webkit
```

Please note that for this test to work, I had to add the webkit browser to the playwright.config.ts. I've omitted those changes in this PR to keep it focused on the issue at hand.