### PR TITLE
Fix #577: Send the Turbo-Frame header as referenced by data-turbo-frame attribute on form submission

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@hotwired/turbo",
+  "name": "@neosyne/turbo",
   "version": "7.3.0",
   "description": "The speed of a single-page web application without having to write any JavaScript",
   "module": "dist/turbo.es2017-esm.js",
@@ -12,7 +12,7 @@
   ],
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/hotwired/turbo.git"
+    "url": "git+https://github.com/neosyne/turbo.git"
   },
   "keywords": [
     "hotwire",

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -215,14 +215,15 @@ export class FrameController
 
     this.formSubmission = new FormSubmission(this, element, submitter)
     const { fetchRequest } = this.formSubmission
-    this.prepareRequest(fetchRequest)
+    const frame = this.findFrameElement(element, submitter)
+    this.prepareRequest(fetchRequest, frame)
     this.formSubmission.start()
   }
 
   // Fetch request delegate
 
-  prepareRequest(request: FetchRequest) {
-    request.headers["Turbo-Frame"] = this.id
+  prepareRequest(request: FetchRequest, frame: FrameElement = this.element) {
+    request.headers["Turbo-Frame"] = frame.id
 
     if (this.currentNavigationElement?.hasAttribute("data-turbo-stream")) {
       request.acceptResponseType(StreamMessage.contentType)

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,8 @@ import * as Turbo from "./core"
 window.Turbo = Turbo
 Turbo.start()
 
+console.info("neosyne/turbo:7.3.0#fix/form-turbo-frame")
+
 export * from "./core"
 export * from "./elements"
 export * from "./http"

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -299,8 +299,15 @@
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
         <button type="submit" data-turbo-frame="_top">Break-out of Frame with POST</button>
       </form>
+      <form action="/src/tests/fixtures/frames/hello.html" method="get" data-turbo-frame="hello">
+        <button type="submit">Navigate other Frame with GET</button>
+      </form>
       <form action="/src/tests/fixtures/frames/hello.html" method="get">
         <button type="submit" data-turbo-frame="hello">Navigate other Frame with GET</button>
+      </form>
+      <form action="/__turbo/redirect" method="post" data-turbo-frame="hello">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/hello.html">
+        <button type="submit">Navigate other Frame with POST</button>
       </form>
       <form action="/__turbo/redirect" method="post">
         <input type="hidden" name="path" value="/src/tests/fixtures/frames/hello.html">

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -861,6 +861,26 @@ test("test form submission targeting a frame submits the Turbo-Frame header", as
   assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
 })
 
+test("test form submission targeting another frame submits the Turbo-Frame header", async ({ page }) => {
+  await page.click("#frame form[method=get][data-turbo-frame=hello] [type=submit]")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
+  assert.equal("hello", fetchOptions.headers["Turbo-Frame"])
+})
+
+test("test form submission with submitter referencing another frame submits the Turbo-Frame header", async ({
+  page,
+}) => {
+  await page.click("#frame form[method=get] [type=submit][data-turbo-frame=hello]")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
+  assert.equal("hello", fetchOptions.headers["Turbo-Frame"])
+})
+
 test("test link method form submission dispatches events from a connected <form> element", async ({ page }) => {
   await page.evaluate(() =>
     new MutationObserver(([record]) => {


### PR DESCRIPTION
This PR is directly issued from the work of @inkstak on the https://github.com/hotwired/turbo/pull/579. It has just been aligned on the 7.3.0 release.