### PR TITLE
Close `StreamSource` when `<turbo-stream-source>` disconnects

### DIFF
--- a/src/elements/stream_source_element.js
+++ b/src/elements/stream_source_element.js
@@ -11,6 +11,8 @@ export class StreamSourceElement extends HTMLElement {
 
   disconnectedCallback() {
     if (this.streamSource) {
+      this.streamSource.close()
+
       disconnectStreamSource(this.streamSource)
     }
   }


### PR DESCRIPTION
Closes [hotwired/turbo#969][]

When a `<turbo-stream-source>` element is removed, close the connection that is created during connection.

[hotwired/turbo#969]: https://github.com/hotwired/turbo/issues/969