### PR TITLE
Add test coverage toggling `[aria-busy]` for `GET` Form Submissions

### DIFF
--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -111,7 +111,7 @@ test("test standard form submission does not render a progress bar before expiri
   assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "does not show progress bar before delay")
 })
 
-test("test standard form submission with redirect response", async ({ page }) => {
+test("test standard POST form submission with redirect response", async ({ page }) => {
   await page.click("#standard form.redirect input[type=submit]")
   await nextBody(page)
 
@@ -684,7 +684,7 @@ test("test frame form submission with redirect response", async ({ page }) => {
   assert.equal(await page.getAttribute("#frame", "src"), url.href, "redirects the target frame")
 })
 
-test("test frame form submission toggles the ancestor frame's [aria-busy] attribute", async ({ page }) => {
+test("test frame POST form submission toggles the ancestor frame's [aria-busy] attribute", async ({ page }) => {
   await page.click("#frame form.redirect input[type=submit]")
   await nextBeat()
 
@@ -698,7 +698,7 @@ test("test frame form submission toggles the ancestor frame's [aria-busy] attrib
   )
 })
 
-test("test frame form submission toggles the target frame's [aria-busy] attribute", async ({ page }) => {
+test("test frame POST form submission toggles the target frame's [aria-busy] attribute", async ({ page }) => {
   await page.click('#targets-frame form.frame [type="submit"]')
   await nextBeat()
 

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -217,6 +217,16 @@ test("test standard GET form submission", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a form")
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    "true",
+    "sets [aria-busy] on the document element"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    null,
+    "removes [aria-busy] from the document element"
+  )
 })
 
 test("test standard GET HTMLFormElement.requestSubmit() with Turbo Action", async ({ page }) => {


### PR DESCRIPTION
[Coverage for 954][]

Assert that `[aria-busy="true"]` at the start of a `GET` request
initiated by a `<form>` element and handled as a page-wide navigation by
Turbo Drive.

[Coverage for 954]: https://github.com/hotwired/turbo/issues/954