### PR TITLE
FIX: Turbo stream link setting the src of a turbo frame container

### DIFF
--- a/src/observers/form_link_click_observer.js
+++ b/src/observers/form_link_click_observer.js
@@ -20,7 +20,7 @@ export class FormLinkClickObserver {
   willFollowLinkToLocation(link, location, originalEvent) {
     return (
       this.delegate.willSubmitFormLinkToLocation(link, location, originalEvent) &&
-      link.hasAttribute("data-turbo-method")
+      (link.hasAttribute("data-turbo-method") || link.hasAttribute("data-turbo-stream"))
     )
   }
 

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -82,6 +82,19 @@ test("test following a link sets the frame element's [src]", async ({ page }) =>
   assert.equal(src.searchParams.get("key"), "value", "[src] attribute encodes query parameters")
 })
 
+test("test following a link doesn't set the frame element's [src] if the link has [data-turbo-stream]", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/form.html")
+
+  const originalSrc = await page.getAttribute("#frame", "src")
+
+  await page.click("#stream-link-get-method-inside-frame")
+  await nextBeat()
+
+  const newSrc = await page.getAttribute("#frame", "src")
+
+  assert.equal(originalSrc, newSrc, "the turbo-frame src should not change after clicking the link")
+})
+
 test("test a frame whose src references itself does not infinitely loop", async ({ page }) => {
   await page.click("#frame-self")
 


### PR DESCRIPTION
### Bug Overview
This PR addresses a specific issue that arises when using a Turbo Stream link within a Turbo Frame in a Rails 7 application. Clicking on such a link currently sets the `src` attribute of the Turbo Frame element. Although Turbo saves this state for browser history navigation, it fails to fetch the content correctly. This is because the `src` attribute is intended to be used for Turbo Stream responses, leading to unexpected behavior.

### Steps to Reproduce
1. Create a new Rails 7 application.
2. Add a Turbo Stream link inside a Turbo Frame.
3. Click the Turbo Stream link.
4. Observe that the `src` attribute of the Turbo Frame element is set.
5. Navigate the browser history.
6. Turbo fails to fetch the content.

### Visual Reference
![Illustrative example in a new Rails 7 application](https://github.com/hotwired/turbo/assets/31761693/b07607b0-7167-48e1-b713-290b6d31959d)

### Proposed Solution
This PR adds a conditional check for the `data-turbo-stream` attribute. If the attribute exists, the `src` attribute of the Turbo Frame element will not be modified, thus preserving the expected behavior.

By implementing this check, the PR aims to make the behavior of Turbo Stream links within Turbo Frames more predictable and consistent with user expectations.
