### PR TITLE
Add ! to the copyright banner comment

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,7 +3,7 @@ import typescript from "@rollup/plugin-typescript"
 
 import { version } from "./package.json"
 const year = new Date().getFullYear()
-const banner = `/*\nTurbo ${version}\nCopyright © ${year} 37signals LLC\n */`
+const banner = `/*!\nTurbo ${version}\nCopyright © ${year} 37signals LLC\n */`
 
 export default [
   {


### PR DESCRIPTION
So that build tools like esbuild or rollup-plugin-license can detect the banner and keep the license in the minified output.

The banner is only a few bytes, so bundle size is not a concern.

Ref. https://github.com/evanw/esbuild/issues/2745