### PR TITLE
Dispatch turbo:load after loading 404 response

### DIFF
--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -202,6 +202,7 @@ export class Visit implements FetchRequestDelegate {
     if (this.state == VisitState.started) {
       this.state = VisitState.failed
       this.adapter.visitFailed(this)
+      this.delegate.visitCompleted(this)
     }
   }
 

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -46,7 +46,7 @@ test("test includes isPreview in render event details", async ({ page }) => {
   assert.equal(await isPreview, false)
 })
 
-test("test triggers before-render and render events for error pages", async ({ page }) => {
+test("test triggers before-render, render, and load events for error pages", async ({ page }) => {
   await page.click("#nonexistent-link")
   const { newBody } = await nextEventNamed(page, "turbo:before-render")
 
@@ -54,6 +54,8 @@ test("test triggers before-render and render events for error pages", async ({ p
 
   await nextEventNamed(page, "turbo:render")
   assert.equal(await newBody, await page.evaluate(() => document.body.outerHTML))
+
+  await nextEventNamed(page, "turbo:load")
 })
 
 test("test reloads when tracked elements change", async ({ page }) => {


### PR DESCRIPTION
I'm not 100% sure if this is the correct approach, but as far as I can tell, this just dispatches the `turbo:load` event after rendering a 404.

Fixes https://github.com/hotwired/turbo/issues/958