### PR TITLE
Fix frame not advancing when using `Turbo.visit`

### DIFF
--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -352,6 +352,9 @@ export class FrameController
 
   private async visit(url: URL) {
     const request = new FetchRequest(this, FetchMethod.get, url, new URLSearchParams(), this.element)
+    if (this.element) {
+      this.action = getVisitAction(this.element)
+    }
 
     this.currentFetchRequest?.cancel()
     this.currentFetchRequest = request


### PR DESCRIPTION
When you have a frame with `data-trubo-action` attribute and use `Turbo.visit({frame: "frame-id"})` to navigate the frame the action is ignored and the url does not change. The url will change if a link was click prior to the `Turbo.visit`. Below is a gif demonstrating the issue.

![turbo-bug-repo](https://github.com/hotwired/turbo/assets/209137/19ce481c-5209-40d9-add6-1a6b74b38c28)
(the example code can been seen in https://github.com/fac/turbo-frame-visit-bug-reproduction)

This appears to happen as the `visit` method of the frame does not set the `action` on the `FrameController` as it does in the `proposeVisitIfNavigatedWithAction`.

To fix this I've set the `action` property on the frame in the visit method.

I've not had much luck writing a test for this so any help or pointers in writing a test would be much appreciated.