### PR TITLE
Streams search for element(s) inside template tag

### DIFF
--- a/src/elements/stream_element.js
+++ b/src/elements/stream_element.js
@@ -169,22 +169,31 @@ export class StreamElement extends HTMLElement {
   }
 
   get targetElementsById() {
+    const elements = []
     const element = this.ownerDocument?.getElementById(this.target)
 
     if (element !== null) {
-      return [element]
-    } else {
-      return []
+      elements.push(element)
     }
+
+    for (const template of (this.ownerDocument?.querySelectorAll("template") || [])) {
+      const elementInTemplate = template.content.getElementById(this.target)
+
+      if (elementInTemplate !== null) {
+        elements.push(elementInTemplate)
+      }
+    }
+
+    return elements
   }
 
   get targetElementsByQuery() {
-    const elements = this.ownerDocument?.querySelectorAll(this.targets)
+    const elements = [...(this.ownerDocument?.querySelectorAll(this.targets) || [])]
 
-    if (elements.length !== 0) {
-      return Array.prototype.slice.call(elements)
-    } else {
-      return []
+    for (const template of (this.ownerDocument?.querySelectorAll("template") || [])) {
+      elements.push(...template.content.querySelectorAll(this.targets))
     }
+
+    return elements
   }
 }

--- a/src/tests/fixtures/stream.html
+++ b/src/tests/fixtures/stream.html
@@ -43,5 +43,12 @@
     <div id="message_1">
       <div>Morph me</div>
     </div>
+
+    <template id="messages_template">
+      <div id="messages" class="messages">
+        <div class="message">Message inside template</div>
+      </div>
+    </template>
+    
   </body>
 </html>

--- a/src/tests/functional/stream_tests.js
+++ b/src/tests/functional/stream_tests.js
@@ -16,7 +16,7 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("receiving a stream message", async ({ page }) => {
+test("receiving a stream message for single target", async ({ page }) => {
   const messages = await page.locator("#messages .message")
 
   assert.deepEqual(await messages.allTextContents(), ["First"])
@@ -25,6 +25,27 @@ test("receiving a stream message", async ({ page }) => {
   await nextBeat()
 
   assert.deepEqual(await messages.allTextContents(), ["First", "Hello world!"])
+})
+
+test("receiving a stream message for single target in a template", async ({ page }) => {
+  const templateNode = await page.locator("#messages_template")
+
+  const fetchMessagesInTemplateNode = (node) => {
+    const messagesNode = node.content.querySelector("#messages")
+    return messagesNode.innerText.trim().split(/\s{2,}/g)
+
+  }
+
+  let messagesInTemplate = await templateNode.evaluate(fetchMessagesInTemplateNode)
+
+  assert.deepEqual(messagesInTemplate, ["Message inside template"])
+
+  await page.click("#append-target button")
+  await nextBeat()
+
+  messagesInTemplate = await templateNode.evaluate(fetchMessagesInTemplateNode)
+
+  assert.deepEqual(messagesInTemplate, ["Message inside template", "Hello world!"])
 })
 
 test("dispatches a turbo:before-stream-render event", async ({ page }) => {
@@ -50,6 +71,27 @@ test("receiving a stream message with css selector target", async ({ page }) => 
 
   assert.deepEqual(await messages2.allTextContents(), ["Second", "Hello CSS!"])
   assert.deepEqual(await messages3.allTextContents(), ["Third", "Hello CSS!"])
+})
+
+
+test("receiving a stream message with a targets css selector for an element in a template", async ({ page }) => {
+  const templateNode = await page.locator("#messages_template")
+
+  const fetchMessagesInTemplateNode = (node) => {
+    const messagesNode = node.content.querySelector(".messages")
+    return messagesNode.innerText.trim().split(/\s{2,}/g)
+  }
+
+  let messagesInTemplate = await templateNode.evaluate(fetchMessagesInTemplateNode)
+
+  assert.deepEqual(messagesInTemplate, ["Message inside template"])
+
+  await page.click("#append-targets button")
+  await nextBeat()
+
+  messagesInTemplate = await templateNode.evaluate(fetchMessagesInTemplateNode)
+
+  assert.deepEqual(messagesInTemplate, ["Message inside template", "Hello CSS!"])
 })
 
 test("receiving a message without a template", async ({ page }) => {


### PR DESCRIPTION
Up until now `StreamElement` searches for a target (by id) or targets (by generic css selector) by traversing the DOM using `document.getElementById` or `document.querySelectorAll`. These methods doesn't search for tags inside templates. 

This PR changes `StreamElement` to also search for target/targets inside templates. 

Ref: https://github.com/hotwired/turbo/issues/932 