### PR TITLE
Add TypeScript #972

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,23 @@
+{
+  "root": true,
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint",
+    "prettier"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier"
+  ],
+  "rules": {
+    "@typescript-eslint/no-empty-function": "off",
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/no-namespace": ["error", { "allowDeclarations": true }],
+    "@typescript-eslint/no-non-null-assertion": "off",
+    "@typescript-eslint/no-unused-vars": ["error", { "argsIgnorePattern": "^_" }],
+    "no-unused-vars": "off",
+    "prettier/prettier": ["error"]
+  }
+}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,9 @@
     "@playwright/test": "^1.28.0",
     "@rollup/plugin-node-resolve": "13.1.3",
     "@rollup/plugin-typescript": "^11.0.0",
+    "@types/multer": "^1.4.5",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
+    "@typescript-eslint/parser": "^5.50.0",
     "@web/dev-server-esbuild": "^0.3.3",
     "@web/test-runner": "^0.15.0",
     "@web/test-runner-playwright": "^0.9.0",
@@ -47,23 +49,29 @@
     "body-parser": "^1.20.1",
     "chai": "~4.3.4",
     "eslint": "^8.13.0",
+    "eslint-config-prettier": "^8.5.0",
+    "eslint-plugin-prettier": "^4.0.0",
     "express": "^4.18.2",
     "multer": "^1.4.2",
-    "rollup": "^2.35.1"
+    "prettier": "2.6.2",
+    "rollup": "^2.35.1",
+    "ts-node": "^10.9.1",
+    "tslib": "^2.5.0",
+    "typescript": "^4.9.5"
   },
   "scripts": {
     "clean": "rm -fr dist",
     "clean:win": "rmdir /s /q dist",
-    "build": "rollup -c",
-    "build:win": "rollup -c",
+    "build": "tsc --noEmit false --declaration true --emitDeclarationOnly true --outDir dist/types && rollup -c",
+    "build:win": "tsc --noEmit false --declaration true --emitDeclarationOnly true --outDir dist/types & rollup -c",
     "watch": "rollup -wc",
-    "start": "node src/tests/server.mjs",
+    "start": "ts-node -O '{\"module\":\"commonjs\"}' src/tests/server.ts",
     "test": "yarn test:unit && yarn test:browser",
     "test:browser": "playwright test",
     "test:unit": "NODE_OPTIONS=--inspect web-test-runner",
     "test:unit:win": "SET NODE_OPTIONS=--inspect & web-test-runner",
     "release": "yarn build && npm publish",
-    "lint": "eslint . --ext .js"
+    "lint": "eslint . --ext .ts"
   },
   "engines": {
     "node": ">= 14"

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,28 @@
+import { type PlaywrightTestConfig, devices } from "@playwright/test"
+
+const config: PlaywrightTestConfig = {
+  projects: [
+    {
+      name: "chrome",
+      use: { ...devices["Desktop Chrome"] },
+    },
+    {
+      name: "firefox",
+      use: { ...devices["Desktop Firefox"] },
+    },
+  ],
+  retries: 2,
+  testDir: "./src/tests/",
+  testMatch: /(functional|integration)\/.*_tests\.ts/,
+  webServer: {
+    command: "yarn start",
+    url: "http://localhost:9000/src/tests/fixtures/test.js",
+    timeout: 120 * 1000,
+    reuseExistingServer: !process.env.CI,
+  },
+  use: {
+    baseURL: "http://localhost:9000/",
+  },
+}
+
+export default config

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -1,4 +1,5 @@
 import resolve from "@rollup/plugin-node-resolve"
+import typescript from "@rollup/plugin-typescript"
 
 import { version } from "./package.json"
 const year = new Date().getFullYear()
@@ -6,7 +7,7 @@ const banner = `/*!\nTurbo ${version}\nCopyright © ${year} 37signals LLC\n */`
 
 export default [
   {
-    input: "src/index.js",
+    input: "src/index.ts",
     output: [
       {
         name: "Turbo",
@@ -20,7 +21,10 @@ export default [
         banner
       }
     ],
-    plugins: [resolve()],
+    plugins: [
+      resolve(),
+      typescript()
+    ],
     watch: {
       include: "src/**"
     }

--- a/src/core/bardo.ts
+++ b/src/core/bardo.ts
@@ -1,0 +1,74 @@
+import { PermanentElementMap } from "./snapshot"
+
+export interface BardoDelegate {
+  enteringBardo(currentPermanentElement: Element, newPermanentElement: Element): void
+  leavingBardo(currentPermanentElement: Element): void
+}
+
+export class Bardo {
+  readonly permanentElementMap: PermanentElementMap
+  readonly delegate: BardoDelegate
+
+  static async preservingPermanentElements(
+    delegate: BardoDelegate,
+    permanentElementMap: PermanentElementMap,
+    callback: () => void
+  ) {
+    const bardo = new this(delegate, permanentElementMap)
+    bardo.enter()
+    await callback()
+    bardo.leave()
+  }
+
+  constructor(delegate: BardoDelegate, permanentElementMap: PermanentElementMap) {
+    this.delegate = delegate
+    this.permanentElementMap = permanentElementMap
+  }
+
+  enter() {
+    for (const id in this.permanentElementMap) {
+      const [currentPermanentElement, newPermanentElement] = this.permanentElementMap[id]
+      this.delegate.enteringBardo(currentPermanentElement, newPermanentElement)
+      this.replaceNewPermanentElementWithPlaceholder(newPermanentElement)
+    }
+  }
+
+  leave() {
+    for (const id in this.permanentElementMap) {
+      const [currentPermanentElement] = this.permanentElementMap[id]
+      this.replaceCurrentPermanentElementWithClone(currentPermanentElement)
+      this.replacePlaceholderWithPermanentElement(currentPermanentElement)
+      this.delegate.leavingBardo(currentPermanentElement)
+    }
+  }
+
+  replaceNewPermanentElementWithPlaceholder(permanentElement: Element) {
+    const placeholder = createPlaceholderForPermanentElement(permanentElement)
+    permanentElement.replaceWith(placeholder)
+  }
+
+  replaceCurrentPermanentElementWithClone(permanentElement: Element) {
+    const clone = permanentElement.cloneNode(true)
+    permanentElement.replaceWith(clone)
+  }
+
+  replacePlaceholderWithPermanentElement(permanentElement: Element) {
+    const placeholder = this.getPlaceholderById(permanentElement.id)
+    placeholder?.replaceWith(permanentElement)
+  }
+
+  getPlaceholderById(id: string) {
+    return this.placeholders.find((element) => element.content == id)
+  }
+
+  get placeholders(): HTMLMetaElement[] {
+    return [...document.querySelectorAll<HTMLMetaElement>("meta[name=turbo-permanent-placeholder][content]")]
+  }
+}
+
+function createPlaceholderForPermanentElement(permanentElement: Element) {
+  const element = document.createElement("meta")
+  element.setAttribute("name", "turbo-permanent-placeholder")
+  element.setAttribute("content", permanentElement.id)
+  return element
+}

--- a/src/core/cache.ts
+++ b/src/core/cache.ts
@@ -1,0 +1,30 @@
+import { Session } from "./session"
+import { setMetaContent } from "../util"
+
+export class Cache {
+  readonly session: Session
+
+  constructor(session: Session) {
+    this.session = session
+  }
+
+  clear() {
+    this.session.clearCache()
+  }
+
+  resetCacheControl() {
+    this.setCacheControl("")
+  }
+
+  exemptPageFromCache() {
+    this.setCacheControl("no-cache")
+  }
+
+  exemptPageFromPreview() {
+    this.setCacheControl("no-preview")
+  }
+
+  private setCacheControl(value: string) {
+    setMetaContent("turbo-cache-control", value)
+  }
+}

--- a/src/core/drive/error_renderer.ts
+++ b/src/core/drive/error_renderer.ts
@@ -1,0 +1,40 @@
+import { PageSnapshot } from "./page_snapshot"
+import { Renderer } from "../renderer"
+import { activateScriptElement } from "../../util"
+
+export class ErrorRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
+  static renderElement(currentElement: HTMLBodyElement, newElement: HTMLBodyElement) {
+    const { documentElement, body } = document
+
+    documentElement.replaceChild(newElement, body)
+  }
+
+  async render() {
+    this.replaceHeadAndBody()
+    this.activateScriptElements()
+  }
+
+  replaceHeadAndBody() {
+    const { documentElement, head } = document
+    documentElement.replaceChild(this.newHead, head)
+    this.renderElement(this.currentElement, this.newElement)
+  }
+
+  activateScriptElements() {
+    for (const replaceableElement of this.scriptElements) {
+      const parentNode = replaceableElement.parentNode
+      if (parentNode) {
+        const element = activateScriptElement(replaceableElement)
+        parentNode.replaceChild(element, replaceableElement)
+      }
+    }
+  }
+
+  get newHead() {
+    return this.newSnapshot.headSnapshot.element
+  }
+
+  get scriptElements() {
+    return document.documentElement.querySelectorAll("script")
+  }
+}

--- a/src/core/drive/form_submission.ts
+++ b/src/core/drive/form_submission.ts
@@ -1,0 +1,293 @@
+import { FetchRequest, FetchMethod, fetchMethodFromString } from "../../http/fetch_request"
+import { FetchResponse } from "../../http/fetch_response"
+import { expandURL } from "../url"
+import { dispatch, getAttribute, getMetaContent, hasAttribute } from "../../util"
+import { StreamMessage } from "../streams/stream_message"
+
+export interface FormSubmissionDelegate {
+  formSubmissionStarted(formSubmission: FormSubmission): void
+  formSubmissionSucceededWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse): void
+  formSubmissionFailedWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse): void
+  formSubmissionErrored(formSubmission: FormSubmission, error: Error): void
+  formSubmissionFinished(formSubmission: FormSubmission): void
+}
+
+export type FormSubmissionResult = { success: boolean; fetchResponse: FetchResponse } | { success: false; error: Error }
+
+export enum FormSubmissionState {
+  initialized,
+  requesting,
+  waiting,
+  receiving,
+  stopping,
+  stopped,
+}
+
+enum FormEnctype {
+  urlEncoded = "application/x-www-form-urlencoded",
+  multipart = "multipart/form-data",
+  plain = "text/plain",
+}
+
+export type TurboSubmitStartEvent = CustomEvent<{ formSubmission: FormSubmission }>
+export type TurboSubmitEndEvent = CustomEvent<
+  { formSubmission: FormSubmission } & { [K in keyof FormSubmissionResult]?: FormSubmissionResult[K] }
+>
+
+function formEnctypeFromString(encoding: string): FormEnctype {
+  switch (encoding.toLowerCase()) {
+    case FormEnctype.multipart:
+      return FormEnctype.multipart
+    case FormEnctype.plain:
+      return FormEnctype.plain
+    default:
+      return FormEnctype.urlEncoded
+  }
+}
+
+export class FormSubmission {
+  readonly delegate: FormSubmissionDelegate
+  readonly formElement: HTMLFormElement
+  readonly submitter?: HTMLElement
+  readonly formData: FormData
+  readonly location: URL
+  readonly fetchRequest: FetchRequest
+  readonly mustRedirect: boolean
+  state = FormSubmissionState.initialized
+  result?: FormSubmissionResult
+  originalSubmitText?: string
+
+  static confirmMethod(
+    message: string,
+    _element: HTMLFormElement,
+    _submitter: HTMLElement | undefined
+  ): Promise<boolean> {
+    return Promise.resolve(confirm(message))
+  }
+
+  constructor(
+    delegate: FormSubmissionDelegate,
+    formElement: HTMLFormElement,
+    submitter?: HTMLElement,
+    mustRedirect = false
+  ) {
+    this.delegate = delegate
+    this.formElement = formElement
+    this.submitter = submitter
+    this.formData = buildFormData(formElement, submitter)
+    this.location = expandURL(this.action)
+    if (this.method == FetchMethod.get) {
+      mergeFormDataEntries(this.location, [...this.body.entries()])
+    }
+    this.fetchRequest = new FetchRequest(this, this.method, this.location, this.body, this.formElement)
+    this.mustRedirect = mustRedirect
+  }
+
+  get method(): FetchMethod {
+    const method = this.submitter?.getAttribute("formmethod") || this.formElement.getAttribute("method") || ""
+    return fetchMethodFromString(method.toLowerCase()) || FetchMethod.get
+  }
+
+  get action(): string {
+    const formElementAction = typeof this.formElement.action === "string" ? this.formElement.action : null
+
+    if (this.submitter?.hasAttribute("formaction")) {
+      return this.submitter.getAttribute("formaction") || ""
+    } else {
+      return this.formElement.getAttribute("action") || formElementAction || ""
+    }
+  }
+
+  get body() {
+    if (this.enctype == FormEnctype.urlEncoded || this.method == FetchMethod.get) {
+      return new URLSearchParams(this.stringFormData)
+    } else {
+      return this.formData
+    }
+  }
+
+  get enctype(): FormEnctype {
+    return formEnctypeFromString(this.submitter?.getAttribute("formenctype") || this.formElement.enctype)
+  }
+
+  get isSafe() {
+    return this.fetchRequest.isSafe
+  }
+
+  get stringFormData() {
+    return [...this.formData].reduce((entries, [name, value]) => {
+      return entries.concat(typeof value == "string" ? [[name, value]] : [])
+    }, [] as [string, string][])
+  }
+
+  // The submission process
+
+  async start() {
+    const { initialized, requesting } = FormSubmissionState
+    const confirmationMessage = getAttribute("data-turbo-confirm", this.submitter, this.formElement)
+
+    if (typeof confirmationMessage === "string") {
+      const answer = await FormSubmission.confirmMethod(confirmationMessage, this.formElement, this.submitter)
+      if (!answer) {
+        return
+      }
+    }
+
+    if (this.state == initialized) {
+      this.state = requesting
+      return this.fetchRequest.perform()
+    }
+  }
+
+  stop() {
+    const { stopping, stopped } = FormSubmissionState
+    if (this.state != stopping && this.state != stopped) {
+      this.state = stopping
+      this.fetchRequest.cancel()
+      return true
+    }
+  }
+
+  // Fetch request delegate
+
+  prepareRequest(request: FetchRequest) {
+    if (!request.isSafe) {
+      const token = getCookieValue(getMetaContent("csrf-param")) || getMetaContent("csrf-token")
+      if (token) {
+        request.headers["X-CSRF-Token"] = token
+      }
+    }
+
+    if (this.requestAcceptsTurboStreamResponse(request)) {
+      request.acceptResponseType(StreamMessage.contentType)
+    }
+  }
+
+  requestStarted(_request: FetchRequest) {
+    this.state = FormSubmissionState.waiting
+    this.submitter?.setAttribute("disabled", "")
+    this.setSubmitsWith()
+    dispatch<TurboSubmitStartEvent>("turbo:submit-start", {
+      target: this.formElement,
+      detail: { formSubmission: this },
+    })
+    this.delegate.formSubmissionStarted(this)
+  }
+
+  requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse) {
+    this.result = { success: response.succeeded, fetchResponse: response }
+  }
+
+  requestSucceededWithResponse(request: FetchRequest, response: FetchResponse) {
+    if (response.clientError || response.serverError) {
+      this.delegate.formSubmissionFailedWithResponse(this, response)
+    } else if (this.requestMustRedirect(request) && responseSucceededWithoutRedirect(response)) {
+      const error = new Error("Form responses must redirect to another location")
+      this.delegate.formSubmissionErrored(this, error)
+    } else {
+      this.state = FormSubmissionState.receiving
+      this.result = { success: true, fetchResponse: response }
+      this.delegate.formSubmissionSucceededWithResponse(this, response)
+    }
+  }
+
+  requestFailedWithResponse(request: FetchRequest, response: FetchResponse) {
+    this.result = { success: false, fetchResponse: response }
+    this.delegate.formSubmissionFailedWithResponse(this, response)
+  }
+
+  requestErrored(request: FetchRequest, error: Error) {
+    this.result = { success: false, error }
+    this.delegate.formSubmissionErrored(this, error)
+  }
+
+  requestFinished(_request: FetchRequest) {
+    this.state = FormSubmissionState.stopped
+    this.submitter?.removeAttribute("disabled")
+    this.resetSubmitterText()
+    dispatch<TurboSubmitEndEvent>("turbo:submit-end", {
+      target: this.formElement,
+      detail: { formSubmission: this, ...this.result },
+    })
+    this.delegate.formSubmissionFinished(this)
+  }
+
+  // Private
+
+  setSubmitsWith() {
+    if (!this.submitter || !this.submitsWith) return
+
+    if (this.submitter.matches("button")) {
+      this.originalSubmitText = this.submitter.innerHTML
+      this.submitter.innerHTML = this.submitsWith
+    } else if (this.submitter.matches("input")) {
+      const input = this.submitter as HTMLInputElement
+      this.originalSubmitText = input.value
+      input.value = this.submitsWith
+    }
+  }
+
+  resetSubmitterText() {
+    if (!this.submitter || !this.originalSubmitText) return
+
+    if (this.submitter.matches("button")) {
+      this.submitter.innerHTML = this.originalSubmitText
+    } else if (this.submitter.matches("input")) {
+      const input = this.submitter as HTMLInputElement
+      input.value = this.originalSubmitText
+    }
+  }
+
+  requestMustRedirect(request: FetchRequest) {
+    return !request.isSafe && this.mustRedirect
+  }
+
+  requestAcceptsTurboStreamResponse(request: FetchRequest) {
+    return !request.isSafe || hasAttribute("data-turbo-stream", this.submitter, this.formElement)
+  }
+
+  get submitsWith() {
+    return this.submitter?.getAttribute("data-turbo-submits-with")
+  }
+}
+
+function buildFormData(formElement: HTMLFormElement, submitter?: HTMLElement): FormData {
+  const formData = new FormData(formElement)
+  const name = submitter?.getAttribute("name")
+  const value = submitter?.getAttribute("value")
+
+  if (name) {
+    formData.append(name, value || "")
+  }
+
+  return formData
+}
+
+function getCookieValue(cookieName: string | null) {
+  if (cookieName != null) {
+    const cookies = document.cookie ? document.cookie.split("; ") : []
+    const cookie = cookies.find((cookie) => cookie.startsWith(cookieName))
+    if (cookie) {
+      const value = cookie.split("=").slice(1).join("=")
+      return value ? decodeURIComponent(value) : undefined
+    }
+  }
+}
+
+function responseSucceededWithoutRedirect(response: FetchResponse) {
+  return response.statusCode == 200 && !response.redirected
+}
+
+function mergeFormDataEntries(url: URL, entries: [string, FormDataEntryValue][]): URL {
+  const searchParams = new URLSearchParams()
+
+  for (const [name, value] of entries) {
+    if (value instanceof File) continue
+
+    searchParams.append(name, value)
+  }
+
+  url.search = searchParams.toString()
+
+  return url
+}

--- a/src/core/drive/head_snapshot.ts
+++ b/src/core/drive/head_snapshot.ts
@@ -1,0 +1,124 @@
+import { Snapshot } from "../snapshot"
+
+type ElementDetailMap = { [outerHTML: string]: ElementDetails }
+
+type ElementDetails = {
+  type?: ElementType
+  tracked: boolean
+  elements: Element[]
+}
+
+type ElementType = "script" | "stylesheet"
+
+export class HeadSnapshot extends Snapshot<HTMLHeadElement> {
+  readonly detailsByOuterHTML = this.children
+    .filter((element) => !elementIsNoscript(element))
+    .map((element) => elementWithoutNonce(element))
+    .reduce((result, element) => {
+      const { outerHTML } = element
+      const details: ElementDetails =
+        outerHTML in result
+          ? result[outerHTML]
+          : {
+              type: elementType(element),
+              tracked: elementIsTracked(element),
+              elements: [],
+            }
+      return {
+        ...result,
+        [outerHTML]: {
+          ...details,
+          elements: [...details.elements, element],
+        },
+      }
+    }, {} as ElementDetailMap)
+
+  get trackedElementSignature(): string {
+    return Object.keys(this.detailsByOuterHTML)
+      .filter((outerHTML) => this.detailsByOuterHTML[outerHTML].tracked)
+      .join("")
+  }
+
+  getScriptElementsNotInSnapshot(snapshot: HeadSnapshot) {
+    return this.getElementsMatchingTypeNotInSnapshot<HTMLScriptElement>("script", snapshot)
+  }
+
+  getStylesheetElementsNotInSnapshot(snapshot: HeadSnapshot) {
+    return this.getElementsMatchingTypeNotInSnapshot<HTMLLinkElement>("stylesheet", snapshot)
+  }
+
+  getElementsMatchingTypeNotInSnapshot<T extends Element>(matchedType: ElementType, snapshot: HeadSnapshot): T[] {
+    return Object.keys(this.detailsByOuterHTML)
+      .filter((outerHTML) => !(outerHTML in snapshot.detailsByOuterHTML))
+      .map((outerHTML) => this.detailsByOuterHTML[outerHTML])
+      .filter(({ type }) => type == matchedType)
+      .map(({ elements: [element] }) => element) as T[]
+  }
+
+  get provisionalElements(): Element[] {
+    return Object.keys(this.detailsByOuterHTML).reduce((result, outerHTML) => {
+      const { type, tracked, elements } = this.detailsByOuterHTML[outerHTML]
+      if (type == null && !tracked) {
+        return [...result, ...elements]
+      } else if (elements.length > 1) {
+        return [...result, ...elements.slice(1)]
+      } else {
+        return result
+      }
+    }, [] as Element[])
+  }
+
+  getMetaValue(name: string): string | null {
+    const element = this.findMetaElementByName(name)
+    return element ? element.getAttribute("content") : null
+  }
+
+  findMetaElementByName(name: string) {
+    return Object.keys(this.detailsByOuterHTML).reduce((result, outerHTML) => {
+      const {
+        elements: [element],
+      } = this.detailsByOuterHTML[outerHTML]
+      return elementIsMetaElementWithName(element, name) ? element : result
+    }, undefined as Element | undefined)
+  }
+}
+
+function elementType(element: Element) {
+  if (elementIsScript(element)) {
+    return "script"
+  } else if (elementIsStylesheet(element)) {
+    return "stylesheet"
+  }
+}
+
+function elementIsTracked(element: Element) {
+  return element.getAttribute("data-turbo-track") == "reload"
+}
+
+function elementIsScript(element: Element) {
+  const tagName = element.localName
+  return tagName == "script"
+}
+
+function elementIsNoscript(element: Element) {
+  const tagName = element.localName
+  return tagName == "noscript"
+}
+
+function elementIsStylesheet(element: Element) {
+  const tagName = element.localName
+  return tagName == "style" || (tagName == "link" && element.getAttribute("rel") == "stylesheet")
+}
+
+function elementIsMetaElementWithName(element: Element, name: string) {
+  const tagName = element.localName
+  return tagName == "meta" && element.getAttribute("name") == name
+}
+
+function elementWithoutNonce(element: Element) {
+  if (element.hasAttribute("nonce")) {
+    element.setAttribute("nonce", "")
+  }
+
+  return element
+}

--- a/src/core/drive/history.ts
+++ b/src/core/drive/history.ts
@@ -1,0 +1,121 @@
+import { Position } from "../types"
+import { nextMicrotask, uuid } from "../../util"
+
+export interface HistoryDelegate {
+  historyPoppedToLocationWithRestorationIdentifier(location: URL, restorationIdentifier: string): void
+}
+
+type HistoryMethod = (this: typeof history, state: any, title: string, url?: string | null | undefined) => void
+
+export type RestorationData = { scrollPosition?: Position }
+
+export type RestorationDataMap = {
+  [restorationIdentifier: string]: RestorationData
+}
+
+export class History {
+  readonly delegate: HistoryDelegate
+  location!: URL
+  restorationIdentifier = uuid()
+  restorationData: RestorationDataMap = {}
+  started = false
+  pageLoaded = false
+  previousScrollRestoration?: ScrollRestoration
+
+  constructor(delegate: HistoryDelegate) {
+    this.delegate = delegate
+  }
+
+  start() {
+    if (!this.started) {
+      addEventListener("popstate", this.onPopState, false)
+      addEventListener("load", this.onPageLoad, false)
+      this.started = true
+      this.replace(new URL(window.location.href))
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      removeEventListener("popstate", this.onPopState, false)
+      removeEventListener("load", this.onPageLoad, false)
+      this.started = false
+    }
+  }
+
+  push(location: URL, restorationIdentifier?: string) {
+    this.update(history.pushState, location, restorationIdentifier)
+  }
+
+  replace(location: URL, restorationIdentifier?: string) {
+    this.update(history.replaceState, location, restorationIdentifier)
+  }
+
+  update(method: HistoryMethod, location: URL, restorationIdentifier = uuid()) {
+    const state = { turbo: { restorationIdentifier } }
+    method.call(history, state, "", location.href)
+    this.location = location
+    this.restorationIdentifier = restorationIdentifier
+  }
+
+  // Restoration data
+
+  getRestorationDataForIdentifier(restorationIdentifier: string): RestorationData {
+    return this.restorationData[restorationIdentifier] || {}
+  }
+
+  updateRestorationData(additionalData: Partial<RestorationData>) {
+    const { restorationIdentifier } = this
+    const restorationData = this.restorationData[restorationIdentifier]
+    this.restorationData[restorationIdentifier] = {
+      ...restorationData,
+      ...additionalData,
+    }
+  }
+
+  // Scroll restoration
+
+  assumeControlOfScrollRestoration() {
+    if (!this.previousScrollRestoration) {
+      this.previousScrollRestoration = history.scrollRestoration ?? "auto"
+      history.scrollRestoration = "manual"
+    }
+  }
+
+  relinquishControlOfScrollRestoration() {
+    if (this.previousScrollRestoration) {
+      history.scrollRestoration = this.previousScrollRestoration
+      delete this.previousScrollRestoration
+    }
+  }
+
+  // Event handlers
+
+  onPopState = (event: PopStateEvent) => {
+    if (this.shouldHandlePopState()) {
+      const { turbo } = event.state || {}
+      if (turbo) {
+        this.location = new URL(window.location.href)
+        const { restorationIdentifier } = turbo
+        this.restorationIdentifier = restorationIdentifier
+        this.delegate.historyPoppedToLocationWithRestorationIdentifier(this.location, restorationIdentifier)
+      }
+    }
+  }
+
+  onPageLoad = async (_event: Event) => {
+    await nextMicrotask()
+    this.pageLoaded = true
+  }
+
+  // Private
+
+  shouldHandlePopState() {
+    // Safari dispatches a popstate event after window's load event, ignore it
+    return this.pageIsLoaded()
+  }
+
+  pageIsLoaded() {
+    return this.pageLoaded || document.readyState == "complete"
+  }
+}

--- a/src/core/drive/navigator.ts
+++ b/src/core/drive/navigator.ts
@@ -1,0 +1,169 @@
+import { Action } from "../types"
+import { getVisitAction } from "../../util"
+import { FetchResponse } from "../../http/fetch_response"
+import { FormSubmission } from "./form_submission"
+import { expandURL, getAnchor, getRequestURL, Locatable, locationIsVisitable } from "../url"
+import { Visit, VisitDelegate, VisitOptions } from "./visit"
+import { PageSnapshot } from "./page_snapshot"
+
+export type NavigatorDelegate = VisitDelegate & {
+  allowsVisitingLocationWithAction(location: URL, action?: Action): boolean
+  visitProposedToLocation(location: URL, options: Partial<VisitOptions>): void
+  notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL): void
+}
+
+export class Navigator {
+  readonly delegate: NavigatorDelegate
+  formSubmission?: FormSubmission
+  currentVisit?: Visit
+
+  constructor(delegate: NavigatorDelegate) {
+    this.delegate = delegate
+  }
+
+  proposeVisit(location: URL, options: Partial<VisitOptions> = {}) {
+    if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
+      if (locationIsVisitable(location, this.view.snapshot.rootLocation)) {
+        this.delegate.visitProposedToLocation(location, options)
+      } else {
+        window.location.href = location.toString()
+      }
+    }
+  }
+
+  startVisit(locatable: Locatable, restorationIdentifier: string, options: Partial<VisitOptions> = {}) {
+    this.stop()
+    this.currentVisit = new Visit(this, expandURL(locatable), restorationIdentifier, {
+      referrer: this.location,
+      ...options,
+    })
+    this.currentVisit.start()
+  }
+
+  submitForm(form: HTMLFormElement, submitter?: HTMLElement) {
+    this.stop()
+    this.formSubmission = new FormSubmission(this, form, submitter, true)
+
+    this.formSubmission.start()
+  }
+
+  stop() {
+    if (this.formSubmission) {
+      this.formSubmission.stop()
+      delete this.formSubmission
+    }
+
+    if (this.currentVisit) {
+      this.currentVisit.cancel()
+      delete this.currentVisit
+    }
+  }
+
+  get adapter() {
+    return this.delegate.adapter
+  }
+
+  get view() {
+    return this.delegate.view
+  }
+
+  get history() {
+    return this.delegate.history
+  }
+
+  // Form submission delegate
+
+  formSubmissionStarted(formSubmission: FormSubmission) {
+    // Not all adapters implement formSubmissionStarted
+    if (typeof this.adapter.formSubmissionStarted === "function") {
+      this.adapter.formSubmissionStarted(formSubmission)
+    }
+  }
+
+  async formSubmissionSucceededWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse) {
+    if (formSubmission == this.formSubmission) {
+      const responseHTML = await fetchResponse.responseHTML
+      if (responseHTML) {
+        const shouldCacheSnapshot = formSubmission.isSafe
+        if (!shouldCacheSnapshot) {
+          this.view.clearSnapshotCache()
+        }
+
+        const { statusCode, redirected } = fetchResponse
+        const action = this.getActionForFormSubmission(formSubmission)
+        const visitOptions = {
+          action,
+          shouldCacheSnapshot,
+          response: { statusCode, responseHTML, redirected },
+        }
+        this.proposeVisit(fetchResponse.location, visitOptions)
+      }
+    }
+  }
+
+  async formSubmissionFailedWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse) {
+    const responseHTML = await fetchResponse.responseHTML
+
+    if (responseHTML) {
+      const snapshot = PageSnapshot.fromHTMLString(responseHTML)
+      if (fetchResponse.serverError) {
+        await this.view.renderError(snapshot, this.currentVisit)
+      } else {
+        await this.view.renderPage(snapshot, false, true, this.currentVisit)
+      }
+      this.view.scrollToTop()
+      this.view.clearSnapshotCache()
+    }
+  }
+
+  formSubmissionErrored(formSubmission: FormSubmission, error: Error) {
+    console.error(error)
+  }
+
+  formSubmissionFinished(formSubmission: FormSubmission) {
+    // Not all adapters implement formSubmissionFinished
+    if (typeof this.adapter.formSubmissionFinished === "function") {
+      this.adapter.formSubmissionFinished(formSubmission)
+    }
+  }
+
+  // Visit delegate
+
+  visitStarted(visit: Visit) {
+    this.delegate.visitStarted(visit)
+  }
+
+  visitCompleted(visit: Visit) {
+    this.delegate.visitCompleted(visit)
+  }
+
+  locationWithActionIsSamePage(location: URL, action?: Action): boolean {
+    const anchor = getAnchor(location)
+    const currentAnchor = getAnchor(this.view.lastRenderedLocation)
+    const isRestorationToTop = action === "restore" && typeof anchor === "undefined"
+
+    return (
+      action !== "replace" &&
+      getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
+      (isRestorationToTop || (anchor != null && anchor !== currentAnchor))
+    )
+  }
+
+  visitScrolledToSamePageLocation(oldURL: URL, newURL: URL) {
+    this.delegate.visitScrolledToSamePageLocation(oldURL, newURL)
+  }
+
+  // Visits
+
+  get location() {
+    return this.history.location
+  }
+
+  get restorationIdentifier() {
+    return this.history.restorationIdentifier
+  }
+
+  getActionForFormSubmission({ submitter, formElement }: FormSubmission): Action {
+    return getVisitAction(submitter, formElement) || "advance"
+  }
+}

--- a/src/core/drive/page_renderer.ts
+++ b/src/core/drive/page_renderer.ts
@@ -1,0 +1,183 @@
+import { Renderer } from "../renderer"
+import { PageSnapshot } from "./page_snapshot"
+import { ReloadReason } from "../native/browser_adapter"
+import { activateScriptElement, waitForLoad } from "../../util"
+
+export class PageRenderer extends Renderer<HTMLBodyElement, PageSnapshot> {
+  static renderElement(currentElement: HTMLBodyElement, newElement: HTMLBodyElement) {
+    if (document.body && newElement instanceof HTMLBodyElement) {
+      document.body.replaceWith(newElement)
+    } else {
+      document.documentElement.appendChild(newElement)
+    }
+  }
+
+  get shouldRender() {
+    return this.newSnapshot.isVisitable && this.trackedElementsAreIdentical
+  }
+
+  get reloadReason(): ReloadReason {
+    if (!this.newSnapshot.isVisitable) {
+      return {
+        reason: "turbo_visit_control_is_reload",
+      }
+    }
+
+    if (!this.trackedElementsAreIdentical) {
+      return {
+        reason: "tracked_element_mismatch",
+      }
+    }
+  }
+
+  async prepareToRender() {
+    await this.mergeHead()
+  }
+
+  async render() {
+    if (this.willRender) {
+      await this.replaceBody()
+    }
+  }
+
+  finishRendering() {
+    super.finishRendering()
+    if (!this.isPreview) {
+      this.focusFirstAutofocusableElement()
+    }
+  }
+
+  get currentHeadSnapshot() {
+    return this.currentSnapshot.headSnapshot
+  }
+
+  get newHeadSnapshot() {
+    return this.newSnapshot.headSnapshot
+  }
+
+  get newElement() {
+    return this.newSnapshot.element
+  }
+
+  async mergeHead() {
+    const mergedHeadElements = this.mergeProvisionalElements()
+    const newStylesheetElements = this.copyNewHeadStylesheetElements()
+    this.copyNewHeadScriptElements()
+    await mergedHeadElements
+    await newStylesheetElements
+  }
+
+  async replaceBody() {
+    await this.preservingPermanentElements(async () => {
+      this.activateNewBody()
+      await this.assignNewBody()
+    })
+  }
+
+  get trackedElementsAreIdentical() {
+    return this.currentHeadSnapshot.trackedElementSignature == this.newHeadSnapshot.trackedElementSignature
+  }
+
+  async copyNewHeadStylesheetElements() {
+    const loadingElements = []
+
+    for (const element of this.newHeadStylesheetElements) {
+      loadingElements.push(waitForLoad(element as HTMLLinkElement))
+
+      document.head.appendChild(element)
+    }
+
+    await Promise.all(loadingElements)
+  }
+
+  copyNewHeadScriptElements() {
+    for (const element of this.newHeadScriptElements) {
+      document.head.appendChild(activateScriptElement(element))
+    }
+  }
+
+  async mergeProvisionalElements() {
+    const newHeadElements = [...this.newHeadProvisionalElements]
+
+    for (const element of this.currentHeadProvisionalElements) {
+      if (!this.isCurrentElementInElementList(element, newHeadElements)) {
+        document.head.removeChild(element)
+      }
+    }
+
+    for (const element of newHeadElements) {
+      document.head.appendChild(element)
+    }
+  }
+
+  isCurrentElementInElementList(element: Element, elementList: Element[]) {
+    for (const [index, newElement] of elementList.entries()) {
+      // if title element...
+      if (element.tagName == "TITLE") {
+        if (newElement.tagName != "TITLE") {
+          continue
+        }
+        if (element.innerHTML == newElement.innerHTML) {
+          elementList.splice(index, 1)
+          return true
+        }
+      }
+
+      // if any other element...
+      if (newElement.isEqualNode(element)) {
+        elementList.splice(index, 1)
+        return true
+      }
+    }
+
+    return false
+  }
+
+  removeCurrentHeadProvisionalElements() {
+    for (const element of this.currentHeadProvisionalElements) {
+      document.head.removeChild(element)
+    }
+  }
+
+  copyNewHeadProvisionalElements() {
+    for (const element of this.newHeadProvisionalElements) {
+      document.head.appendChild(element)
+    }
+  }
+
+  activateNewBody() {
+    document.adoptNode(this.newElement)
+    this.activateNewBodyScriptElements()
+  }
+
+  activateNewBodyScriptElements() {
+    for (const inertScriptElement of this.newBodyScriptElements) {
+      const activatedScriptElement = activateScriptElement(inertScriptElement)
+      inertScriptElement.replaceWith(activatedScriptElement)
+    }
+  }
+
+  async assignNewBody() {
+    await this.renderElement(this.currentElement, this.newElement)
+  }
+
+  get newHeadStylesheetElements() {
+    return this.newHeadSnapshot.getStylesheetElementsNotInSnapshot(this.currentHeadSnapshot)
+  }
+
+  get newHeadScriptElements() {
+    return this.newHeadSnapshot.getScriptElementsNotInSnapshot(this.currentHeadSnapshot)
+  }
+
+  get currentHeadProvisionalElements() {
+    return this.currentHeadSnapshot.provisionalElements
+  }
+
+  get newHeadProvisionalElements() {
+    return this.newHeadSnapshot.provisionalElements
+  }
+
+  get newBodyScriptElements() {
+    return this.newElement.querySelectorAll("script")
+  }
+}

--- a/src/core/drive/page_snapshot.ts
+++ b/src/core/drive/page_snapshot.ts
@@ -1,0 +1,79 @@
+import { parseHTMLDocument } from "../../util"
+import { Snapshot } from "../snapshot"
+import { expandURL } from "../url"
+import { HeadSnapshot } from "./head_snapshot"
+
+export class PageSnapshot extends Snapshot<HTMLBodyElement> {
+  static fromHTMLString(html = "") {
+    return this.fromDocument(parseHTMLDocument(html))
+  }
+
+  static fromElement(element: Element) {
+    return this.fromDocument(element.ownerDocument)
+  }
+
+  static fromDocument({ head, body }: Document) {
+    return new this(body as HTMLBodyElement, new HeadSnapshot(head))
+  }
+
+  readonly headSnapshot: HeadSnapshot
+
+  constructor(element: HTMLBodyElement, headSnapshot: HeadSnapshot) {
+    super(element)
+    this.headSnapshot = headSnapshot
+  }
+
+  clone() {
+    const clonedElement = this.element.cloneNode(true)
+
+    const selectElements = this.element.querySelectorAll("select")
+    const clonedSelectElements = clonedElement.querySelectorAll("select")
+
+    for (const [index, source] of selectElements.entries()) {
+      const clone = clonedSelectElements[index]
+      for (const option of clone.selectedOptions) option.selected = false
+      for (const option of source.selectedOptions) clone.options[option.index].selected = true
+    }
+
+    for (const clonedPasswordInput of clonedElement.querySelectorAll<HTMLInputElement>('input[type="password"]')) {
+      clonedPasswordInput.value = ""
+    }
+
+    return new PageSnapshot(clonedElement, this.headSnapshot)
+  }
+
+  get headElement() {
+    return this.headSnapshot.element
+  }
+
+  get rootLocation() {
+    const root = this.getSetting("root") ?? "/"
+    return expandURL(root)
+  }
+
+  get cacheControlValue() {
+    return this.getSetting("cache-control")
+  }
+
+  get isPreviewable() {
+    return this.cacheControlValue != "no-preview"
+  }
+
+  get isCacheable() {
+    return this.cacheControlValue != "no-cache"
+  }
+
+  get isVisitable() {
+    return this.getSetting("visit-control") != "reload"
+  }
+
+  get prefersViewTransitions() {
+    return this.headSnapshot.getMetaValue("view-transition") === "same-origin"
+  }
+
+  // Private
+
+  getSetting(name: string) {
+    return this.headSnapshot.getMetaValue(`turbo-${name}`)
+  }
+}

--- a/src/core/drive/page_view.ts
+++ b/src/core/drive/page_view.ts
@@ -1,0 +1,66 @@
+import { nextEventLoopTick } from "../../util"
+import { View, ViewDelegate, ViewRenderOptions } from "../view"
+import { ErrorRenderer } from "./error_renderer"
+import { PageRenderer } from "./page_renderer"
+import { PageSnapshot } from "./page_snapshot"
+import { SnapshotCache } from "./snapshot_cache"
+import { Visit } from "./visit"
+
+export type PageViewRenderOptions = ViewRenderOptions<HTMLBodyElement>
+
+export interface PageViewDelegate extends ViewDelegate<HTMLBodyElement, PageSnapshot> {
+  viewWillCacheSnapshot(): void
+}
+
+type PageViewRenderer = PageRenderer | ErrorRenderer
+
+export class PageView extends View<HTMLBodyElement, PageSnapshot, PageViewRenderer, PageViewDelegate> {
+  readonly snapshotCache = new SnapshotCache(10)
+  lastRenderedLocation = new URL(location.href)
+  forceReloaded = false
+
+  shouldTransitionTo(newSnapshot: PageSnapshot) {
+    return this.snapshot.prefersViewTransitions && newSnapshot.prefersViewTransitions
+  }
+
+  renderPage(snapshot: PageSnapshot, isPreview = false, willRender = true, visit?: Visit) {
+    const renderer = new PageRenderer(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)
+
+    if (!renderer.shouldRender) {
+      this.forceReloaded = true
+    } else {
+      visit?.changeHistory()
+    }
+
+    return this.render(renderer)
+  }
+
+  renderError(snapshot: PageSnapshot, visit?: Visit) {
+    visit?.changeHistory()
+    const renderer = new ErrorRenderer(this.snapshot, snapshot, ErrorRenderer.renderElement, false)
+    return this.render(renderer)
+  }
+
+  clearSnapshotCache() {
+    this.snapshotCache.clear()
+  }
+
+  async cacheSnapshot(snapshot: PageSnapshot = this.snapshot) {
+    if (snapshot.isCacheable) {
+      this.delegate.viewWillCacheSnapshot()
+      const { lastRenderedLocation: location } = this
+      await nextEventLoopTick()
+      const cachedSnapshot = snapshot.clone()
+      this.snapshotCache.put(location, cachedSnapshot)
+      return cachedSnapshot
+    }
+  }
+
+  getCachedSnapshotForLocation(location: URL) {
+    return this.snapshotCache.get(location)
+  }
+
+  get snapshot() {
+    return PageSnapshot.fromElement(this.element)
+  }
+}

--- a/src/core/drive/preloader.ts
+++ b/src/core/drive/preloader.ts
@@ -1,0 +1,54 @@
+import { Navigator } from "./navigator"
+import { PageSnapshot } from "./page_snapshot"
+import { SnapshotCache } from "./snapshot_cache"
+
+export interface PreloaderDelegate {
+  readonly navigator: Navigator
+}
+
+export class Preloader {
+  readonly delegate: PreloaderDelegate
+  readonly selector: string = "a[data-turbo-preload]"
+
+  constructor(delegate: PreloaderDelegate) {
+    this.delegate = delegate
+  }
+
+  get snapshotCache(): SnapshotCache {
+    return this.delegate.navigator.view.snapshotCache
+  }
+
+  start() {
+    if (document.readyState === "loading") {
+      return document.addEventListener("DOMContentLoaded", () => {
+        this.preloadOnLoadLinksForView(document.body)
+      })
+    } else {
+      this.preloadOnLoadLinksForView(document.body)
+    }
+  }
+
+  preloadOnLoadLinksForView(element: Element) {
+    for (const link of element.querySelectorAll<HTMLAnchorElement>(this.selector)) {
+      this.preloadURL(link)
+    }
+  }
+
+  async preloadURL(link: HTMLAnchorElement) {
+    const location = new URL(link.href)
+
+    if (this.snapshotCache.has(location)) {
+      return
+    }
+
+    try {
+      const response = await fetch(location.toString(), { headers: { "Sec-Purpose": "prefetch", Accept: "text/html" } })
+      const responseText = await response.text()
+      const snapshot = PageSnapshot.fromHTMLString(responseText)
+
+      this.snapshotCache.put(location, snapshot)
+    } catch (_) {
+      // If we cannot preload that is ok!
+    }
+  }
+}

--- a/src/core/drive/progress_bar.ts
+++ b/src/core/drive/progress_bar.ts
@@ -1,0 +1,128 @@
+import { unindent, getMetaContent } from "../../util"
+
+export class ProgressBar {
+  static animationDuration = 300 /*ms*/
+
+  static get defaultCSS() {
+    return unindent`
+      .turbo-progress-bar {
+        position: fixed;
+        display: block;
+        top: 0;
+        left: 0;
+        height: 3px;
+        background: #0076ff;
+        z-index: 2147483647;
+        transition:
+          width ${ProgressBar.animationDuration}ms ease-out,
+          opacity ${ProgressBar.animationDuration / 2}ms ${ProgressBar.animationDuration / 2}ms ease-in;
+        transform: translate3d(0, 0, 0);
+      }
+    `
+  }
+
+  readonly stylesheetElement: HTMLStyleElement
+  readonly progressElement: HTMLDivElement
+
+  hiding = false
+  trickleInterval?: number
+  value = 0
+  visible = false
+
+  constructor() {
+    this.stylesheetElement = this.createStylesheetElement()
+    this.progressElement = this.createProgressElement()
+    this.installStylesheetElement()
+    this.setValue(0)
+  }
+
+  show() {
+    if (!this.visible) {
+      this.visible = true
+      this.installProgressElement()
+      this.startTrickling()
+    }
+  }
+
+  hide() {
+    if (this.visible && !this.hiding) {
+      this.hiding = true
+      this.fadeProgressElement(() => {
+        this.uninstallProgressElement()
+        this.stopTrickling()
+        this.visible = false
+        this.hiding = false
+      })
+    }
+  }
+
+  setValue(value: number) {
+    this.value = value
+    this.refresh()
+  }
+
+  // Private
+
+  installStylesheetElement() {
+    document.head.insertBefore(this.stylesheetElement, document.head.firstChild)
+  }
+
+  installProgressElement() {
+    this.progressElement.style.width = "0"
+    this.progressElement.style.opacity = "1"
+    document.documentElement.insertBefore(this.progressElement, document.body)
+    this.refresh()
+  }
+
+  fadeProgressElement(callback: () => void) {
+    this.progressElement.style.opacity = "0"
+    setTimeout(callback, ProgressBar.animationDuration * 1.5)
+  }
+
+  uninstallProgressElement() {
+    if (this.progressElement.parentNode) {
+      document.documentElement.removeChild(this.progressElement)
+    }
+  }
+
+  startTrickling() {
+    if (!this.trickleInterval) {
+      this.trickleInterval = window.setInterval(this.trickle, ProgressBar.animationDuration)
+    }
+  }
+
+  stopTrickling() {
+    window.clearInterval(this.trickleInterval)
+    delete this.trickleInterval
+  }
+
+  trickle = () => {
+    this.setValue(this.value + Math.random() / 100)
+  }
+
+  refresh() {
+    requestAnimationFrame(() => {
+      this.progressElement.style.width = `${10 + this.value * 90}%`
+    })
+  }
+
+  createStylesheetElement() {
+    const element = document.createElement("style")
+    element.type = "text/css"
+    element.textContent = ProgressBar.defaultCSS
+    if (this.cspNonce) {
+      element.nonce = this.cspNonce
+    }
+    return element
+  }
+
+  createProgressElement() {
+    const element = document.createElement("div")
+    element.className = "turbo-progress-bar"
+    return element
+  }
+
+  get cspNonce() {
+    return getMetaContent("csp-nonce")
+  }
+}

--- a/src/core/drive/snapshot_cache.ts
+++ b/src/core/drive/snapshot_cache.ts
@@ -1,0 +1,58 @@
+import { toCacheKey } from "../url"
+import { PageSnapshot } from "./page_snapshot"
+
+export class SnapshotCache {
+  readonly keys: string[] = []
+  readonly size: number
+  snapshots: { [url: string]: PageSnapshot } = {}
+
+  constructor(size: number) {
+    this.size = size
+  }
+
+  has(location: URL) {
+    return toCacheKey(location) in this.snapshots
+  }
+
+  get(location: URL): PageSnapshot | undefined {
+    if (this.has(location)) {
+      const snapshot = this.read(location)
+      this.touch(location)
+      return snapshot
+    }
+  }
+
+  put(location: URL, snapshot: PageSnapshot) {
+    this.write(location, snapshot)
+    this.touch(location)
+    return snapshot
+  }
+
+  clear() {
+    this.snapshots = {}
+  }
+
+  // Private
+
+  read(location: URL) {
+    return this.snapshots[toCacheKey(location)]
+  }
+
+  write(location: URL, snapshot: PageSnapshot) {
+    this.snapshots[toCacheKey(location)] = snapshot
+  }
+
+  touch(location: URL) {
+    const key = toCacheKey(location)
+    const index = this.keys.indexOf(key)
+    if (index > -1) this.keys.splice(index, 1)
+    this.keys.unshift(key)
+    this.trim()
+  }
+
+  trim() {
+    for (const key of this.keys.splice(this.size)) {
+      delete this.snapshots[key]
+    }
+  }
+}

--- a/src/core/drive/view_transitioner.ts
+++ b/src/core/drive/view_transitioner.ts
@@ -1,0 +1,31 @@
+declare global {
+  type ViewTransition = {
+    finished: Promise<void>
+  }
+
+  interface Document {
+    startViewTransition?(callback: () => Promise<void>): ViewTransition
+  }
+}
+
+export class ViewTransitioner {
+  private viewTransitionStarted = false
+  private lastOperation = Promise.resolve()
+
+  renderChange(useViewTransition: boolean, render: () => Promise<void>) {
+    if (useViewTransition && this.viewTransitionsAvailable && !this.viewTransitionStarted) {
+      this.viewTransitionStarted = true
+      this.lastOperation = this.lastOperation.then(async () => {
+        await document.startViewTransition!(render).finished
+      })
+    } else {
+      this.lastOperation = this.lastOperation.then(render)
+    }
+
+    return this.lastOperation
+  }
+
+  private get viewTransitionsAvailable() {
+    return document.startViewTransition
+  }
+}

--- a/src/core/drive/visit.ts
+++ b/src/core/drive/visit.ts
@@ -1,0 +1,498 @@
+import { Adapter } from "../native/adapter"
+import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
+import { FetchResponse } from "../../http/fetch_response"
+import { History } from "./history"
+import { getAnchor } from "../url"
+import { Snapshot } from "../snapshot"
+import { PageSnapshot } from "./page_snapshot"
+import { Action } from "../types"
+import { getHistoryMethodForAction, uuid } from "../../util"
+import { PageView } from "./page_view"
+import { StreamMessage } from "../streams/stream_message"
+import { ViewTransitioner } from "./view_transitioner"
+
+export interface VisitDelegate {
+  readonly adapter: Adapter
+  readonly history: History
+  readonly view: PageView
+
+  visitStarted(visit: Visit): void
+  visitCompleted(visit: Visit): void
+  locationWithActionIsSamePage(location: URL, action: Action): boolean
+  visitScrolledToSamePageLocation(oldURL: URL, newURL: URL): void
+}
+
+export enum TimingMetric {
+  visitStart = "visitStart",
+  requestStart = "requestStart",
+  requestEnd = "requestEnd",
+  visitEnd = "visitEnd",
+}
+
+export type TimingMetrics = Partial<{ [metric in TimingMetric]: any }>
+
+export enum VisitState {
+  initialized = "initialized",
+  started = "started",
+  canceled = "canceled",
+  failed = "failed",
+  completed = "completed",
+}
+
+export type VisitOptions = {
+  action: Action
+  historyChanged: boolean
+  referrer?: URL
+  snapshot?: PageSnapshot
+  snapshotHTML?: string
+  response?: VisitResponse
+  visitCachedSnapshot(snapshot: Snapshot): void
+  willRender: boolean
+  updateHistory: boolean
+  restorationIdentifier?: string
+  shouldCacheSnapshot: boolean
+  frame?: string
+  acceptsStreamResponse: boolean
+}
+
+const defaultOptions: VisitOptions = {
+  action: "advance",
+  historyChanged: false,
+  visitCachedSnapshot: () => {},
+  willRender: true,
+  updateHistory: true,
+  shouldCacheSnapshot: true,
+  acceptsStreamResponse: false,
+}
+
+export type VisitResponse = {
+  statusCode: number
+  redirected: boolean
+  responseHTML?: string
+}
+
+export enum SystemStatusCode {
+  networkFailure = 0,
+  timeoutFailure = -1,
+  contentTypeMismatch = -2,
+}
+
+export class Visit implements FetchRequestDelegate {
+  readonly delegate: VisitDelegate
+  readonly identifier = uuid() // Required by turbo-ios
+  readonly restorationIdentifier: string
+  readonly action: Action
+  readonly referrer?: URL
+  readonly timingMetrics: TimingMetrics = {}
+  readonly visitCachedSnapshot: (snapshot: Snapshot) => void
+  readonly willRender: boolean
+  readonly updateHistory: boolean
+
+  followedRedirect = false
+  frame?: number
+  historyChanged = false
+  location: URL
+  isSamePage: boolean
+  redirectedToLocation?: URL
+  request?: FetchRequest
+  response?: VisitResponse
+  scrolled = false
+  shouldCacheSnapshot = true
+  acceptsStreamResponse = false
+  snapshotHTML?: string
+  snapshotCached = false
+  state = VisitState.initialized
+  snapshot?: PageSnapshot
+  viewTransitioner = new ViewTransitioner()
+
+  constructor(
+    delegate: VisitDelegate,
+    location: URL,
+    restorationIdentifier: string | undefined,
+    options: Partial<VisitOptions> = {}
+  ) {
+    this.delegate = delegate
+    this.location = location
+    this.restorationIdentifier = restorationIdentifier || uuid()
+
+    const {
+      action,
+      historyChanged,
+      referrer,
+      snapshot,
+      snapshotHTML,
+      response,
+      visitCachedSnapshot,
+      willRender,
+      updateHistory,
+      shouldCacheSnapshot,
+      acceptsStreamResponse,
+    } = {
+      ...defaultOptions,
+      ...options,
+    }
+    this.action = action
+    this.historyChanged = historyChanged
+    this.referrer = referrer
+    this.snapshot = snapshot
+    this.snapshotHTML = snapshotHTML
+    this.response = response
+    this.isSamePage = this.delegate.locationWithActionIsSamePage(this.location, this.action)
+    this.visitCachedSnapshot = visitCachedSnapshot
+    this.willRender = willRender
+    this.updateHistory = updateHistory
+    this.scrolled = !willRender
+    this.shouldCacheSnapshot = shouldCacheSnapshot
+    this.acceptsStreamResponse = acceptsStreamResponse
+  }
+
+  get adapter() {
+    return this.delegate.adapter
+  }
+
+  get view() {
+    return this.delegate.view
+  }
+
+  get history() {
+    return this.delegate.history
+  }
+
+  get restorationData() {
+    return this.history.getRestorationDataForIdentifier(this.restorationIdentifier)
+  }
+
+  get silent() {
+    return this.isSamePage
+  }
+
+  start() {
+    if (this.state == VisitState.initialized) {
+      this.recordTimingMetric(TimingMetric.visitStart)
+      this.state = VisitState.started
+      this.adapter.visitStarted(this)
+      this.delegate.visitStarted(this)
+    }
+  }
+
+  cancel() {
+    if (this.state == VisitState.started) {
+      if (this.request) {
+        this.request.cancel()
+      }
+      this.cancelRender()
+      this.state = VisitState.canceled
+    }
+  }
+
+  complete() {
+    if (this.state == VisitState.started) {
+      this.recordTimingMetric(TimingMetric.visitEnd)
+      this.state = VisitState.completed
+      this.followRedirect()
+
+      if (!this.followedRedirect) {
+        this.adapter.visitCompleted(this)
+        this.delegate.visitCompleted(this)
+      }
+    }
+  }
+
+  fail() {
+    if (this.state == VisitState.started) {
+      this.state = VisitState.failed
+      this.adapter.visitFailed(this)
+      this.delegate.visitCompleted(this)
+    }
+  }
+
+  changeHistory() {
+    if (!this.historyChanged && this.updateHistory) {
+      const actionForHistory = this.location.href === this.referrer?.href ? "replace" : this.action
+      const method = getHistoryMethodForAction(actionForHistory)
+      this.history.update(method, this.location, this.restorationIdentifier)
+      this.historyChanged = true
+    }
+  }
+
+  issueRequest() {
+    if (this.hasPreloadedResponse()) {
+      this.simulateRequest()
+    } else if (this.shouldIssueRequest() && !this.request) {
+      this.request = new FetchRequest(this, FetchMethod.get, this.location)
+      this.request.perform()
+    }
+  }
+
+  simulateRequest() {
+    if (this.response) {
+      this.startRequest()
+      this.recordResponse()
+      this.finishRequest()
+    }
+  }
+
+  startRequest() {
+    this.recordTimingMetric(TimingMetric.requestStart)
+    this.adapter.visitRequestStarted(this)
+  }
+
+  recordResponse(response = this.response) {
+    this.response = response
+    if (response) {
+      const { statusCode } = response
+      if (isSuccessful(statusCode)) {
+        this.adapter.visitRequestCompleted(this)
+      } else {
+        this.adapter.visitRequestFailedWithStatusCode(this, statusCode)
+      }
+    }
+  }
+
+  finishRequest() {
+    this.recordTimingMetric(TimingMetric.requestEnd)
+    this.adapter.visitRequestFinished(this)
+  }
+
+  loadResponse() {
+    if (this.response) {
+      const { statusCode, responseHTML } = this.response
+      this.render(async () => {
+        if (this.shouldCacheSnapshot) this.cacheSnapshot()
+        if (this.view.renderPromise) await this.view.renderPromise
+
+        if (isSuccessful(statusCode) && responseHTML != null) {
+          const snapshot = PageSnapshot.fromHTMLString(responseHTML)
+          await this.renderPageSnapshot(snapshot, false)
+
+          this.adapter.visitRendered(this)
+          this.complete()
+        } else {
+          await this.view.renderError(PageSnapshot.fromHTMLString(responseHTML), this)
+          this.adapter.visitRendered(this)
+          this.fail()
+        }
+      })
+    }
+  }
+
+  getCachedSnapshot() {
+    const snapshot = this.view.getCachedSnapshotForLocation(this.location) || this.getPreloadedSnapshot()
+
+    if (snapshot && (!getAnchor(this.location) || snapshot.hasAnchor(getAnchor(this.location)))) {
+      if (this.action == "restore" || snapshot.isPreviewable) {
+        return snapshot
+      }
+    }
+  }
+
+  getPreloadedSnapshot() {
+    if (this.snapshotHTML) {
+      return PageSnapshot.fromHTMLString(this.snapshotHTML)
+    }
+  }
+
+  hasCachedSnapshot() {
+    return this.getCachedSnapshot() != null
+  }
+
+  loadCachedSnapshot() {
+    const snapshot = this.getCachedSnapshot()
+    if (snapshot) {
+      const isPreview = this.shouldIssueRequest()
+      this.render(async () => {
+        this.cacheSnapshot()
+        if (this.isSamePage) {
+          this.adapter.visitRendered(this)
+        } else {
+          if (this.view.renderPromise) await this.view.renderPromise
+
+          await this.renderPageSnapshot(snapshot, isPreview)
+
+          this.adapter.visitRendered(this)
+          if (!isPreview) {
+            this.complete()
+          }
+        }
+      })
+    }
+  }
+
+  followRedirect() {
+    if (this.redirectedToLocation && !this.followedRedirect && this.response?.redirected) {
+      this.adapter.visitProposedToLocation(this.redirectedToLocation, {
+        action: "replace",
+        response: this.response,
+        shouldCacheSnapshot: false,
+        willRender: false,
+      })
+      this.followedRedirect = true
+    }
+  }
+
+  goToSamePageAnchor() {
+    if (this.isSamePage) {
+      this.render(async () => {
+        this.cacheSnapshot()
+        this.performScroll()
+        this.changeHistory()
+        this.adapter.visitRendered(this)
+      })
+    }
+  }
+
+  // Fetch request delegate
+
+  prepareRequest(request: FetchRequest) {
+    if (this.acceptsStreamResponse) {
+      request.acceptResponseType(StreamMessage.contentType)
+    }
+  }
+
+  requestStarted() {
+    this.startRequest()
+  }
+
+  requestPreventedHandlingResponse(_request: FetchRequest, _response: FetchResponse) {}
+
+  async requestSucceededWithResponse(request: FetchRequest, response: FetchResponse) {
+    const responseHTML = await response.responseHTML
+    const { redirected, statusCode } = response
+    if (responseHTML == undefined) {
+      this.recordResponse({
+        statusCode: SystemStatusCode.contentTypeMismatch,
+        redirected,
+      })
+    } else {
+      this.redirectedToLocation = response.redirected ? response.location : undefined
+      this.recordResponse({ statusCode: statusCode, responseHTML, redirected })
+    }
+  }
+
+  async requestFailedWithResponse(request: FetchRequest, response: FetchResponse) {
+    const responseHTML = await response.responseHTML
+    const { redirected, statusCode } = response
+    if (responseHTML == undefined) {
+      this.recordResponse({
+        statusCode: SystemStatusCode.contentTypeMismatch,
+        redirected,
+      })
+    } else {
+      this.recordResponse({ statusCode: statusCode, responseHTML, redirected })
+    }
+  }
+
+  requestErrored(_request: FetchRequest, _error: Error) {
+    this.recordResponse({
+      statusCode: SystemStatusCode.networkFailure,
+      redirected: false,
+    })
+  }
+
+  requestFinished() {
+    this.finishRequest()
+  }
+
+  // Scrolling
+
+  performScroll() {
+    if (!this.scrolled && !this.view.forceReloaded) {
+      if (this.action == "restore") {
+        this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()
+      } else {
+        this.scrollToAnchor() || this.view.scrollToTop()
+      }
+      if (this.isSamePage) {
+        this.delegate.visitScrolledToSamePageLocation(this.view.lastRenderedLocation, this.location)
+      }
+
+      this.scrolled = true
+    }
+  }
+
+  scrollToRestoredPosition() {
+    const { scrollPosition } = this.restorationData
+    if (scrollPosition) {
+      this.view.scrollToPosition(scrollPosition)
+      return true
+    }
+  }
+
+  scrollToAnchor() {
+    const anchor = getAnchor(this.location)
+    if (anchor != null) {
+      this.view.scrollToAnchor(anchor)
+      return true
+    }
+  }
+
+  // Instrumentation
+
+  recordTimingMetric(metric: TimingMetric) {
+    this.timingMetrics[metric] = new Date().getTime()
+  }
+
+  getTimingMetrics(): TimingMetrics {
+    return { ...this.timingMetrics }
+  }
+
+  // Private
+
+  getHistoryMethodForAction(action: Action) {
+    switch (action) {
+      case "replace":
+        return history.replaceState
+      case "advance":
+      case "restore":
+        return history.pushState
+    }
+  }
+
+  hasPreloadedResponse() {
+    return typeof this.response == "object"
+  }
+
+  shouldIssueRequest() {
+    if (this.isSamePage) {
+      return false
+    } else if (this.action == "restore") {
+      return !this.hasCachedSnapshot()
+    } else {
+      return this.willRender
+    }
+  }
+
+  cacheSnapshot() {
+    if (!this.snapshotCached) {
+      this.view.cacheSnapshot(this.snapshot).then((snapshot) => snapshot && this.visitCachedSnapshot(snapshot))
+      this.snapshotCached = true
+    }
+  }
+
+  async render(callback: () => Promise<void>) {
+    this.cancelRender()
+    await new Promise<void>((resolve) => {
+      this.frame = requestAnimationFrame(() => resolve())
+    })
+    await callback()
+    delete this.frame
+  }
+
+  async renderPageSnapshot(snapshot: PageSnapshot, isPreview: boolean) {
+    await this.viewTransitioner.renderChange(this.view.shouldTransitionTo(snapshot), async () => {
+      await this.view.renderPage(snapshot, isPreview, this.willRender, this)
+      this.performScroll()
+    })
+  }
+
+  cancelRender() {
+    if (this.frame) {
+      cancelAnimationFrame(this.frame)
+      delete this.frame
+    }
+  }
+}
+
+function isSuccessful(statusCode: number) {
+  return statusCode >= 200 && statusCode < 300
+}

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,1 @@
+export class TurboFrameMissingError extends Error {}

--- a/src/core/frames/frame_controller.ts
+++ b/src/core/frames/frame_controller.ts
@@ -1,0 +1,625 @@
+import {
+  FrameElement,
+  FrameElementDelegate,
+  FrameLoadingStyle,
+  FrameElementObservedAttribute,
+} from "../../elements/frame_element"
+import { FetchMethod, FetchRequest, FetchRequestDelegate } from "../../http/fetch_request"
+import { FetchResponse } from "../../http/fetch_response"
+import { AppearanceObserver, AppearanceObserverDelegate } from "../../observers/appearance_observer"
+import {
+  clearBusyState,
+  dispatch,
+  getAttribute,
+  parseHTMLDocument,
+  markAsBusy,
+  uuid,
+  getHistoryMethodForAction,
+  getVisitAction,
+} from "../../util"
+import { FormSubmission, FormSubmissionDelegate } from "../drive/form_submission"
+import { Snapshot } from "../snapshot"
+import { ViewDelegate, ViewRenderOptions } from "../view"
+import { Locatable, getAction, expandURL, urlsAreEqual, locationIsVisitable } from "../url"
+import { FormSubmitObserver, FormSubmitObserverDelegate } from "../../observers/form_submit_observer"
+import { FrameView } from "./frame_view"
+import { LinkInterceptor, LinkInterceptorDelegate } from "./link_interceptor"
+import { FormLinkClickObserver, FormLinkClickObserverDelegate } from "../../observers/form_link_click_observer"
+import { FrameRenderer } from "./frame_renderer"
+import { session } from "../index"
+import { Action } from "../types"
+import { VisitOptions } from "../drive/visit"
+import { TurboBeforeFrameRenderEvent } from "../session"
+import { StreamMessage } from "../streams/stream_message"
+import { PageSnapshot } from "../drive/page_snapshot"
+import { TurboFrameMissingError } from "../errors"
+
+type VisitFallback = (location: Response | Locatable, options: Partial<VisitOptions>) => Promise<void>
+export type TurboFrameMissingEvent = CustomEvent<{ response: Response; visit: VisitFallback }>
+
+export class FrameController
+  implements
+    AppearanceObserverDelegate<FrameElement>,
+    FetchRequestDelegate,
+    FormSubmitObserverDelegate,
+    FormSubmissionDelegate,
+    FrameElementDelegate,
+    FormLinkClickObserverDelegate,
+    LinkInterceptorDelegate,
+    ViewDelegate<FrameElement, Snapshot<FrameElement>>
+{
+  readonly element: FrameElement
+  readonly view: FrameView
+  readonly appearanceObserver: AppearanceObserver<FrameElement>
+  readonly formLinkClickObserver: FormLinkClickObserver
+  readonly linkInterceptor: LinkInterceptor
+  readonly formSubmitObserver: FormSubmitObserver
+  formSubmission?: FormSubmission
+  fetchResponseLoaded = (_fetchResponse: FetchResponse) => {}
+  private currentFetchRequest: FetchRequest | null = null
+  private resolveVisitPromise = () => {}
+  private connected = false
+  private hasBeenLoaded = false
+  private ignoredAttributes: Set<FrameElementObservedAttribute> = new Set()
+  private action: Action | null = null
+  readonly restorationIdentifier: string
+  private previousFrameElement?: FrameElement
+  private currentNavigationElement?: Element
+
+  constructor(element: FrameElement) {
+    this.element = element
+    this.view = new FrameView(this, this.element)
+    this.appearanceObserver = new AppearanceObserver(this, this.element)
+    this.formLinkClickObserver = new FormLinkClickObserver(this, this.element)
+    this.linkInterceptor = new LinkInterceptor(this, this.element)
+    this.restorationIdentifier = uuid()
+    this.formSubmitObserver = new FormSubmitObserver(this, this.element)
+  }
+
+  connect() {
+    if (!this.connected) {
+      this.connected = true
+      if (this.loadingStyle == FrameLoadingStyle.lazy) {
+        this.appearanceObserver.start()
+      } else {
+        this.loadSourceURL()
+      }
+      this.formLinkClickObserver.start()
+      this.linkInterceptor.start()
+      this.formSubmitObserver.start()
+    }
+  }
+
+  disconnect() {
+    if (this.connected) {
+      this.connected = false
+      this.appearanceObserver.stop()
+      this.formLinkClickObserver.stop()
+      this.linkInterceptor.stop()
+      this.formSubmitObserver.stop()
+    }
+  }
+
+  disabledChanged() {
+    if (this.loadingStyle == FrameLoadingStyle.eager) {
+      this.loadSourceURL()
+    }
+  }
+
+  sourceURLChanged() {
+    if (this.isIgnoringChangesTo("src")) return
+
+    if (this.element.isConnected) {
+      this.complete = false
+    }
+
+    if (this.loadingStyle == FrameLoadingStyle.eager || this.hasBeenLoaded) {
+      this.loadSourceURL()
+    }
+  }
+
+  sourceURLReloaded() {
+    const { src } = this.element
+    this.ignoringChangesToAttribute("complete", () => {
+      this.element.removeAttribute("complete")
+    })
+    this.element.src = null
+    this.element.src = src
+    return this.element.loaded
+  }
+
+  completeChanged() {
+    if (this.isIgnoringChangesTo("complete")) return
+
+    this.loadSourceURL()
+  }
+
+  loadingStyleChanged() {
+    if (this.loadingStyle == FrameLoadingStyle.lazy) {
+      this.appearanceObserver.start()
+    } else {
+      this.appearanceObserver.stop()
+      this.loadSourceURL()
+    }
+  }
+
+  private async loadSourceURL() {
+    if (this.enabled && this.isActive && !this.complete && this.sourceURL) {
+      this.element.loaded = this.visit(expandURL(this.sourceURL))
+      this.appearanceObserver.stop()
+      await this.element.loaded
+      this.hasBeenLoaded = true
+    }
+  }
+
+  async loadResponse(fetchResponse: FetchResponse) {
+    if (fetchResponse.redirected || (fetchResponse.succeeded && fetchResponse.isHTML)) {
+      this.sourceURL = fetchResponse.response.url
+    }
+
+    try {
+      const html = await fetchResponse.responseHTML
+      if (html) {
+        const document = parseHTMLDocument(html)
+        const pageSnapshot = PageSnapshot.fromDocument(document)
+
+        if (pageSnapshot.isVisitable) {
+          await this.loadFrameResponse(fetchResponse, document)
+        } else {
+          await this.handleUnvisitableFrameResponse(fetchResponse)
+        }
+      }
+    } finally {
+      this.fetchResponseLoaded = () => {}
+    }
+  }
+
+  // Appearance observer delegate
+
+  elementAppearedInViewport(element: FrameElement) {
+    this.proposeVisitIfNavigatedWithAction(element, element)
+    this.loadSourceURL()
+  }
+
+  // Form link click observer delegate
+
+  willSubmitFormLinkToLocation(link: Element): boolean {
+    return this.shouldInterceptNavigation(link)
+  }
+
+  submittedFormLinkToLocation(link: Element, _location: URL, form: HTMLFormElement): void {
+    const frame = this.findFrameElement(link)
+    if (frame) form.setAttribute("data-turbo-frame", frame.id)
+  }
+
+  // Link interceptor delegate
+
+  shouldInterceptLinkClick(element: Element, _location: string, _event: MouseEvent) {
+    return this.shouldInterceptNavigation(element)
+  }
+
+  linkClickIntercepted(element: Element, location: string) {
+    this.navigateFrame(element, location)
+  }
+
+  // Form submit observer delegate
+
+  willSubmitForm(element: HTMLFormElement, submitter?: HTMLElement) {
+    return element.closest("turbo-frame") == this.element && this.shouldInterceptNavigation(element, submitter)
+  }
+
+  formSubmitted(element: HTMLFormElement, submitter?: HTMLElement) {
+    if (this.formSubmission) {
+      this.formSubmission.stop()
+    }
+
+    this.formSubmission = new FormSubmission(this, element, submitter)
+    const { fetchRequest } = this.formSubmission
+    this.prepareRequest(fetchRequest)
+    this.formSubmission.start()
+  }
+
+  // Fetch request delegate
+
+  prepareRequest(request: FetchRequest) {
+    request.headers["Turbo-Frame"] = this.id
+
+    if (this.currentNavigationElement?.hasAttribute("data-turbo-stream")) {
+      request.acceptResponseType(StreamMessage.contentType)
+    }
+  }
+
+  requestStarted(_request: FetchRequest) {
+    markAsBusy(this.element)
+  }
+
+  requestPreventedHandlingResponse(_request: FetchRequest, _response: FetchResponse) {
+    this.resolveVisitPromise()
+  }
+
+  async requestSucceededWithResponse(request: FetchRequest, response: FetchResponse) {
+    await this.loadResponse(response)
+    this.resolveVisitPromise()
+  }
+
+  async requestFailedWithResponse(request: FetchRequest, response: FetchResponse) {
+    await this.loadResponse(response)
+    this.resolveVisitPromise()
+  }
+
+  requestErrored(request: FetchRequest, error: Error) {
+    console.error(error)
+    this.resolveVisitPromise()
+  }
+
+  requestFinished(_request: FetchRequest) {
+    clearBusyState(this.element)
+  }
+
+  // Form submission delegate
+
+  formSubmissionStarted({ formElement }: FormSubmission) {
+    markAsBusy(formElement, this.findFrameElement(formElement))
+  }
+
+  formSubmissionSucceededWithResponse(formSubmission: FormSubmission, response: FetchResponse) {
+    const frame = this.findFrameElement(formSubmission.formElement, formSubmission.submitter)
+
+    frame.delegate.proposeVisitIfNavigatedWithAction(frame, formSubmission.formElement, formSubmission.submitter)
+    frame.delegate.loadResponse(response)
+
+    if (!formSubmission.isSafe) {
+      session.clearCache()
+    }
+  }
+
+  formSubmissionFailedWithResponse(formSubmission: FormSubmission, fetchResponse: FetchResponse) {
+    this.element.delegate.loadResponse(fetchResponse)
+    session.clearCache()
+  }
+
+  formSubmissionErrored(formSubmission: FormSubmission, error: Error) {
+    console.error(error)
+  }
+
+  formSubmissionFinished({ formElement }: FormSubmission) {
+    clearBusyState(formElement, this.findFrameElement(formElement))
+  }
+
+  // View delegate
+
+  allowsImmediateRender(
+    { element: newFrame }: Snapshot<FrameElement>,
+    _isPreview: boolean,
+    options: ViewRenderOptions<FrameElement>
+  ) {
+    const event = dispatch<TurboBeforeFrameRenderEvent>("turbo:before-frame-render", {
+      target: this.element,
+      detail: { newFrame, ...options },
+      cancelable: true,
+    })
+    const {
+      defaultPrevented,
+      detail: { render },
+    } = event
+
+    if (this.view.renderer && render) {
+      this.view.renderer.renderElement = render
+    }
+
+    return !defaultPrevented
+  }
+
+  viewRenderedSnapshot(_snapshot: Snapshot, _isPreview: boolean) {}
+
+  preloadOnLoadLinksForView(element: Element) {
+    session.preloadOnLoadLinksForView(element)
+  }
+
+  viewInvalidated() {}
+
+  // Frame renderer delegate
+  willRenderFrame(currentElement: FrameElement, _newElement: FrameElement) {
+    this.previousFrameElement = currentElement.cloneNode(true)
+  }
+
+  visitCachedSnapshot = ({ element }: Snapshot) => {
+    const frame = element.querySelector("#" + this.element.id)
+
+    if (frame && this.previousFrameElement) {
+      frame.replaceChildren(...this.previousFrameElement.children)
+    }
+
+    delete this.previousFrameElement
+  }
+
+  // Private
+
+  private async loadFrameResponse(fetchResponse: FetchResponse, document: Document) {
+    const newFrameElement = await this.extractForeignFrameElement(document.body)
+
+    if (newFrameElement) {
+      const snapshot = new Snapshot(newFrameElement)
+      const renderer = new FrameRenderer(this, this.view.snapshot, snapshot, FrameRenderer.renderElement, false, false)
+      if (this.view.renderPromise) await this.view.renderPromise
+      this.changeHistory()
+
+      await this.view.render(renderer)
+      this.complete = true
+      session.frameRendered(fetchResponse, this.element)
+      session.frameLoaded(this.element)
+      this.fetchResponseLoaded(fetchResponse)
+    } else if (this.willHandleFrameMissingFromResponse(fetchResponse)) {
+      this.handleFrameMissingFromResponse(fetchResponse)
+    }
+  }
+
+  private async visit(url: URL) {
+    const request = new FetchRequest(this, FetchMethod.get, url, new URLSearchParams(), this.element)
+
+    this.currentFetchRequest?.cancel()
+    this.currentFetchRequest = request
+
+    return new Promise<void>((resolve) => {
+      this.resolveVisitPromise = () => {
+        this.resolveVisitPromise = () => {}
+        this.currentFetchRequest = null
+        resolve()
+      }
+      request.perform()
+    })
+  }
+
+  private navigateFrame(element: Element, url: string, submitter?: HTMLElement) {
+    const frame = this.findFrameElement(element, submitter)
+
+    frame.delegate.proposeVisitIfNavigatedWithAction(frame, element, submitter)
+
+    this.withCurrentNavigationElement(element, () => {
+      frame.src = url
+    })
+  }
+
+  proposeVisitIfNavigatedWithAction(frame: FrameElement, element: Element, submitter?: HTMLElement) {
+    this.action = getVisitAction(submitter, element, frame)
+
+    if (this.action) {
+      const pageSnapshot = PageSnapshot.fromElement(frame).clone()
+      const { visitCachedSnapshot } = frame.delegate
+
+      frame.delegate.fetchResponseLoaded = (fetchResponse: FetchResponse) => {
+        if (frame.src) {
+          const { statusCode, redirected } = fetchResponse
+          const responseHTML = frame.ownerDocument.documentElement.outerHTML
+          const response = { statusCode, redirected, responseHTML }
+          const options: Partial<VisitOptions> = {
+            response,
+            visitCachedSnapshot,
+            willRender: false,
+            updateHistory: false,
+            restorationIdentifier: this.restorationIdentifier,
+            snapshot: pageSnapshot,
+          }
+
+          if (this.action) options.action = this.action
+
+          session.visit(frame.src, options)
+        }
+      }
+    }
+  }
+
+  changeHistory() {
+    if (this.action) {
+      const method = getHistoryMethodForAction(this.action)
+      session.history.update(method, expandURL(this.element.src || ""), this.restorationIdentifier)
+    }
+  }
+
+  private async handleUnvisitableFrameResponse(fetchResponse: FetchResponse) {
+    console.warn(
+      `The response (${fetchResponse.statusCode}) from <turbo-frame id="${this.element.id}"> is performing a full page visit due to turbo-visit-control.`
+    )
+
+    await this.visitResponse(fetchResponse.response)
+  }
+
+  private willHandleFrameMissingFromResponse(fetchResponse: FetchResponse): boolean {
+    this.element.setAttribute("complete", "")
+
+    const response = fetchResponse.response
+    const visit = async (url: Locatable | Response, options: Partial<VisitOptions> = {}) => {
+      if (url instanceof Response) {
+        this.visitResponse(url)
+      } else {
+        session.visit(url, options)
+      }
+    }
+
+    const event = dispatch<TurboFrameMissingEvent>("turbo:frame-missing", {
+      target: this.element,
+      detail: { response, visit },
+      cancelable: true,
+    })
+
+    return !event.defaultPrevented
+  }
+
+  private handleFrameMissingFromResponse(fetchResponse: FetchResponse) {
+    this.view.missing()
+    this.throwFrameMissingError(fetchResponse)
+  }
+
+  private throwFrameMissingError(fetchResponse: FetchResponse) {
+    const message = `The response (${fetchResponse.statusCode}) did not contain the expected <turbo-frame id="${this.element.id}"> and will be ignored. To perform a full page visit instead, set turbo-visit-control to reload.`
+    throw new TurboFrameMissingError(message)
+  }
+
+  private async visitResponse(response: Response): Promise<void> {
+    const wrapped = new FetchResponse(response)
+    const responseHTML = await wrapped.responseHTML
+    const { location, redirected, statusCode } = wrapped
+
+    return session.visit(location, { response: { redirected, statusCode, responseHTML } })
+  }
+
+  private findFrameElement(element: Element, submitter?: HTMLElement) {
+    const id = getAttribute("data-turbo-frame", submitter, element) || this.element.getAttribute("target")
+    return getFrameElementById(id) ?? this.element
+  }
+
+  async extractForeignFrameElement(container: ParentNode): Promise<FrameElement | null> {
+    let element
+    const id = CSS.escape(this.id)
+
+    try {
+      element = activateElement(container.querySelector(`turbo-frame#${id}`), this.sourceURL)
+      if (element) {
+        return element
+      }
+
+      element = activateElement(container.querySelector(`turbo-frame[src][recurse~=${id}]`), this.sourceURL)
+      if (element) {
+        await element.loaded
+        return await this.extractForeignFrameElement(element)
+      }
+    } catch (error) {
+      console.error(error)
+      return new FrameElement()
+    }
+
+    return null
+  }
+
+  private formActionIsVisitable(form: HTMLFormElement, submitter?: HTMLElement) {
+    const action = getAction(form, submitter)
+
+    return locationIsVisitable(expandURL(action), this.rootLocation)
+  }
+
+  private shouldInterceptNavigation(element: Element, submitter?: HTMLElement) {
+    const id = getAttribute("data-turbo-frame", submitter, element) || this.element.getAttribute("target")
+
+    if (element instanceof HTMLFormElement && !this.formActionIsVisitable(element, submitter)) {
+      return false
+    }
+
+    if (!this.enabled || id == "_top") {
+      return false
+    }
+
+    if (id) {
+      const frameElement = getFrameElementById(id)
+      if (frameElement) {
+        return !frameElement.disabled
+      }
+    }
+
+    if (!session.elementIsNavigatable(element)) {
+      return false
+    }
+
+    if (submitter && !session.elementIsNavigatable(submitter)) {
+      return false
+    }
+
+    return true
+  }
+
+  // Computed properties
+
+  get id() {
+    return this.element.id
+  }
+
+  get enabled() {
+    return !this.element.disabled
+  }
+
+  get sourceURL() {
+    if (this.element.src) {
+      return this.element.src
+    }
+  }
+
+  set sourceURL(sourceURL: string | undefined) {
+    this.ignoringChangesToAttribute("src", () => {
+      this.element.src = sourceURL ?? null
+    })
+  }
+
+  get loadingStyle() {
+    return this.element.loading
+  }
+
+  get isLoading() {
+    return this.formSubmission !== undefined || this.resolveVisitPromise() !== undefined
+  }
+
+  get complete() {
+    return this.element.hasAttribute("complete")
+  }
+
+  set complete(value: boolean) {
+    this.ignoringChangesToAttribute("complete", () => {
+      if (value) {
+        this.element.setAttribute("complete", "")
+      } else {
+        this.element.removeAttribute("complete")
+      }
+    })
+  }
+
+  get isActive() {
+    return this.element.isActive && this.connected
+  }
+
+  get rootLocation() {
+    const meta = this.element.ownerDocument.querySelector<HTMLMetaElement>(`meta[name="turbo-root"]`)
+    const root = meta?.content ?? "/"
+    return expandURL(root)
+  }
+
+  private isIgnoringChangesTo(attributeName: FrameElementObservedAttribute): boolean {
+    return this.ignoredAttributes.has(attributeName)
+  }
+
+  private ignoringChangesToAttribute(attributeName: FrameElementObservedAttribute, callback: () => void) {
+    this.ignoredAttributes.add(attributeName)
+    callback()
+    this.ignoredAttributes.delete(attributeName)
+  }
+
+  private withCurrentNavigationElement(element: Element, callback: () => void) {
+    this.currentNavigationElement = element
+    callback()
+    delete this.currentNavigationElement
+  }
+}
+
+function getFrameElementById(id: string | null) {
+  if (id != null) {
+    const element = document.getElementById(id)
+    if (element instanceof FrameElement) {
+      return element
+    }
+  }
+}
+
+function activateElement(element: Element | null, currentURL?: string | null) {
+  if (element) {
+    const src = element.getAttribute("src")
+    if (src != null && currentURL != null && urlsAreEqual(src, currentURL)) {
+      throw new Error(`Matching <turbo-frame id="${element.id}"> element has a source URL which references itself`)
+    }
+    if (element.ownerDocument !== document) {
+      element = document.importNode(element, true)
+    }
+
+    if (element instanceof FrameElement) {
+      element.connectedCallback()
+      element.disconnectedCallback()
+      return element
+    }
+  }
+}

--- a/src/core/frames/frame_redirector.ts
+++ b/src/core/frames/frame_redirector.ts
@@ -1,0 +1,86 @@
+import { FormSubmitObserver, FormSubmitObserverDelegate } from "../../observers/form_submit_observer"
+import { FrameElement } from "../../elements/frame_element"
+import { LinkInterceptor, LinkInterceptorDelegate } from "./link_interceptor"
+import { expandURL, getAction, locationIsVisitable } from "../url"
+import { Session } from "../session"
+export class FrameRedirector implements LinkInterceptorDelegate, FormSubmitObserverDelegate {
+  readonly session: Session
+  readonly element: Element
+  readonly linkInterceptor: LinkInterceptor
+  readonly formSubmitObserver: FormSubmitObserver
+
+  constructor(session: Session, element: Element) {
+    this.session = session
+    this.element = element
+    this.linkInterceptor = new LinkInterceptor(this, element)
+    this.formSubmitObserver = new FormSubmitObserver(this, element)
+  }
+
+  start() {
+    this.linkInterceptor.start()
+    this.formSubmitObserver.start()
+  }
+
+  stop() {
+    this.linkInterceptor.stop()
+    this.formSubmitObserver.stop()
+  }
+
+  shouldInterceptLinkClick(element: Element, _location: string, _event: MouseEvent) {
+    return this.shouldRedirect(element)
+  }
+
+  linkClickIntercepted(element: Element, url: string, event: MouseEvent) {
+    const frame = this.findFrameElement(element)
+    if (frame) {
+      frame.delegate.linkClickIntercepted(element, url, event)
+    }
+  }
+
+  willSubmitForm(element: HTMLFormElement, submitter?: HTMLElement) {
+    return (
+      element.closest("turbo-frame") == null &&
+      this.shouldSubmit(element, submitter) &&
+      this.shouldRedirect(element, submitter)
+    )
+  }
+
+  formSubmitted(element: HTMLFormElement, submitter?: HTMLElement) {
+    const frame = this.findFrameElement(element, submitter)
+    if (frame) {
+      frame.delegate.formSubmitted(element, submitter)
+    }
+  }
+
+  private shouldSubmit(form: HTMLFormElement, submitter?: HTMLElement) {
+    const action = getAction(form, submitter)
+    const meta = this.element.ownerDocument.querySelector<HTMLMetaElement>(`meta[name="turbo-root"]`)
+    const rootLocation = expandURL(meta?.content ?? "/")
+
+    return this.shouldRedirect(form, submitter) && locationIsVisitable(action, rootLocation)
+  }
+
+  private shouldRedirect(element: Element, submitter?: HTMLElement) {
+    const isNavigatable =
+      element instanceof HTMLFormElement
+        ? this.session.submissionIsNavigatable(element, submitter)
+        : this.session.elementIsNavigatable(element)
+
+    if (isNavigatable) {
+      const frame = this.findFrameElement(element, submitter)
+      return frame ? frame != element.closest("turbo-frame") : false
+    } else {
+      return false
+    }
+  }
+
+  private findFrameElement(element: Element, submitter?: HTMLElement) {
+    const id = submitter?.getAttribute("data-turbo-frame") || element.getAttribute("data-turbo-frame")
+    if (id && id != "_top") {
+      const frame = this.element.querySelector(`#${id}:not([disabled])`)
+      if (frame instanceof FrameElement) {
+        return frame
+      }
+    }
+  }
+}

--- a/src/core/frames/frame_renderer.ts
+++ b/src/core/frames/frame_renderer.ts
@@ -1,0 +1,99 @@
+import { FrameElement } from "../../elements/frame_element"
+import { activateScriptElement, nextAnimationFrame } from "../../util"
+import { Render, Renderer } from "../renderer"
+import { Snapshot } from "../snapshot"
+
+export interface FrameRendererDelegate {
+  willRenderFrame(currentElement: FrameElement, newElement: FrameElement): void
+}
+
+export class FrameRenderer extends Renderer<FrameElement> {
+  private readonly delegate: FrameRendererDelegate
+
+  static renderElement(currentElement: FrameElement, newElement: FrameElement) {
+    const destinationRange = document.createRange()
+    destinationRange.selectNodeContents(currentElement)
+    destinationRange.deleteContents()
+
+    const frameElement = newElement
+    const sourceRange = frameElement.ownerDocument?.createRange()
+    if (sourceRange) {
+      sourceRange.selectNodeContents(frameElement)
+      currentElement.appendChild(sourceRange.extractContents())
+    }
+  }
+
+  constructor(
+    delegate: FrameRendererDelegate,
+    currentSnapshot: Snapshot<FrameElement>,
+    newSnapshot: Snapshot<FrameElement>,
+    renderElement: Render<FrameElement>,
+    isPreview: boolean,
+    willRender = true
+  ) {
+    super(currentSnapshot, newSnapshot, renderElement, isPreview, willRender)
+    this.delegate = delegate
+  }
+
+  get shouldRender() {
+    return true
+  }
+
+  async render() {
+    await nextAnimationFrame()
+    this.preservingPermanentElements(() => {
+      this.loadFrameElement()
+    })
+    this.scrollFrameIntoView()
+    await nextAnimationFrame()
+    this.focusFirstAutofocusableElement()
+    await nextAnimationFrame()
+    this.activateScriptElements()
+  }
+
+  loadFrameElement() {
+    this.delegate.willRenderFrame(this.currentElement, this.newElement)
+    this.renderElement(this.currentElement, this.newElement)
+  }
+
+  scrollFrameIntoView() {
+    if (this.currentElement.autoscroll || this.newElement.autoscroll) {
+      const element = this.currentElement.firstElementChild
+      const block = readScrollLogicalPosition(this.currentElement.getAttribute("data-autoscroll-block"), "end")
+      const behavior = readScrollBehavior(this.currentElement.getAttribute("data-autoscroll-behavior"), "auto")
+
+      if (element) {
+        element.scrollIntoView({ block, behavior })
+        return true
+      }
+    }
+    return false
+  }
+
+  activateScriptElements() {
+    for (const inertScriptElement of this.newScriptElements) {
+      const activatedScriptElement = activateScriptElement(inertScriptElement)
+      inertScriptElement.replaceWith(activatedScriptElement)
+    }
+  }
+
+  get newScriptElements() {
+    return this.currentElement.querySelectorAll("script")
+  }
+}
+
+function readScrollLogicalPosition(value: string | null, defaultValue: ScrollLogicalPosition): ScrollLogicalPosition {
+  if (value == "end" || value == "start" || value == "center" || value == "nearest") {
+    return value
+  } else {
+    return defaultValue
+  }
+}
+
+function readScrollBehavior(value: string | null, defaultValue: ScrollBehavior): ScrollBehavior {
+  if (value == "auto" || value == "smooth") {
+    return value
+  } else {
+    return defaultValue
+  }
+}

--- a/src/core/frames/frame_view.ts
+++ b/src/core/frames/frame_view.ts
@@ -1,0 +1,15 @@
+import { FrameElement } from "../../elements"
+import { Snapshot } from "../snapshot"
+import { View, ViewRenderOptions } from "../view"
+
+export type FrameViewRenderOptions = ViewRenderOptions<FrameElement>
+
+export class FrameView extends View<FrameElement> {
+  missing() {
+    this.element.innerHTML = `<strong class="turbo-frame-error">Content missing</strong>`
+  }
+
+  get snapshot() {
+    return new Snapshot(this.element)
+  }
+}

--- a/src/core/frames/link_interceptor.ts
+++ b/src/core/frames/link_interceptor.ts
@@ -1,0 +1,57 @@
+import { TurboClickEvent, TurboBeforeVisitEvent } from "../session"
+
+export interface LinkInterceptorDelegate {
+  shouldInterceptLinkClick(element: Element, url: string, originalEvent: MouseEvent): boolean
+  linkClickIntercepted(element: Element, url: string, originalEvent: MouseEvent): void
+}
+
+export class LinkInterceptor {
+  readonly delegate: LinkInterceptorDelegate
+  readonly element: Element
+  private clickEvent?: Event
+
+  constructor(delegate: LinkInterceptorDelegate, element: Element) {
+    this.delegate = delegate
+    this.element = element
+  }
+
+  start() {
+    this.element.addEventListener("click", this.clickBubbled)
+    document.addEventListener("turbo:click", this.linkClicked)
+    document.addEventListener("turbo:before-visit", this.willVisit)
+  }
+
+  stop() {
+    this.element.removeEventListener("click", this.clickBubbled)
+    document.removeEventListener("turbo:click", this.linkClicked)
+    document.removeEventListener("turbo:before-visit", this.willVisit)
+  }
+
+  clickBubbled = (event: Event) => {
+    if (this.respondsToEventTarget(event.target)) {
+      this.clickEvent = event
+    } else {
+      delete this.clickEvent
+    }
+  }
+
+  linkClicked = <EventListener>((event: TurboClickEvent) => {
+    if (this.clickEvent && this.respondsToEventTarget(event.target) && event.target instanceof Element) {
+      if (this.delegate.shouldInterceptLinkClick(event.target, event.detail.url, event.detail.originalEvent)) {
+        this.clickEvent.preventDefault()
+        event.preventDefault()
+        this.delegate.linkClickIntercepted(event.target, event.detail.url, event.detail.originalEvent)
+      }
+    }
+    delete this.clickEvent
+  })
+
+  willVisit = <EventListener>((_event: TurboBeforeVisitEvent) => {
+    delete this.clickEvent
+  })
+
+  respondsToEventTarget(target: EventTarget | null) {
+    const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null
+    return element && element.closest("turbo-frame, html") == this.element
+  }
+}

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -1,0 +1,135 @@
+import { Adapter } from "./native/adapter"
+import { FormMode, Session } from "./session"
+import { Cache } from "./cache"
+import { Locatable } from "./url"
+import { StreamMessage } from "./streams/stream_message"
+import { StreamSource } from "./types"
+import { VisitOptions } from "./drive/visit"
+import { PageRenderer } from "./drive/page_renderer"
+import { PageSnapshot } from "./drive/page_snapshot"
+import { FrameRenderer } from "./frames/frame_renderer"
+import { FormSubmission } from "./drive/form_submission"
+
+const session = new Session()
+const cache = new Cache(session)
+const { navigator } = session
+export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer }
+export type {
+  TurboBeforeCacheEvent,
+  TurboBeforeRenderEvent,
+  TurboBeforeVisitEvent,
+  TurboClickEvent,
+  TurboBeforeFrameRenderEvent,
+  TurboFrameLoadEvent,
+  TurboFrameRenderEvent,
+  TurboLoadEvent,
+  TurboRenderEvent,
+  TurboVisitEvent,
+} from "./session"
+
+export type { TurboSubmitStartEvent, TurboSubmitEndEvent } from "./drive/form_submission"
+export type { TurboFrameMissingEvent } from "./frames/frame_controller"
+
+export { StreamActions } from "./streams/stream_actions"
+export type { TurboStreamAction, TurboStreamActions } from "./streams/stream_actions"
+
+/**
+ * Starts the main session.
+ * This initialises any necessary observers such as those to monitor
+ * link interactions.
+ */
+export function start() {
+  session.start()
+}
+
+/**
+ * Registers an adapter for the main session.
+ *
+ * @param adapter Adapter to register
+ */
+export function registerAdapter(adapter: Adapter) {
+  session.registerAdapter(adapter)
+}
+
+/**
+ * Performs an application visit to the given location.
+ *
+ * @param location Location to visit (a URL or path)
+ * @param options Options to apply
+ * @param options.action Type of history navigation to apply ("restore",
+ * "replace" or "advance")
+ * @param options.historyChanged Specifies whether the browser history has
+ * already been changed for this visit or not
+ * @param options.referrer Specifies the referrer of this visit such that
+ * navigations to the same page will not result in a new history entry.
+ * @param options.snapshotHTML Cached snapshot to render
+ * @param options.response Response of the specified location
+ */
+export function visit(location: Locatable, options?: Partial<VisitOptions>) {
+  session.visit(location, options)
+}
+
+/**
+ * Connects a stream source to the main session.
+ *
+ * @param source Stream source to connect
+ */
+export function connectStreamSource(source: StreamSource) {
+  session.connectStreamSource(source)
+}
+
+/**
+ * Disconnects a stream source from the main session.
+ *
+ * @param source Stream source to disconnect
+ */
+export function disconnectStreamSource(source: StreamSource) {
+  session.disconnectStreamSource(source)
+}
+
+/**
+ * Renders a stream message to the main session by appending it to the
+ * current document.
+ *
+ * @param message Message to render
+ */
+export function renderStreamMessage(message: StreamMessage | string) {
+  session.renderStreamMessage(message)
+}
+
+/**
+ * Removes all entries from the Turbo Drive page cache.
+ * Call this when state has changed on the server that may affect cached pages.
+ *
+ * @deprecated since version 7.2.0 in favor of `Turbo.cache.clear()`
+ */
+export function clearCache() {
+  console.warn(
+    "Please replace `Turbo.clearCache()` with `Turbo.cache.clear()`. The top-level function is deprecated and will be removed in a future version of Turbo.`"
+  )
+  session.clearCache()
+}
+
+/**
+ * Sets the delay after which the progress bar will appear during navigation.
+ *
+ * The progress bar appears after 500ms by default.
+ *
+ * Note that this method has no effect when used with the iOS or Android
+ * adapters.
+ *
+ * @param delay Time to delay in milliseconds
+ */
+export function setProgressBarDelay(delay: number) {
+  session.setProgressBarDelay(delay)
+}
+
+export function setConfirmMethod(
+  confirmMethod: (message: string, element: HTMLFormElement, submitter: HTMLElement | undefined) => Promise<boolean>
+) {
+  FormSubmission.confirmMethod = confirmMethod
+}
+
+export function setFormMode(mode: FormMode) {
+  session.setFormMode(mode)
+}

--- a/src/core/native/adapter.ts
+++ b/src/core/native/adapter.ts
@@ -1,0 +1,18 @@
+import { Visit, VisitOptions } from "../drive/visit"
+import { FormSubmission } from "../drive/form_submission"
+import { ReloadReason } from "./browser_adapter"
+
+export interface Adapter {
+  visitProposedToLocation(location: URL, options?: Partial<VisitOptions>): void
+  visitStarted(visit: Visit): void
+  visitCompleted(visit: Visit): void
+  visitFailed(visit: Visit): void
+  visitRequestStarted(visit: Visit): void
+  visitRequestCompleted(visit: Visit): void
+  visitRequestFailedWithStatusCode(visit: Visit, statusCode: number): void
+  visitRequestFinished(visit: Visit): void
+  visitRendered(visit: Visit): void
+  formSubmissionStarted?(formSubmission: FormSubmission): void
+  formSubmissionFinished?(formSubmission: FormSubmission): void
+  pageInvalidated(reason: ReloadReason): void
+}

--- a/src/core/native/browser_adapter.ts
+++ b/src/core/native/browser_adapter.ts
@@ -1,0 +1,132 @@
+import { Adapter } from "./adapter"
+import { ProgressBar } from "../drive/progress_bar"
+import { SystemStatusCode, Visit, VisitOptions } from "../drive/visit"
+import { FormSubmission } from "../drive/form_submission"
+import { Session } from "../session"
+import { uuid, dispatch } from "../../util"
+
+export type ReloadReason = StructuredReason | undefined
+interface StructuredReason {
+  reason: string
+  context?: { [key: string]: any }
+}
+
+export class BrowserAdapter implements Adapter {
+  readonly session: Session
+  readonly progressBar = new ProgressBar()
+
+  visitProgressBarTimeout?: number
+  formProgressBarTimeout?: number
+  location?: URL
+
+  constructor(session: Session) {
+    this.session = session
+  }
+
+  visitProposedToLocation(location: URL, options?: Partial<VisitOptions>) {
+    this.navigator.startVisit(location, options?.restorationIdentifier || uuid(), options)
+  }
+
+  visitStarted(visit: Visit) {
+    this.location = visit.location
+    visit.loadCachedSnapshot()
+    visit.issueRequest()
+    visit.goToSamePageAnchor()
+  }
+
+  visitRequestStarted(visit: Visit) {
+    this.progressBar.setValue(0)
+    if (visit.hasCachedSnapshot() || visit.action != "restore") {
+      this.showVisitProgressBarAfterDelay()
+    } else {
+      this.showProgressBar()
+    }
+  }
+
+  visitRequestCompleted(visit: Visit) {
+    visit.loadResponse()
+  }
+
+  visitRequestFailedWithStatusCode(visit: Visit, statusCode: number) {
+    switch (statusCode) {
+      case SystemStatusCode.networkFailure:
+      case SystemStatusCode.timeoutFailure:
+      case SystemStatusCode.contentTypeMismatch:
+        return this.reload({
+          reason: "request_failed",
+          context: {
+            statusCode,
+          },
+        })
+      default:
+        return visit.loadResponse()
+    }
+  }
+
+  visitRequestFinished(_visit: Visit) {
+    this.progressBar.setValue(1)
+    this.hideVisitProgressBar()
+  }
+
+  visitCompleted(_visit: Visit) {}
+
+  pageInvalidated(reason: ReloadReason) {
+    this.reload(reason)
+  }
+
+  visitFailed(_visit: Visit) {}
+
+  visitRendered(_visit: Visit) {}
+
+  formSubmissionStarted(_formSubmission: FormSubmission) {
+    this.progressBar.setValue(0)
+    this.showFormProgressBarAfterDelay()
+  }
+
+  formSubmissionFinished(_formSubmission: FormSubmission) {
+    this.progressBar.setValue(1)
+    this.hideFormProgressBar()
+  }
+
+  // Private
+
+  showVisitProgressBarAfterDelay() {
+    this.visitProgressBarTimeout = window.setTimeout(this.showProgressBar, this.session.progressBarDelay)
+  }
+
+  hideVisitProgressBar() {
+    this.progressBar.hide()
+    if (this.visitProgressBarTimeout != null) {
+      window.clearTimeout(this.visitProgressBarTimeout)
+      delete this.visitProgressBarTimeout
+    }
+  }
+
+  showFormProgressBarAfterDelay() {
+    if (this.formProgressBarTimeout == null) {
+      this.formProgressBarTimeout = window.setTimeout(this.showProgressBar, this.session.progressBarDelay)
+    }
+  }
+
+  hideFormProgressBar() {
+    this.progressBar.hide()
+    if (this.formProgressBarTimeout != null) {
+      window.clearTimeout(this.formProgressBarTimeout)
+      delete this.formProgressBarTimeout
+    }
+  }
+
+  showProgressBar = () => {
+    this.progressBar.show()
+  }
+
+  reload(reason: ReloadReason) {
+    dispatch("turbo:reload", { detail: reason })
+
+    window.location.href = this.location?.toString() || window.location.href
+  }
+
+  get navigator() {
+    return this.session.navigator
+  }
+}

--- a/src/core/renderer.ts
+++ b/src/core/renderer.ts
@@ -1,0 +1,100 @@
+import { Bardo, BardoDelegate } from "./bardo"
+import { Snapshot } from "./snapshot"
+import { ReloadReason } from "./native/browser_adapter"
+
+type ResolvingFunctions<T = unknown> = {
+  resolve(value: T | PromiseLike<T>): void
+  reject(reason?: any): void
+}
+
+export type Render<E> = (currentElement: E, newElement: E) => void
+
+export abstract class Renderer<E extends Element, S extends Snapshot<E> = Snapshot<E>> implements BardoDelegate {
+  readonly currentSnapshot: S
+  readonly newSnapshot: S
+  readonly isPreview: boolean
+  readonly willRender: boolean
+  readonly promise: Promise<void>
+  renderElement: Render<E>
+  private resolvingFunctions?: ResolvingFunctions<void>
+  private activeElement: Element | null = null
+
+  constructor(currentSnapshot: S, newSnapshot: S, renderElement: Render<E>, isPreview: boolean, willRender = true) {
+    this.currentSnapshot = currentSnapshot
+    this.newSnapshot = newSnapshot
+    this.isPreview = isPreview
+    this.willRender = willRender
+    this.renderElement = renderElement
+    this.promise = new Promise((resolve, reject) => (this.resolvingFunctions = { resolve, reject }))
+  }
+
+  get shouldRender() {
+    return true
+  }
+
+  get reloadReason(): ReloadReason {
+    return
+  }
+
+  prepareToRender() {
+    return
+  }
+
+  abstract render(): Promise<void>
+
+  finishRendering() {
+    if (this.resolvingFunctions) {
+      this.resolvingFunctions.resolve()
+      delete this.resolvingFunctions
+    }
+  }
+
+  async preservingPermanentElements(callback: () => void) {
+    await Bardo.preservingPermanentElements(this, this.permanentElementMap, callback)
+  }
+
+  focusFirstAutofocusableElement() {
+    const element = this.connectedSnapshot.firstAutofocusableElement
+    if (elementIsFocusable(element)) {
+      element.focus()
+    }
+  }
+
+  // Bardo delegate
+
+  enteringBardo(currentPermanentElement: Element) {
+    if (this.activeElement) return
+
+    if (currentPermanentElement.contains(this.currentSnapshot.activeElement)) {
+      this.activeElement = this.currentSnapshot.activeElement
+    }
+  }
+
+  leavingBardo(currentPermanentElement: Element) {
+    if (currentPermanentElement.contains(this.activeElement) && this.activeElement instanceof HTMLElement) {
+      this.activeElement.focus()
+
+      this.activeElement = null
+    }
+  }
+
+  get connectedSnapshot() {
+    return this.newSnapshot.isConnected ? this.newSnapshot : this.currentSnapshot
+  }
+
+  get currentElement() {
+    return this.currentSnapshot.element
+  }
+
+  get newElement() {
+    return this.newSnapshot.element
+  }
+
+  get permanentElementMap() {
+    return this.currentSnapshot.getPermanentElementMapForSnapshot(this.newSnapshot)
+  }
+}
+
+function elementIsFocusable(element: any): element is { focus: () => void } {
+  return element && typeof element.focus == "function"
+}

--- a/src/core/session.ts
+++ b/src/core/session.ts
@@ -1,0 +1,461 @@
+import { Adapter } from "./native/adapter"
+import { BrowserAdapter, ReloadReason } from "./native/browser_adapter"
+import { CacheObserver } from "../observers/cache_observer"
+import { FormSubmitObserver, FormSubmitObserverDelegate } from "../observers/form_submit_observer"
+import { FrameRedirector } from "./frames/frame_redirector"
+import { History, HistoryDelegate } from "./drive/history"
+import { LinkClickObserver, LinkClickObserverDelegate } from "../observers/link_click_observer"
+import { FormLinkClickObserver, FormLinkClickObserverDelegate } from "../observers/form_link_click_observer"
+import { getAction, expandURL, locationIsVisitable, Locatable } from "./url"
+import { Navigator, NavigatorDelegate } from "./drive/navigator"
+import { PageObserver, PageObserverDelegate } from "../observers/page_observer"
+import { ScrollObserver } from "../observers/scroll_observer"
+import { StreamMessage } from "./streams/stream_message"
+import { StreamMessageRenderer } from "./streams/stream_message_renderer"
+import { StreamObserver } from "../observers/stream_observer"
+import { Action, Position, StreamSource } from "./types"
+import { clearBusyState, dispatch, findClosestRecursively, getVisitAction, markAsBusy } from "../util"
+import { PageView, PageViewDelegate, PageViewRenderOptions } from "./drive/page_view"
+import { Visit, VisitOptions } from "./drive/visit"
+import { PageSnapshot } from "./drive/page_snapshot"
+import { FrameElement } from "../elements/frame_element"
+import { FrameViewRenderOptions } from "./frames/frame_view"
+import { FetchResponse } from "../http/fetch_response"
+import { Preloader, PreloaderDelegate } from "./drive/preloader"
+
+export type FormMode = "on" | "off" | "optin"
+export type TimingData = unknown
+export type TurboBeforeCacheEvent = CustomEvent
+export type TurboBeforeRenderEvent = CustomEvent<
+  { newBody: HTMLBodyElement; isPreview: boolean } & PageViewRenderOptions
+>
+export type TurboBeforeVisitEvent = CustomEvent<{ url: string }>
+export type TurboClickEvent = CustomEvent<{ url: string; originalEvent: MouseEvent }>
+export type TurboFrameLoadEvent = CustomEvent
+export type TurboBeforeFrameRenderEvent = CustomEvent<{ newFrame: FrameElement } & FrameViewRenderOptions>
+export type TurboFrameRenderEvent = CustomEvent<{ fetchResponse: FetchResponse }>
+export type TurboLoadEvent = CustomEvent<{ url: string; timing: TimingData }>
+export type TurboRenderEvent = CustomEvent<{ isPreview: boolean }>
+export type TurboVisitEvent = CustomEvent<{ url: string; action: Action }>
+
+export class Session
+  implements
+    FormSubmitObserverDelegate,
+    HistoryDelegate,
+    FormLinkClickObserverDelegate,
+    LinkClickObserverDelegate,
+    NavigatorDelegate,
+    PageObserverDelegate,
+    PageViewDelegate,
+    PreloaderDelegate
+{
+  readonly navigator = new Navigator(this)
+  readonly history = new History(this)
+  readonly preloader = new Preloader(this)
+  readonly view = new PageView(this, document.documentElement as HTMLBodyElement)
+  adapter: Adapter = new BrowserAdapter(this)
+
+  readonly pageObserver = new PageObserver(this)
+  readonly cacheObserver = new CacheObserver()
+  readonly linkClickObserver = new LinkClickObserver(this, window)
+  readonly formSubmitObserver = new FormSubmitObserver(this, document)
+  readonly scrollObserver = new ScrollObserver(this)
+  readonly streamObserver = new StreamObserver(this)
+  readonly formLinkClickObserver = new FormLinkClickObserver(this, document.documentElement)
+  readonly frameRedirector = new FrameRedirector(this, document.documentElement)
+  readonly streamMessageRenderer = new StreamMessageRenderer()
+
+  drive = true
+  enabled = true
+  progressBarDelay = 500
+  started = false
+  formMode: FormMode = "on"
+
+  start() {
+    if (!this.started) {
+      this.pageObserver.start()
+      this.cacheObserver.start()
+      this.formLinkClickObserver.start()
+      this.linkClickObserver.start()
+      this.formSubmitObserver.start()
+      this.scrollObserver.start()
+      this.streamObserver.start()
+      this.frameRedirector.start()
+      this.history.start()
+      this.preloader.start()
+      this.started = true
+      this.enabled = true
+    }
+  }
+
+  disable() {
+    this.enabled = false
+  }
+
+  stop() {
+    if (this.started) {
+      this.pageObserver.stop()
+      this.cacheObserver.stop()
+      this.formLinkClickObserver.stop()
+      this.linkClickObserver.stop()
+      this.formSubmitObserver.stop()
+      this.scrollObserver.stop()
+      this.streamObserver.stop()
+      this.frameRedirector.stop()
+      this.history.stop()
+      this.started = false
+    }
+  }
+
+  registerAdapter(adapter: Adapter) {
+    this.adapter = adapter
+  }
+
+  visit(location: Locatable, options: Partial<VisitOptions> = {}) {
+    const frameElement = options.frame ? document.getElementById(options.frame) : null
+
+    if (frameElement instanceof FrameElement) {
+      frameElement.src = location.toString()
+      frameElement.loaded
+    } else {
+      this.navigator.proposeVisit(expandURL(location), options)
+    }
+  }
+
+  connectStreamSource(source: StreamSource) {
+    this.streamObserver.connectStreamSource(source)
+  }
+
+  disconnectStreamSource(source: StreamSource) {
+    this.streamObserver.disconnectStreamSource(source)
+  }
+
+  renderStreamMessage(message: StreamMessage | string) {
+    this.streamMessageRenderer.render(StreamMessage.wrap(message))
+  }
+
+  clearCache() {
+    this.view.clearSnapshotCache()
+  }
+
+  setProgressBarDelay(delay: number) {
+    this.progressBarDelay = delay
+  }
+
+  setFormMode(mode: FormMode) {
+    this.formMode = mode
+  }
+
+  get location() {
+    return this.history.location
+  }
+
+  get restorationIdentifier() {
+    return this.history.restorationIdentifier
+  }
+
+  // History delegate
+
+  historyPoppedToLocationWithRestorationIdentifier(location: URL, restorationIdentifier: string) {
+    if (this.enabled) {
+      this.navigator.startVisit(location, restorationIdentifier, {
+        action: "restore",
+        historyChanged: true,
+      })
+    } else {
+      this.adapter.pageInvalidated({
+        reason: "turbo_disabled",
+      })
+    }
+  }
+
+  // Scroll observer delegate
+
+  scrollPositionChanged(position: Position) {
+    this.history.updateRestorationData({ scrollPosition: position })
+  }
+
+  // Form click observer delegate
+
+  willSubmitFormLinkToLocation(link: Element, location: URL): boolean {
+    return this.elementIsNavigatable(link) && locationIsVisitable(location, this.snapshot.rootLocation)
+  }
+
+  submittedFormLinkToLocation() {}
+
+  // Link click observer delegate
+
+  willFollowLinkToLocation(link: Element, location: URL, event: MouseEvent) {
+    return (
+      this.elementIsNavigatable(link) &&
+      locationIsVisitable(location, this.snapshot.rootLocation) &&
+      this.applicationAllowsFollowingLinkToLocation(link, location, event)
+    )
+  }
+
+  followedLinkToLocation(link: Element, location: URL) {
+    const action = this.getActionForLink(link)
+    const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
+
+    this.visit(location.href, { action, acceptsStreamResponse })
+  }
+
+  // Navigator delegate
+
+  allowsVisitingLocationWithAction(location: URL, action?: Action) {
+    return this.locationWithActionIsSamePage(location, action) || this.applicationAllowsVisitingLocation(location)
+  }
+
+  visitProposedToLocation(location: URL, options: Partial<VisitOptions>) {
+    extendURLWithDeprecatedProperties(location)
+    this.adapter.visitProposedToLocation(location, options)
+  }
+
+  visitStarted(visit: Visit) {
+    if (!visit.acceptsStreamResponse) {
+      markAsBusy(document.documentElement)
+    }
+    extendURLWithDeprecatedProperties(visit.location)
+    if (!visit.silent) {
+      this.notifyApplicationAfterVisitingLocation(visit.location, visit.action)
+    }
+  }
+
+  visitCompleted(visit: Visit) {
+    clearBusyState(document.documentElement)
+    this.notifyApplicationAfterPageLoad(visit.getTimingMetrics())
+  }
+
+  locationWithActionIsSamePage(location: URL, action?: Action): boolean {
+    return this.navigator.locationWithActionIsSamePage(location, action)
+  }
+
+  visitScrolledToSamePageLocation(oldURL: URL, newURL: URL) {
+    this.notifyApplicationAfterVisitingSamePageLocation(oldURL, newURL)
+  }
+
+  // Form submit observer delegate
+
+  willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+    const action = getAction(form, submitter)
+
+    return (
+      this.submissionIsNavigatable(form, submitter) &&
+      locationIsVisitable(expandURL(action), this.snapshot.rootLocation)
+    )
+  }
+
+  formSubmitted(form: HTMLFormElement, submitter?: HTMLElement) {
+    this.navigator.submitForm(form, submitter)
+  }
+
+  // Page observer delegate
+
+  pageBecameInteractive() {
+    this.view.lastRenderedLocation = this.location
+    this.notifyApplicationAfterPageLoad()
+  }
+
+  pageLoaded() {
+    this.history.assumeControlOfScrollRestoration()
+  }
+
+  pageWillUnload() {
+    this.history.relinquishControlOfScrollRestoration()
+  }
+
+  // Stream observer delegate
+
+  receivedMessageFromStream(message: StreamMessage) {
+    this.renderStreamMessage(message)
+  }
+
+  // Page view delegate
+
+  viewWillCacheSnapshot() {
+    if (!this.navigator.currentVisit?.silent) {
+      this.notifyApplicationBeforeCachingSnapshot()
+    }
+  }
+
+  allowsImmediateRender({ element }: PageSnapshot, isPreview: boolean, options: PageViewRenderOptions) {
+    const event = this.notifyApplicationBeforeRender(element, isPreview, options)
+    const {
+      defaultPrevented,
+      detail: { render },
+    } = event
+
+    if (this.view.renderer && render) {
+      this.view.renderer.renderElement = render
+    }
+
+    return !defaultPrevented
+  }
+
+  viewRenderedSnapshot(_snapshot: PageSnapshot, isPreview: boolean) {
+    this.view.lastRenderedLocation = this.history.location
+    this.notifyApplicationAfterRender(isPreview)
+  }
+
+  preloadOnLoadLinksForView(element: Element) {
+    this.preloader.preloadOnLoadLinksForView(element)
+  }
+
+  viewInvalidated(reason: ReloadReason) {
+    this.adapter.pageInvalidated(reason)
+  }
+
+  // Frame element
+
+  frameLoaded(frame: FrameElement) {
+    this.notifyApplicationAfterFrameLoad(frame)
+  }
+
+  frameRendered(fetchResponse: FetchResponse, frame: FrameElement) {
+    this.notifyApplicationAfterFrameRender(fetchResponse, frame)
+  }
+
+  // Application events
+
+  applicationAllowsFollowingLinkToLocation(link: Element, location: URL, ev: MouseEvent) {
+    const event = this.notifyApplicationAfterClickingLinkToLocation(link, location, ev)
+    return !event.defaultPrevented
+  }
+
+  applicationAllowsVisitingLocation(location: URL) {
+    const event = this.notifyApplicationBeforeVisitingLocation(location)
+    return !event.defaultPrevented
+  }
+
+  notifyApplicationAfterClickingLinkToLocation(link: Element, location: URL, event: MouseEvent) {
+    return dispatch<TurboClickEvent>("turbo:click", {
+      target: link,
+      detail: { url: location.href, originalEvent: event },
+      cancelable: true,
+    })
+  }
+
+  notifyApplicationBeforeVisitingLocation(location: URL) {
+    return dispatch<TurboBeforeVisitEvent>("turbo:before-visit", {
+      detail: { url: location.href },
+      cancelable: true,
+    })
+  }
+
+  notifyApplicationAfterVisitingLocation(location: URL, action: Action) {
+    return dispatch<TurboVisitEvent>("turbo:visit", { detail: { url: location.href, action } })
+  }
+
+  notifyApplicationBeforeCachingSnapshot() {
+    return dispatch<TurboBeforeCacheEvent>("turbo:before-cache")
+  }
+
+  notifyApplicationBeforeRender(newBody: HTMLBodyElement, isPreview: boolean, options: PageViewRenderOptions) {
+    return dispatch<TurboBeforeRenderEvent>("turbo:before-render", {
+      detail: { newBody, isPreview, ...options },
+      cancelable: true,
+    })
+  }
+
+  notifyApplicationAfterRender(isPreview: boolean) {
+    return dispatch<TurboRenderEvent>("turbo:render", { detail: { isPreview } })
+  }
+
+  notifyApplicationAfterPageLoad(timing: TimingData = {}) {
+    return dispatch<TurboLoadEvent>("turbo:load", {
+      detail: { url: this.location.href, timing },
+    })
+  }
+
+  notifyApplicationAfterVisitingSamePageLocation(oldURL: URL, newURL: URL) {
+    dispatchEvent(
+      new HashChangeEvent("hashchange", {
+        oldURL: oldURL.toString(),
+        newURL: newURL.toString(),
+      })
+    )
+  }
+
+  notifyApplicationAfterFrameLoad(frame: FrameElement) {
+    return dispatch<TurboFrameLoadEvent>("turbo:frame-load", { target: frame })
+  }
+
+  notifyApplicationAfterFrameRender(fetchResponse: FetchResponse, frame: FrameElement) {
+    return dispatch<TurboFrameRenderEvent>("turbo:frame-render", {
+      detail: { fetchResponse },
+      target: frame,
+      cancelable: true,
+    })
+  }
+
+  // Helpers
+
+  submissionIsNavigatable(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+    if (this.formMode == "off") {
+      return false
+    } else {
+      const submitterIsNavigatable = submitter ? this.elementIsNavigatable(submitter) : true
+
+      if (this.formMode == "optin") {
+        return submitterIsNavigatable && form.closest('[data-turbo="true"]') != null
+      } else {
+        return submitterIsNavigatable && this.elementIsNavigatable(form)
+      }
+    }
+  }
+
+  elementIsNavigatable(element: Element): boolean {
+    const container = findClosestRecursively(element, "[data-turbo]")
+    const withinFrame = findClosestRecursively(element, "turbo-frame")
+
+    // Check if Drive is enabled on the session or we're within a Frame.
+    if (this.drive || withinFrame) {
+      // Element is navigatable by default, unless `data-turbo="false"`.
+      if (container) {
+        return container.getAttribute("data-turbo") != "false"
+      } else {
+        return true
+      }
+    } else {
+      // Element isn't navigatable by default, unless `data-turbo="true"`.
+      if (container) {
+        return container.getAttribute("data-turbo") == "true"
+      } else {
+        return false
+      }
+    }
+  }
+
+  // Private
+
+  getActionForLink(link: Element): Action {
+    return getVisitAction(link) || "advance"
+  }
+
+  get snapshot() {
+    return this.view.snapshot
+  }
+}
+
+// Older versions of the Turbo Native adapters referenced the
+// `Location#absoluteURL` property in their implementations of
+// the `Adapter#visitProposedToLocation()` and `#visitStarted()`
+// methods. The Location class has since been removed in favor
+// of the DOM URL API, and accordingly all Adapter methods now
+// receive URL objects.
+//
+// We alias #absoluteURL to #toString() here to avoid crashing
+// older adapters which do not expect URL objects. We should
+// consider removing this support at some point in the future.
+
+function extendURLWithDeprecatedProperties(url: URL) {
+  Object.defineProperties(url, deprecatedLocationPropertyDescriptors)
+}
+
+const deprecatedLocationPropertyDescriptors = {
+  absoluteURL: {
+    get() {
+      return this.toString()
+    },
+  },
+}

--- a/src/core/snapshot.ts
+++ b/src/core/snapshot.ts
@@ -1,0 +1,70 @@
+export class Snapshot<E extends Element = Element> {
+  readonly element: E
+
+  constructor(element: E) {
+    this.element = element
+  }
+
+  get activeElement() {
+    return this.element.ownerDocument.activeElement
+  }
+
+  get children() {
+    return [...this.element.children]
+  }
+
+  hasAnchor(anchor: string | undefined) {
+    return this.getElementForAnchor(anchor) != null
+  }
+
+  getElementForAnchor(anchor: string | undefined) {
+    return anchor ? this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`) : null
+  }
+
+  get isConnected() {
+    return this.element.isConnected
+  }
+
+  get firstAutofocusableElement() {
+    const inertDisabledOrHidden = "[inert], :disabled, [hidden], details:not([open]), dialog:not([open])"
+
+    for (const element of this.element.querySelectorAll("[autofocus]")) {
+      if (element.closest(inertDisabledOrHidden) == null) return element
+      else continue
+    }
+
+    return null
+  }
+
+  get permanentElements() {
+    return queryPermanentElementsAll(this.element)
+  }
+
+  getPermanentElementById(id: string) {
+    return getPermanentElementById(this.element, id)
+  }
+
+  getPermanentElementMapForSnapshot(snapshot: Snapshot) {
+    const permanentElementMap: PermanentElementMap = {}
+
+    for (const currentPermanentElement of this.permanentElements) {
+      const { id } = currentPermanentElement
+      const newPermanentElement = snapshot.getPermanentElementById(id)
+      if (newPermanentElement) {
+        permanentElementMap[id] = [currentPermanentElement, newPermanentElement]
+      }
+    }
+
+    return permanentElementMap
+  }
+}
+
+export function getPermanentElementById(node: ParentNode, id: string) {
+  return node.querySelector(`#${id}[data-turbo-permanent]`)
+}
+
+export function queryPermanentElementsAll(node: ParentNode) {
+  return node.querySelectorAll("[id][data-turbo-permanent]")
+}
+
+export type PermanentElementMap = Record<string, [Element, Element]>

--- a/src/core/streams/stream_actions.ts
+++ b/src/core/streams/stream_actions.ts
@@ -1,0 +1,39 @@
+import { StreamElement } from "../../elements/stream_element"
+
+export type TurboStreamAction = (this: StreamElement) => void
+export type TurboStreamActions = { [action: string]: TurboStreamAction }
+
+export const StreamActions: TurboStreamActions = {
+  after() {
+    this.targetElements.forEach((e) => e.parentElement?.insertBefore(this.templateContent, e.nextSibling))
+  },
+
+  append() {
+    this.removeDuplicateTargetChildren()
+    this.targetElements.forEach((e) => e.append(this.templateContent))
+  },
+
+  before() {
+    this.targetElements.forEach((e) => e.parentElement?.insertBefore(this.templateContent, e))
+  },
+
+  prepend() {
+    this.removeDuplicateTargetChildren()
+    this.targetElements.forEach((e) => e.prepend(this.templateContent))
+  },
+
+  remove() {
+    this.targetElements.forEach((e) => e.remove())
+  },
+
+  replace() {
+    this.targetElements.forEach((e) => e.replaceWith(this.templateContent))
+  },
+
+  update() {
+    this.targetElements.forEach((targetElement) => {
+      targetElement.innerHTML = ""
+      targetElement.append(this.templateContent)
+    })
+  },
+}

--- a/src/core/streams/stream_message.ts
+++ b/src/core/streams/stream_message.ts
@@ -1,0 +1,33 @@
+import { StreamElement } from "../../elements/stream_element"
+import { activateScriptElement, createDocumentFragment } from "../../util"
+
+export class StreamMessage {
+  static readonly contentType = "text/vnd.turbo-stream.html"
+  readonly fragment: DocumentFragment
+
+  static wrap(message: StreamMessage | string) {
+    if (typeof message == "string") {
+      return new this(createDocumentFragment(message))
+    } else {
+      return message
+    }
+  }
+
+  constructor(fragment: DocumentFragment) {
+    this.fragment = importStreamElements(fragment)
+  }
+}
+
+function importStreamElements(fragment: DocumentFragment): DocumentFragment {
+  for (const element of fragment.querySelectorAll<StreamElement>("turbo-stream")) {
+    const streamElement = document.importNode(element, true)
+
+    for (const inertScriptElement of streamElement.templateElement.content.querySelectorAll("script")) {
+      inertScriptElement.replaceWith(activateScriptElement(inertScriptElement))
+    }
+
+    element.replaceWith(streamElement)
+  }
+
+  return fragment
+}

--- a/src/core/streams/stream_message_renderer.ts
+++ b/src/core/streams/stream_message_renderer.ts
@@ -1,0 +1,36 @@
+import { StreamMessage } from "./stream_message"
+import { StreamElement } from "../../elements/stream_element"
+import { Bardo, BardoDelegate } from "../bardo"
+import { PermanentElementMap, getPermanentElementById, queryPermanentElementsAll } from "../snapshot"
+
+export class StreamMessageRenderer implements BardoDelegate {
+  render({ fragment }: StreamMessage) {
+    Bardo.preservingPermanentElements(this, getPermanentElementMapForFragment(fragment), () =>
+      document.documentElement.appendChild(fragment)
+    )
+  }
+
+  enteringBardo(currentPermanentElement: Element, newPermanentElement: Element) {
+    newPermanentElement.replaceWith(currentPermanentElement.cloneNode(true))
+  }
+
+  leavingBardo() {}
+}
+
+function getPermanentElementMapForFragment(fragment: DocumentFragment): PermanentElementMap {
+  const permanentElementsInDocument = queryPermanentElementsAll(document.documentElement)
+  const permanentElementMap: PermanentElementMap = {}
+  for (const permanentElementInDocument of permanentElementsInDocument) {
+    const { id } = permanentElementInDocument
+
+    for (const streamElement of fragment.querySelectorAll<StreamElement>("turbo-stream")) {
+      const elementInStream = getPermanentElementById(streamElement.templateElement.content, id)
+
+      if (elementInStream) {
+        permanentElementMap[id] = [permanentElementInDocument, elementInStream]
+      }
+    }
+  }
+
+  return permanentElementMap
+}

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -1,0 +1,16 @@
+export type Action = "advance" | "replace" | "restore"
+
+export type Position = { x: number; y: number }
+
+export type StreamSource = {
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void,
+    options?: boolean | AddEventListenerOptions
+  ): void
+  removeEventListener(
+    type: "message",
+    listener: (event: MessageEvent) => void,
+    options?: boolean | EventListenerOptions
+  ): void
+}

--- a/src/core/url.ts
+++ b/src/core/url.ts
@@ -1,0 +1,67 @@
+export type Locatable = URL | string
+
+export function expandURL(locatable: Locatable) {
+  return new URL(locatable.toString(), document.baseURI)
+}
+
+export function getAnchor(url: URL) {
+  let anchorMatch
+  if (url.hash) {
+    return url.hash.slice(1)
+    // eslint-disable-next-line no-cond-assign
+  } else if ((anchorMatch = url.href.match(/#(.*)$/))) {
+    return anchorMatch[1]
+  }
+}
+
+export function getAction(form: HTMLFormElement, submitter?: HTMLElement) {
+  const action = submitter?.getAttribute("formaction") || form.getAttribute("action") || form.action
+
+  return expandURL(action)
+}
+
+export function getExtension(url: URL) {
+  return (getLastPathComponent(url).match(/\.[^.]*$/) || [])[0] || ""
+}
+
+export function isHTML(url: URL) {
+  return !!getExtension(url).match(/^(?:|\.(?:htm|html|xhtml|php))$/)
+}
+
+export function isPrefixedBy(baseURL: URL, url: URL) {
+  const prefix = getPrefix(url)
+  return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
+}
+
+export function locationIsVisitable(location: URL, rootLocation: URL) {
+  return isPrefixedBy(location, rootLocation) && isHTML(location)
+}
+
+export function getRequestURL(url: URL) {
+  const anchor = getAnchor(url)
+  return anchor != null ? url.href.slice(0, -(anchor.length + 1)) : url.href
+}
+
+export function toCacheKey(url: URL) {
+  return getRequestURL(url)
+}
+
+export function urlsAreEqual(left: string, right: string) {
+  return expandURL(left).href == expandURL(right).href
+}
+
+function getPathComponents(url: URL) {
+  return url.pathname.split("/").slice(1)
+}
+
+function getLastPathComponent(url: URL) {
+  return getPathComponents(url).slice(-1)[0]
+}
+
+function getPrefix(url: URL) {
+  return addTrailingSlash(url.origin + url.pathname)
+}
+
+function addTrailingSlash(value: string) {
+  return value.endsWith("/") ? value : value + "/"
+}

--- a/src/core/view.ts
+++ b/src/core/view.ts
@@ -1,0 +1,135 @@
+import { ReloadReason } from "./native/browser_adapter"
+import { Renderer, Render } from "./renderer"
+import { Snapshot } from "./snapshot"
+import { Position } from "./types"
+import { getAnchor } from "./url"
+
+export interface ViewRenderOptions<E> {
+  resume: (value?: any) => void
+  render: Render<E>
+}
+
+export interface ViewDelegate<E extends Element, S extends Snapshot<E>> {
+  allowsImmediateRender(snapshot: S, isPreview: boolean, options: ViewRenderOptions<E>): boolean
+  preloadOnLoadLinksForView(element: Element): void
+  viewRenderedSnapshot(snapshot: S, isPreview: boolean): void
+  viewInvalidated(reason: ReloadReason): void
+}
+
+export abstract class View<
+  E extends Element,
+  S extends Snapshot<E> = Snapshot<E>,
+  R extends Renderer<E, S> = Renderer<E, S>,
+  D extends ViewDelegate<E, S> = ViewDelegate<E, S>
+> {
+  readonly delegate: D
+  readonly element: E
+  renderer?: R
+  abstract readonly snapshot: S
+  renderPromise?: Promise<void>
+  private resolveRenderPromise = (_value: any) => {}
+  private resolveInterceptionPromise = (_value: any) => {}
+
+  constructor(delegate: D, element: E) {
+    this.delegate = delegate
+    this.element = element
+  }
+
+  // Scrolling
+
+  scrollToAnchor(anchor: string | undefined) {
+    const element = this.snapshot.getElementForAnchor(anchor)
+    if (element) {
+      this.scrollToElement(element)
+      this.focusElement(element)
+    } else {
+      this.scrollToPosition({ x: 0, y: 0 })
+    }
+  }
+
+  scrollToAnchorFromLocation(location: URL) {
+    this.scrollToAnchor(getAnchor(location))
+  }
+
+  scrollToElement(element: Element) {
+    element.scrollIntoView()
+  }
+
+  focusElement(element: Element) {
+    if (element instanceof HTMLElement) {
+      if (element.hasAttribute("tabindex")) {
+        element.focus()
+      } else {
+        element.setAttribute("tabindex", "-1")
+        element.focus()
+        element.removeAttribute("tabindex")
+      }
+    }
+  }
+
+  scrollToPosition({ x, y }: Position) {
+    this.scrollRoot.scrollTo(x, y)
+  }
+
+  scrollToTop() {
+    this.scrollToPosition({ x: 0, y: 0 })
+  }
+
+  get scrollRoot(): { scrollTo(x: number, y: number): void } {
+    return window
+  }
+
+  // Rendering
+
+  async render(renderer: R) {
+    const { isPreview, shouldRender, newSnapshot: snapshot } = renderer
+    if (shouldRender) {
+      try {
+        this.renderPromise = new Promise((resolve) => (this.resolveRenderPromise = resolve))
+        this.renderer = renderer
+        await this.prepareToRenderSnapshot(renderer)
+
+        const renderInterception = new Promise((resolve) => (this.resolveInterceptionPromise = resolve))
+        const options = { resume: this.resolveInterceptionPromise, render: this.renderer.renderElement }
+        const immediateRender = this.delegate.allowsImmediateRender(snapshot, isPreview, options)
+        if (!immediateRender) await renderInterception
+
+        await this.renderSnapshot(renderer)
+        this.delegate.viewRenderedSnapshot(snapshot, isPreview)
+        this.delegate.preloadOnLoadLinksForView(this.element)
+        this.finishRenderingSnapshot(renderer)
+      } finally {
+        delete this.renderer
+        this.resolveRenderPromise(undefined)
+        delete this.renderPromise
+      }
+    } else {
+      this.invalidate(renderer.reloadReason)
+    }
+  }
+
+  invalidate(reason: ReloadReason) {
+    this.delegate.viewInvalidated(reason)
+  }
+
+  async prepareToRenderSnapshot(renderer: R) {
+    this.markAsPreview(renderer.isPreview)
+    await renderer.prepareToRender()
+  }
+
+  markAsPreview(isPreview: boolean) {
+    if (isPreview) {
+      this.element.setAttribute("data-turbo-preview", "")
+    } else {
+      this.element.removeAttribute("data-turbo-preview")
+    }
+  }
+
+  async renderSnapshot(renderer: R) {
+    await renderer.render()
+  }
+
+  finishRenderingSnapshot(renderer: R) {
+    renderer.finishRendering()
+  }
+}

--- a/src/elements/frame_element.ts
+++ b/src/elements/frame_element.ts
@@ -1,0 +1,196 @@
+import { FetchResponse } from "../http/fetch_response"
+import { Snapshot } from "../core/snapshot"
+import { LinkInterceptorDelegate } from "../core/frames/link_interceptor"
+import { FormSubmitObserverDelegate } from "../observers/form_submit_observer"
+
+export enum FrameLoadingStyle {
+  eager = "eager",
+  lazy = "lazy",
+}
+
+export type FrameElementObservedAttribute = keyof FrameElement & ("disabled" | "complete" | "loading" | "src")
+
+export interface FrameElementDelegate extends LinkInterceptorDelegate, FormSubmitObserverDelegate {
+  connect(): void
+  disconnect(): void
+  completeChanged(): void
+  loadingStyleChanged(): void
+  sourceURLChanged(): void
+  sourceURLReloaded(): Promise<void>
+  disabledChanged(): void
+  loadResponse(response: FetchResponse): void
+  proposeVisitIfNavigatedWithAction(frame: FrameElement, element: Element, submitter?: HTMLElement): void
+  fetchResponseLoaded: (fetchResponse: FetchResponse) => void
+  visitCachedSnapshot: (snapshot: Snapshot) => void
+  isLoading: boolean
+}
+
+/**
+ * Contains a fragment of HTML which is updated based on navigation within
+ * it (e.g. via links or form submissions).
+ *
+ * @customElement turbo-frame
+ * @example
+ *   <turbo-frame id="messages">
+ *     <a href="/messages/expanded">
+ *       Show all expanded messages in this frame.
+ *     </a>
+ *
+ *     <form action="/messages">
+ *       Show response from this form within this frame.
+ *     </form>
+ *   </turbo-frame>
+ */
+export class FrameElement extends HTMLElement {
+  static delegateConstructor: new (element: FrameElement) => FrameElementDelegate
+
+  loaded: Promise<void> = Promise.resolve()
+  readonly delegate: FrameElementDelegate
+
+  static get observedAttributes(): FrameElementObservedAttribute[] {
+    return ["disabled", "complete", "loading", "src"]
+  }
+
+  constructor() {
+    super()
+    this.delegate = new FrameElement.delegateConstructor(this)
+  }
+
+  connectedCallback() {
+    this.delegate.connect()
+  }
+
+  disconnectedCallback() {
+    this.delegate.disconnect()
+  }
+
+  reload(): Promise<void> {
+    return this.delegate.sourceURLReloaded()
+  }
+
+  attributeChangedCallback(name: string) {
+    if (name == "loading") {
+      this.delegate.loadingStyleChanged()
+    } else if (name == "complete") {
+      this.delegate.completeChanged()
+    } else if (name == "src") {
+      this.delegate.sourceURLChanged()
+    } else {
+      this.delegate.disabledChanged()
+    }
+  }
+
+  /**
+   * Gets the URL to lazily load source HTML from
+   */
+  get src() {
+    return this.getAttribute("src")
+  }
+
+  /**
+   * Sets the URL to lazily load source HTML from
+   */
+  set src(value: string | null) {
+    if (value) {
+      this.setAttribute("src", value)
+    } else {
+      this.removeAttribute("src")
+    }
+  }
+
+  /**
+   * Determines if the element is loading
+   */
+  get loading(): FrameLoadingStyle {
+    return frameLoadingStyleFromString(this.getAttribute("loading") || "")
+  }
+
+  /**
+   * Sets the value of if the element is loading
+   */
+  set loading(value: FrameLoadingStyle) {
+    if (value) {
+      this.setAttribute("loading", value)
+    } else {
+      this.removeAttribute("loading")
+    }
+  }
+
+  /**
+   * Gets the disabled state of the frame.
+   *
+   * If disabled, no requests will be intercepted by the frame.
+   */
+  get disabled() {
+    return this.hasAttribute("disabled")
+  }
+
+  /**
+   * Sets the disabled state of the frame.
+   *
+   * If disabled, no requests will be intercepted by the frame.
+   */
+  set disabled(value: boolean) {
+    if (value) {
+      this.setAttribute("disabled", "")
+    } else {
+      this.removeAttribute("disabled")
+    }
+  }
+
+  /**
+   * Gets the autoscroll state of the frame.
+   *
+   * If true, the frame will be scrolled into view automatically on update.
+   */
+  get autoscroll() {
+    return this.hasAttribute("autoscroll")
+  }
+
+  /**
+   * Sets the autoscroll state of the frame.
+   *
+   * If true, the frame will be scrolled into view automatically on update.
+   */
+  set autoscroll(value: boolean) {
+    if (value) {
+      this.setAttribute("autoscroll", "")
+    } else {
+      this.removeAttribute("autoscroll")
+    }
+  }
+
+  /**
+   * Determines if the element has finished loading
+   */
+  get complete() {
+    return !this.delegate.isLoading
+  }
+
+  /**
+   * Gets the active state of the frame.
+   *
+   * If inactive, source changes will not be observed.
+   */
+  get isActive() {
+    return this.ownerDocument === document && !this.isPreview
+  }
+
+  /**
+   * Sets the active state of the frame.
+   *
+   * If inactive, source changes will not be observed.
+   */
+  get isPreview() {
+    return this.ownerDocument?.documentElement?.hasAttribute("data-turbo-preview")
+  }
+}
+
+function frameLoadingStyleFromString(style: string) {
+  switch (style.toLowerCase()) {
+    case "lazy":
+      return FrameLoadingStyle.lazy
+    default:
+      return FrameLoadingStyle.eager
+  }
+}

--- a/src/elements/index.ts
+++ b/src/elements/index.ts
@@ -1,0 +1,22 @@
+import { FrameController } from "../core/frames/frame_controller"
+import { FrameElement } from "./frame_element"
+import { StreamElement } from "./stream_element"
+import { StreamSourceElement } from "./stream_source_element"
+
+FrameElement.delegateConstructor = FrameController
+
+export * from "./frame_element"
+export * from "./stream_element"
+export * from "./stream_source_element"
+
+if (customElements.get("turbo-frame") === undefined) {
+  customElements.define("turbo-frame", FrameElement)
+}
+
+if (customElements.get("turbo-stream") === undefined) {
+  customElements.define("turbo-stream", StreamElement)
+}
+
+if (customElements.get("turbo-stream-source") === undefined) {
+  customElements.define("turbo-stream-source", StreamSourceElement)
+}

--- a/src/elements/stream_element.ts
+++ b/src/elements/stream_element.ts
@@ -1,0 +1,187 @@
+import { StreamActions } from "../core/streams/stream_actions"
+import { nextAnimationFrame } from "../util"
+
+type Render = (currentElement: StreamElement) => Promise<void>
+
+export type TurboBeforeStreamRenderEvent = CustomEvent<{ newStream: StreamElement; render: Render }>
+
+// <turbo-stream action=replace target=id><template>...
+
+/**
+ * Renders updates to the page from a stream of messages.
+ *
+ * Using the `action` attribute, this can be configured one of four ways:
+ *
+ * - `append` - appends the result to the container
+ * - `prepend` - prepends the result to the container
+ * - `replace` - replaces the contents of the container
+ * - `remove` - removes the container
+ * - `before` - inserts the result before the target
+ * - `after` - inserts the result after the target
+ *
+ * @customElement turbo-stream
+ * @example
+ *   <turbo-stream action="append" target="dom_id">
+ *     <template>
+ *       Content to append to container designated with the dom_id.
+ *     </template>
+ *   </turbo-stream>
+ */
+export class StreamElement extends HTMLElement {
+  static async renderElement(newElement: StreamElement): Promise<void> {
+    await newElement.performAction()
+  }
+
+  async connectedCallback() {
+    try {
+      await this.render()
+    } catch (error) {
+      console.error(error)
+    } finally {
+      this.disconnect()
+    }
+  }
+
+  private renderPromise?: Promise<void>
+
+  async render() {
+    return (this.renderPromise ??= (async () => {
+      const event = this.beforeRenderEvent
+
+      if (this.dispatchEvent(event)) {
+        await nextAnimationFrame()
+        await event.detail.render(this)
+      }
+    })())
+  }
+
+  disconnect() {
+    try {
+      this.remove()
+      // eslint-disable-next-line no-empty
+    } catch {}
+  }
+
+  /**
+   * Removes duplicate children (by ID)
+   */
+  removeDuplicateTargetChildren() {
+    this.duplicateChildren.forEach((c) => c.remove())
+  }
+
+  /**
+   * Gets the list of duplicate children (i.e. those with the same ID)
+   */
+  get duplicateChildren() {
+    const existingChildren = this.targetElements.flatMap((e) => [...e.children]).filter((c) => !!c.id)
+    const newChildrenIds = [...(this.templateContent?.children || [])].filter((c) => !!c.id).map((c) => c.id)
+
+    return existingChildren.filter((c) => newChildrenIds.includes(c.id))
+  }
+
+  /**
+   * Gets the action function to be performed.
+   */
+  get performAction() {
+    if (this.action) {
+      const actionFunction = StreamActions[this.action]
+      if (actionFunction) {
+        return actionFunction
+      }
+      this.raise("unknown action")
+    }
+    this.raise("action attribute is missing")
+  }
+
+  /**
+   * Gets the target elements which the template will be rendered to.
+   */
+  get targetElements() {
+    if (this.target) {
+      return this.targetElementsById
+    } else if (this.targets) {
+      return this.targetElementsByQuery
+    } else {
+      this.raise("target or targets attribute is missing")
+    }
+  }
+
+  /**
+   * Gets the contents of the main `<template>`.
+   */
+  get templateContent() {
+    return this.templateElement.content.cloneNode(true)
+  }
+
+  /**
+   * Gets the main `<template>` used for rendering
+   */
+  get templateElement() {
+    if (this.firstElementChild === null) {
+      const template = this.ownerDocument.createElement("template")
+      this.appendChild(template)
+      return template
+    } else if (this.firstElementChild instanceof HTMLTemplateElement) {
+      return this.firstElementChild
+    }
+    this.raise("first child element must be a <template> element")
+  }
+
+  /**
+   * Gets the current action.
+   */
+  get action() {
+    return this.getAttribute("action")
+  }
+
+  /**
+   * Gets the current target (an element ID) to which the result will
+   * be rendered.
+   */
+  get target() {
+    return this.getAttribute("target")
+  }
+
+  /**
+   * Gets the current "targets" selector (a CSS selector)
+   */
+  get targets() {
+    return this.getAttribute("targets")
+  }
+
+  private raise(message: string): never {
+    throw new Error(`${this.description}: ${message}`)
+  }
+
+  private get description() {
+    return (this.outerHTML.match(/<[^>]+>/) ?? [])[0] ?? "<turbo-stream>"
+  }
+
+  private get beforeRenderEvent(): TurboBeforeStreamRenderEvent {
+    return new CustomEvent("turbo:before-stream-render", {
+      bubbles: true,
+      cancelable: true,
+      detail: { newStream: this, render: StreamElement.renderElement },
+    })
+  }
+
+  private get targetElementsById() {
+    const element = this.ownerDocument?.getElementById(this.target!)
+
+    if (element !== null) {
+      return [element]
+    } else {
+      return []
+    }
+  }
+
+  private get targetElementsByQuery() {
+    const elements = this.ownerDocument?.querySelectorAll(this.targets!)
+
+    if (elements.length !== 0) {
+      return Array.prototype.slice.call(elements)
+    } else {
+      return []
+    }
+  }
+}

--- a/src/elements/stream_source_element.ts
+++ b/src/elements/stream_source_element.ts
@@ -1,0 +1,22 @@
+import { StreamSource } from "../core/types"
+import { connectStreamSource, disconnectStreamSource } from "../core/index"
+
+export class StreamSourceElement extends HTMLElement {
+  streamSource: StreamSource | null = null
+
+  connectedCallback() {
+    this.streamSource = this.src.match(/^ws{1,2}:/) ? new WebSocket(this.src) : new EventSource(this.src)
+
+    connectStreamSource(this.streamSource)
+  }
+
+  disconnectedCallback() {
+    if (this.streamSource) {
+      disconnectStreamSource(this.streamSource)
+    }
+  }
+
+  get src(): string {
+    return this.getAttribute("src") || ""
+  }
+}

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -1,0 +1,13 @@
+interface SubmitEvent extends Event {
+  submitter: HTMLElement | null
+}
+
+interface Node {
+  // https://github.com/Microsoft/TypeScript/issues/283
+  cloneNode(deep?: boolean): this
+}
+
+interface Window {
+  Turbo: typeof import("./core/index")
+  SubmitEvent: typeof Event
+}

--- a/src/http/fetch_request.ts
+++ b/src/http/fetch_request.ts
@@ -1,0 +1,194 @@
+import { FetchResponse } from "./fetch_response"
+import { FrameElement } from "../elements/frame_element"
+import { dispatch } from "../util"
+
+export type TurboBeforeFetchRequestEvent = CustomEvent<{
+  fetchOptions: RequestInit
+  url: URL
+  resume: (value?: any) => void
+}>
+export type TurboBeforeFetchResponseEvent = CustomEvent<{
+  fetchResponse: FetchResponse
+}>
+export type TurboFetchRequestErrorEvent = CustomEvent<{
+  request: FetchRequest
+  error: Error
+}>
+
+export interface FetchRequestDelegate {
+  referrer?: URL
+
+  prepareRequest(request: FetchRequest): void
+  requestStarted(request: FetchRequest): void
+  requestPreventedHandlingResponse(request: FetchRequest, response: FetchResponse): void
+  requestSucceededWithResponse(request: FetchRequest, response: FetchResponse): void
+  requestFailedWithResponse(request: FetchRequest, response: FetchResponse): void
+  requestErrored(request: FetchRequest, error: Error): void
+  requestFinished(request: FetchRequest): void
+}
+
+export enum FetchMethod {
+  get,
+  post,
+  put,
+  patch,
+  delete,
+}
+
+export function fetchMethodFromString(method: string) {
+  switch (method.toLowerCase()) {
+    case "get":
+      return FetchMethod.get
+    case "post":
+      return FetchMethod.post
+    case "put":
+      return FetchMethod.put
+    case "patch":
+      return FetchMethod.patch
+    case "delete":
+      return FetchMethod.delete
+  }
+}
+
+export type FetchRequestBody = FormData | URLSearchParams
+
+export type FetchRequestHeaders = { [header: string]: string }
+
+export interface FetchRequestOptions {
+  headers: FetchRequestHeaders
+  body: FetchRequestBody
+  followRedirects: boolean
+}
+
+export class FetchRequest {
+  readonly delegate: FetchRequestDelegate
+  readonly method: FetchMethod
+  readonly headers: FetchRequestHeaders
+  readonly url: URL
+  readonly body?: FetchRequestBody
+  readonly target?: FrameElement | HTMLFormElement | null
+  readonly abortController = new AbortController()
+  private resolveRequestPromise = (_value: any) => {}
+
+  constructor(
+    delegate: FetchRequestDelegate,
+    method: FetchMethod,
+    location: URL,
+    body: FetchRequestBody = new URLSearchParams(),
+    target: FrameElement | HTMLFormElement | null = null
+  ) {
+    this.delegate = delegate
+    this.method = method
+    this.headers = this.defaultHeaders
+    this.body = body
+    this.url = location
+    this.target = target
+  }
+
+  get location(): URL {
+    return this.url
+  }
+
+  get params(): URLSearchParams {
+    return this.url.searchParams
+  }
+
+  get entries() {
+    return this.body ? Array.from(this.body.entries()) : []
+  }
+
+  cancel() {
+    this.abortController.abort()
+  }
+
+  async perform(): Promise<FetchResponse | void> {
+    const { fetchOptions } = this
+    this.delegate.prepareRequest(this)
+    await this.allowRequestToBeIntercepted(fetchOptions)
+    try {
+      this.delegate.requestStarted(this)
+      const response = await fetch(this.url.href, fetchOptions)
+      return await this.receive(response)
+    } catch (error) {
+      if ((error as Error).name !== "AbortError") {
+        if (this.willDelegateErrorHandling(error as Error)) {
+          this.delegate.requestErrored(this, error as Error)
+        }
+        throw error
+      }
+    } finally {
+      this.delegate.requestFinished(this)
+    }
+  }
+
+  async receive(response: Response): Promise<FetchResponse> {
+    const fetchResponse = new FetchResponse(response)
+    const event = dispatch<TurboBeforeFetchResponseEvent>("turbo:before-fetch-response", {
+      cancelable: true,
+      detail: { fetchResponse },
+      target: this.target as EventTarget,
+    })
+    if (event.defaultPrevented) {
+      this.delegate.requestPreventedHandlingResponse(this, fetchResponse)
+    } else if (fetchResponse.succeeded) {
+      this.delegate.requestSucceededWithResponse(this, fetchResponse)
+    } else {
+      this.delegate.requestFailedWithResponse(this, fetchResponse)
+    }
+    return fetchResponse
+  }
+
+  get fetchOptions(): RequestInit {
+    return {
+      method: FetchMethod[this.method].toUpperCase(),
+      credentials: "same-origin",
+      headers: this.headers,
+      redirect: "follow",
+      body: this.isSafe ? null : this.body,
+      signal: this.abortSignal,
+      referrer: this.delegate.referrer?.href,
+    }
+  }
+
+  get defaultHeaders() {
+    return {
+      Accept: "text/html, application/xhtml+xml",
+    }
+  }
+
+  get isSafe() {
+    return this.method === FetchMethod.get
+  }
+
+  get abortSignal() {
+    return this.abortController.signal
+  }
+
+  acceptResponseType(mimeType: string) {
+    this.headers["Accept"] = [mimeType, this.headers["Accept"]].join(", ")
+  }
+
+  private async allowRequestToBeIntercepted(fetchOptions: RequestInit) {
+    const requestInterception = new Promise((resolve) => (this.resolveRequestPromise = resolve))
+    const event = dispatch<TurboBeforeFetchRequestEvent>("turbo:before-fetch-request", {
+      cancelable: true,
+      detail: {
+        fetchOptions,
+        url: this.url,
+        resume: this.resolveRequestPromise,
+      },
+      target: this.target as EventTarget,
+    })
+    if (event.defaultPrevented) await requestInterception
+  }
+
+  private willDelegateErrorHandling(error: Error) {
+    const event = dispatch<TurboFetchRequestErrorEvent>("turbo:fetch-request-error", {
+      target: this.target as EventTarget,
+      cancelable: true,
+      detail: { request: this, error: error },
+    })
+
+    return !event.defaultPrevented
+  }
+}

--- a/src/http/fetch_response.ts
+++ b/src/http/fetch_response.ts
@@ -1,0 +1,61 @@
+import { expandURL } from "../core/url"
+
+export class FetchResponse {
+  readonly response: Response
+
+  constructor(response: Response) {
+    this.response = response
+  }
+
+  get succeeded() {
+    return this.response.ok
+  }
+
+  get failed() {
+    return !this.succeeded
+  }
+
+  get clientError() {
+    return this.statusCode >= 400 && this.statusCode <= 499
+  }
+
+  get serverError() {
+    return this.statusCode >= 500 && this.statusCode <= 599
+  }
+
+  get redirected() {
+    return this.response.redirected
+  }
+
+  get location(): URL {
+    return expandURL(this.response.url)
+  }
+
+  get isHTML() {
+    return this.contentType && this.contentType.match(/^(?:text\/([^\s;,]+\b)?html|application\/xhtml\+xml)\b/)
+  }
+
+  get statusCode() {
+    return this.response.status
+  }
+
+  get contentType() {
+    return this.header("Content-Type")
+  }
+
+  get responseText(): Promise<string> {
+    return this.response.clone().text()
+  }
+
+  get responseHTML(): Promise<string | undefined> {
+    if (this.isHTML) {
+      return this.response.clone().text()
+    } else {
+      return Promise.resolve(undefined)
+    }
+  }
+
+  header(name: string) {
+    return this.response.headers.get(name)
+  }
+}

--- a/src/http/index.ts
+++ b/src/http/index.ts
@@ -1,0 +1,5 @@
+export type {
+  TurboBeforeFetchRequestEvent,
+  TurboBeforeFetchResponseEvent,
+  TurboFetchRequestErrorEvent,
+} from "./fetch_request"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,12 @@
+import "./polyfills"
+import "./elements"
+import "./script_warning"
+
+import * as Turbo from "./core"
+
+window.Turbo = Turbo
+Turbo.start()
+
+export * from "./core"
+export * from "./elements"
+export * from "./http"

--- a/src/observers/appearance_observer.ts
+++ b/src/observers/appearance_observer.ts
@@ -1,0 +1,37 @@
+export interface AppearanceObserverDelegate<T extends Element> {
+  elementAppearedInViewport(element: T): void
+}
+
+export class AppearanceObserver<T extends Element> {
+  readonly delegate: AppearanceObserverDelegate<T>
+  readonly element: T
+  readonly intersectionObserver: IntersectionObserver
+  started = false
+
+  constructor(delegate: AppearanceObserverDelegate<T>, element: T) {
+    this.delegate = delegate
+    this.element = element
+    this.intersectionObserver = new IntersectionObserver(this.intersect)
+  }
+
+  start() {
+    if (!this.started) {
+      this.started = true
+      this.intersectionObserver.observe(this.element)
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.started = false
+      this.intersectionObserver.unobserve(this.element)
+    }
+  }
+
+  intersect: IntersectionObserverCallback = (entries) => {
+    const lastEntry = entries.slice(-1)[0]
+    if (lastEntry?.isIntersecting) {
+      this.delegate.elementAppearedInViewport(this.element)
+    }
+  }
+}

--- a/src/observers/cache_observer.ts
+++ b/src/observers/cache_observer.ts
@@ -1,0 +1,44 @@
+import { TurboBeforeCacheEvent } from "../core/session"
+
+export class CacheObserver {
+  readonly selector: string = "[data-turbo-temporary]"
+  readonly deprecatedSelector: string = "[data-turbo-cache=false]"
+
+  started = false
+
+  start() {
+    if (!this.started) {
+      this.started = true
+      addEventListener("turbo:before-cache", this.removeTemporaryElements, false)
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.started = false
+      removeEventListener("turbo:before-cache", this.removeTemporaryElements, false)
+    }
+  }
+
+  removeTemporaryElements = <EventListener>((_event: TurboBeforeCacheEvent) => {
+    for (const element of this.temporaryElements) {
+      element.remove()
+    }
+  })
+
+  get temporaryElements() {
+    return [...document.querySelectorAll(this.selector), ...this.temporaryElementsWithDeprecation]
+  }
+
+  get temporaryElementsWithDeprecation() {
+    const elements = document.querySelectorAll(this.deprecatedSelector)
+
+    if (elements.length) {
+      console.warn(
+        `The ${this.deprecatedSelector} selector is deprecated and will be removed in a future version. Use ${this.selector} instead.`
+      )
+    }
+
+    return [...elements]
+  }
+}

--- a/src/observers/form_link_click_observer.ts
+++ b/src/observers/form_link_click_observer.ts
@@ -1,0 +1,67 @@
+import { LinkClickObserver, LinkClickObserverDelegate } from "./link_click_observer"
+import { getVisitAction } from "../util"
+
+export type FormLinkClickObserverDelegate = {
+  willSubmitFormLinkToLocation(link: Element, location: URL, event: MouseEvent): boolean
+  submittedFormLinkToLocation(link: Element, location: URL, form: HTMLFormElement): void
+}
+
+export class FormLinkClickObserver implements LinkClickObserverDelegate {
+  readonly linkInterceptor: LinkClickObserver
+  readonly delegate: FormLinkClickObserverDelegate
+
+  constructor(delegate: FormLinkClickObserverDelegate, element: HTMLElement) {
+    this.delegate = delegate
+    this.linkInterceptor = new LinkClickObserver(this, element)
+  }
+
+  start() {
+    this.linkInterceptor.start()
+  }
+
+  stop() {
+    this.linkInterceptor.stop()
+  }
+
+  willFollowLinkToLocation(link: Element, location: URL, originalEvent: MouseEvent): boolean {
+    return (
+      this.delegate.willSubmitFormLinkToLocation(link, location, originalEvent) &&
+      link.hasAttribute("data-turbo-method")
+    )
+  }
+
+  followedLinkToLocation(link: Element, location: URL): void {
+    const form = document.createElement("form")
+
+    const type = "hidden"
+    for (const [name, value] of location.searchParams) {
+      form.append(Object.assign(document.createElement("input"), { type, name, value }))
+    }
+
+    const action = Object.assign(location, { search: "" })
+    form.setAttribute("data-turbo", "true")
+    form.setAttribute("action", action.href)
+    form.setAttribute("hidden", "")
+
+    const method = link.getAttribute("data-turbo-method")
+    if (method) form.setAttribute("method", method)
+
+    const turboFrame = link.getAttribute("data-turbo-frame")
+    if (turboFrame) form.setAttribute("data-turbo-frame", turboFrame)
+
+    const turboAction = getVisitAction(link)
+    if (turboAction) form.setAttribute("data-turbo-action", turboAction)
+
+    const turboConfirm = link.getAttribute("data-turbo-confirm")
+    if (turboConfirm) form.setAttribute("data-turbo-confirm", turboConfirm)
+
+    const turboStream = link.hasAttribute("data-turbo-stream")
+    if (turboStream) form.setAttribute("data-turbo-stream", "")
+
+    this.delegate.submittedFormLinkToLocation(link, location, form)
+
+    document.body.appendChild(form)
+    form.addEventListener("turbo:submit-end", () => form.remove(), { once: true })
+    requestAnimationFrame(() => form.requestSubmit())
+  }
+}

--- a/src/observers/form_submit_observer.ts
+++ b/src/observers/form_submit_observer.ts
@@ -1,0 +1,72 @@
+export interface FormSubmitObserverDelegate {
+  willSubmitForm(form: HTMLFormElement, submitter?: HTMLElement): boolean
+  formSubmitted(form: HTMLFormElement, submitter?: HTMLElement): void
+}
+
+export class FormSubmitObserver {
+  readonly delegate: FormSubmitObserverDelegate
+  readonly eventTarget: EventTarget
+  started = false
+
+  constructor(delegate: FormSubmitObserverDelegate, eventTarget: EventTarget) {
+    this.delegate = delegate
+    this.eventTarget = eventTarget
+  }
+
+  start() {
+    if (!this.started) {
+      this.eventTarget.addEventListener("submit", this.submitCaptured, true)
+      this.started = true
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.eventTarget.removeEventListener("submit", this.submitCaptured, true)
+      this.started = false
+    }
+  }
+
+  submitCaptured = () => {
+    this.eventTarget.removeEventListener("submit", this.submitBubbled, false)
+    this.eventTarget.addEventListener("submit", this.submitBubbled, false)
+  }
+
+  submitBubbled = <EventListener>((event: SubmitEvent) => {
+    if (!event.defaultPrevented) {
+      const form = event.target instanceof HTMLFormElement ? event.target : undefined
+      const submitter = event.submitter || undefined
+
+      if (
+        form &&
+        submissionDoesNotDismissDialog(form, submitter) &&
+        submissionDoesNotTargetIFrame(form, submitter) &&
+        this.delegate.willSubmitForm(form, submitter)
+      ) {
+        event.preventDefault()
+        event.stopImmediatePropagation()
+        this.delegate.formSubmitted(form, submitter)
+      }
+    }
+  })
+}
+
+function submissionDoesNotDismissDialog(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+  const method = submitter?.getAttribute("formmethod") || form.getAttribute("method")
+
+  return method != "dialog"
+}
+
+function submissionDoesNotTargetIFrame(form: HTMLFormElement, submitter?: HTMLElement): boolean {
+  if (submitter?.hasAttribute("formtarget") || form.hasAttribute("target")) {
+    const target = submitter?.getAttribute("formtarget") || form.target
+
+    for (const element of document.getElementsByName(target)) {
+      if (element instanceof HTMLIFrameElement) return false
+    }
+
+    return true
+  } else {
+    return true
+  }
+}

--- a/src/observers/link_click_observer.ts
+++ b/src/observers/link_click_observer.ts
@@ -1,0 +1,83 @@
+import { expandURL } from "../core/url"
+import { findClosestRecursively } from "../util"
+
+export interface LinkClickObserverDelegate {
+  willFollowLinkToLocation(link: Element, location: URL, event: MouseEvent): boolean
+  followedLinkToLocation(link: Element, location: URL): void
+}
+
+export class LinkClickObserver {
+  readonly delegate: LinkClickObserverDelegate
+  readonly eventTarget: EventTarget
+  started = false
+
+  constructor(delegate: LinkClickObserverDelegate, eventTarget: EventTarget) {
+    this.delegate = delegate
+    this.eventTarget = eventTarget
+  }
+
+  start() {
+    if (!this.started) {
+      this.eventTarget.addEventListener("click", this.clickCaptured, true)
+      this.started = true
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.eventTarget.removeEventListener("click", this.clickCaptured, true)
+      this.started = false
+    }
+  }
+
+  clickCaptured = () => {
+    this.eventTarget.removeEventListener("click", this.clickBubbled, false)
+    this.eventTarget.addEventListener("click", this.clickBubbled, false)
+  }
+
+  clickBubbled = (event: Event) => {
+    if (event instanceof MouseEvent && this.clickEventIsSignificant(event)) {
+      const target = (event.composedPath && event.composedPath()[0]) || event.target
+      const link = this.findLinkFromClickTarget(target)
+      if (link && doesNotTargetIFrame(link)) {
+        const location = this.getLocationForLink(link)
+        if (this.delegate.willFollowLinkToLocation(link, location, event)) {
+          event.preventDefault()
+          this.delegate.followedLinkToLocation(link, location)
+        }
+      }
+    }
+  }
+
+  clickEventIsSignificant(event: MouseEvent) {
+    return !(
+      (event.target && (event.target as any).isContentEditable) ||
+      event.defaultPrevented ||
+      event.which > 1 ||
+      event.altKey ||
+      event.ctrlKey ||
+      event.metaKey ||
+      event.shiftKey
+    )
+  }
+
+  findLinkFromClickTarget(target: EventTarget | null): HTMLAnchorElement | undefined {
+    return findClosestRecursively<HTMLAnchorElement>(target as Element, "a[href]:not([target^=_]):not([download])")
+  }
+
+  getLocationForLink(link: Element): URL {
+    return expandURL(link.getAttribute("href") || "")
+  }
+}
+
+function doesNotTargetIFrame(anchor: HTMLAnchorElement): boolean {
+  if (anchor.hasAttribute("target")) {
+    for (const element of document.getElementsByName(anchor.target)) {
+      if (element instanceof HTMLIFrameElement) return false
+    }
+
+    return true
+  } else {
+    return true
+  }
+}

--- a/src/observers/page_observer.ts
+++ b/src/observers/page_observer.ts
@@ -1,0 +1,73 @@
+export interface PageObserverDelegate {
+  pageBecameInteractive(): void
+  pageLoaded(): void
+  pageWillUnload(): void
+}
+
+export enum PageStage {
+  initial,
+  loading,
+  interactive,
+  complete,
+}
+
+export class PageObserver {
+  readonly delegate: PageObserverDelegate
+  stage = PageStage.initial
+  started = false
+
+  constructor(delegate: PageObserverDelegate) {
+    this.delegate = delegate
+  }
+
+  start() {
+    if (!this.started) {
+      if (this.stage == PageStage.initial) {
+        this.stage = PageStage.loading
+      }
+      document.addEventListener("readystatechange", this.interpretReadyState, false)
+      addEventListener("pagehide", this.pageWillUnload, false)
+      this.started = true
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      document.removeEventListener("readystatechange", this.interpretReadyState, false)
+      removeEventListener("pagehide", this.pageWillUnload, false)
+      this.started = false
+    }
+  }
+
+  interpretReadyState = () => {
+    const { readyState } = this
+    if (readyState == "interactive") {
+      this.pageIsInteractive()
+    } else if (readyState == "complete") {
+      this.pageIsComplete()
+    }
+  }
+
+  pageIsInteractive() {
+    if (this.stage == PageStage.loading) {
+      this.stage = PageStage.interactive
+      this.delegate.pageBecameInteractive()
+    }
+  }
+
+  pageIsComplete() {
+    this.pageIsInteractive()
+    if (this.stage == PageStage.interactive) {
+      this.stage = PageStage.complete
+      this.delegate.pageLoaded()
+    }
+  }
+
+  pageWillUnload = () => {
+    this.delegate.pageWillUnload()
+  }
+
+  get readyState() {
+    return document.readyState
+  }
+}

--- a/src/observers/scroll_observer.ts
+++ b/src/observers/scroll_observer.ts
@@ -1,0 +1,39 @@
+import { Position } from "../core/types"
+
+export interface ScrollObserverDelegate {
+  scrollPositionChanged(position: Position): void
+}
+
+export class ScrollObserver {
+  readonly delegate: ScrollObserverDelegate
+  started = false
+
+  constructor(delegate: ScrollObserverDelegate) {
+    this.delegate = delegate
+  }
+
+  start() {
+    if (!this.started) {
+      addEventListener("scroll", this.onScroll, false)
+      this.onScroll()
+      this.started = true
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      removeEventListener("scroll", this.onScroll, false)
+      this.started = false
+    }
+  }
+
+  onScroll = () => {
+    this.updatePosition({ x: window.pageXOffset, y: window.pageYOffset })
+  }
+
+  // Private
+
+  updatePosition(position: Position) {
+    this.delegate.scrollPositionChanged(position)
+  }
+}

--- a/src/observers/stream_observer.ts
+++ b/src/observers/stream_observer.ts
@@ -1,0 +1,87 @@
+import { TurboBeforeFetchResponseEvent } from "../http/fetch_request"
+import { FetchResponse } from "../http/fetch_response"
+import { StreamMessage } from "../core/streams/stream_message"
+import { StreamSource } from "../core/types"
+
+export interface StreamObserverDelegate {
+  receivedMessageFromStream(message: StreamMessage): void
+}
+
+export class StreamObserver {
+  readonly delegate: StreamObserverDelegate
+  readonly sources: Set<StreamSource> = new Set()
+  private started = false
+
+  constructor(delegate: StreamObserverDelegate) {
+    this.delegate = delegate
+  }
+
+  start() {
+    if (!this.started) {
+      this.started = true
+      addEventListener("turbo:before-fetch-response", this.inspectFetchResponse, false)
+    }
+  }
+
+  stop() {
+    if (this.started) {
+      this.started = false
+      removeEventListener("turbo:before-fetch-response", this.inspectFetchResponse, false)
+    }
+  }
+
+  connectStreamSource(source: StreamSource) {
+    if (!this.streamSourceIsConnected(source)) {
+      this.sources.add(source)
+      source.addEventListener("message", this.receiveMessageEvent, false)
+    }
+  }
+
+  disconnectStreamSource(source: StreamSource) {
+    if (this.streamSourceIsConnected(source)) {
+      this.sources.delete(source)
+      source.removeEventListener("message", this.receiveMessageEvent, false)
+    }
+  }
+
+  streamSourceIsConnected(source: StreamSource) {
+    return this.sources.has(source)
+  }
+
+  inspectFetchResponse = <EventListener>((event: TurboBeforeFetchResponseEvent) => {
+    const response = fetchResponseFromEvent(event)
+    if (response && fetchResponseIsStream(response)) {
+      event.preventDefault()
+      this.receiveMessageResponse(response)
+    }
+  })
+
+  receiveMessageEvent = (event: MessageEvent) => {
+    if (this.started && typeof event.data == "string") {
+      this.receiveMessageHTML(event.data)
+    }
+  }
+
+  async receiveMessageResponse(response: FetchResponse) {
+    const html = await response.responseHTML
+    if (html) {
+      this.receiveMessageHTML(html)
+    }
+  }
+
+  receiveMessageHTML(html: string) {
+    this.delegate.receivedMessageFromStream(StreamMessage.wrap(html))
+  }
+}
+
+function fetchResponseFromEvent(event: TurboBeforeFetchResponseEvent) {
+  const fetchResponse = event.detail?.fetchResponse
+  if (fetchResponse instanceof FetchResponse) {
+    return fetchResponse
+  }
+}
+
+function fetchResponseIsStream(response: FetchResponse) {
+  const contentType = response.contentType ?? ""
+  return contentType.startsWith(StreamMessage.contentType)
+}

--- a/src/polyfills/custom-elements-native-shim.ts
+++ b/src/polyfills/custom-elements-native-shim.ts
@@ -1,0 +1,50 @@
+/**
+ * @license
+ * Copyright (c) 2016 The Polymer Project Authors. All rights reserved.
+ * This code may only be used under the BSD style license found at
+ * http://polymer.github.io/LICENSE.txt The complete set of authors may be found
+ * at http://polymer.github.io/AUTHORS.txt The complete set of contributors may
+ * be found at http://polymer.github.io/CONTRIBUTORS.txt Code distributed by
+ * Google as part of the polymer project is also subject to an additional IP
+ * rights grant found at http://polymer.github.io/PATENTS.txt
+ */
+
+/**
+ * This shim allows elements written in, or compiled to, ES5 to work on native
+ * implementations of Custom Elements v1. It sets new.target to the value of
+ * this.constructor so that the native HTMLElement constructor can access the
+ * current under-construction element's definition.
+ */
+;(function () {
+  if (
+    // No Reflect, no classes, no need for shim because native custom elements
+    // require ES2015 classes or Reflect.
+    window.Reflect === undefined ||
+    window.customElements === undefined ||
+    // The webcomponentsjs custom elements polyfill doesn't require
+    // ES2015-compatible construction (`super()` or `Reflect.construct`).
+    (window.customElements as any).polyfillWrapFlushCallback
+  ) {
+    return
+  }
+  const BuiltInHTMLElement = HTMLElement
+
+  /**
+   * With jscompiler's RECOMMENDED_FLAGS the function name will be optimized away.
+   * However, if we declare the function as a property on an object literal, and
+   * use quotes for the property name, then closure will leave that much intact,
+   * which is enough for the JS VM to correctly set Function.prototype.name.
+   */
+  const wrapperForTheName = {
+    HTMLElement: function HTMLElement(this: HTMLElement) {
+      return Reflect.construct(BuiltInHTMLElement, [], this.constructor)
+    },
+  }
+  window.HTMLElement = wrapperForTheName["HTMLElement"] as unknown as typeof HTMLElement
+  HTMLElement.prototype = BuiltInHTMLElement.prototype
+  HTMLElement.prototype.constructor = HTMLElement
+  Object.setPrototypeOf(HTMLElement, BuiltInHTMLElement)
+})()
+
+// Required with --isolatedModules
+export {}

--- a/src/polyfills/form-request-submit-polyfill.js
+++ b/src/polyfills/form-request-submit-polyfill.js
@@ -1,18 +1,18 @@
 /**
  * The MIT License (MIT)
- *
+ * 
  * Copyright (c) 2019 Javan Makhmali
- *
+ * 
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
  * in the Software without restriction, including without limitation the rights
  * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
  * copies of the Software, and to permit persons to whom the Software is
  * furnished to do so, subject to the following conditions:
- *
+ * 
  * The above copyright notice and this permission notice shall be included in
  * all copies or substantial portions of the Software.
- *
+ * 
  * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
  * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
  * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
@@ -22,10 +22,10 @@
  * THE SOFTWARE.
  */
 
-(function (prototype) {
+(function(prototype) {
   if (typeof prototype.requestSubmit == "function") return
 
-  prototype.requestSubmit = function (submitter) {
+  prototype.requestSubmit = function(submitter) {
     if (submitter) {
       validateSubmitter(submitter, this)
       submitter.click()
@@ -42,11 +42,10 @@
   function validateSubmitter(submitter, form) {
     submitter instanceof HTMLElement || raise(TypeError, "parameter 1 is not of type 'HTMLElement'")
     submitter.type == "submit" || raise(TypeError, "The specified element is not a submit button")
-    submitter.form == form ||
-      raise(DOMException, "The specified element is not owned by this form element", "NotFoundError")
+    submitter.form == form || raise(DOMException, "The specified element is not owned by this form element", "NotFoundError")
   }
 
   function raise(errorConstructor, message, name) {
     throw new errorConstructor("Failed to execute 'requestSubmit' on 'HTMLFormElement': " + message + ".", name)
   }
-})(HTMLFormElement.prototype)
+})(HTMLFormElement.prototype);

--- a/src/polyfills/index.ts
+++ b/src/polyfills/index.ts
@@ -1,0 +1,3 @@
+import "./custom-elements-native-shim"
+import "./form-request-submit-polyfill"
+import "./submit-event"

--- a/src/polyfills/submit-event.ts
+++ b/src/polyfills/submit-event.ts
@@ -1,0 +1,48 @@
+type FormSubmitter = HTMLElement & { form?: HTMLFormElement; type?: string }
+
+const submittersByForm: WeakMap<HTMLFormElement, HTMLElement> = new WeakMap()
+
+function findSubmitterFromClickTarget(target: EventTarget | null): FormSubmitter | null {
+  const element = target instanceof Element ? target : target instanceof Node ? target.parentElement : null
+  const candidate = element ? (element.closest("input, button") as FormSubmitter | null) : null
+  return candidate?.type == "submit" ? candidate : null
+}
+
+function clickCaptured(event: Event) {
+  const submitter = findSubmitterFromClickTarget(event.target)
+
+  if (submitter && submitter.form) {
+    submittersByForm.set(submitter.form, submitter)
+  }
+}
+
+;(function () {
+  if ("submitter" in Event.prototype) return
+
+  let prototype = window.Event.prototype
+  // Certain versions of Safari 15 have a bug where they won't
+  // populate the submitter. This hurts TurboDrive's enable/disable detection.
+  // See https://bugs.webkit.org/show_bug.cgi?id=229660
+  if ("SubmitEvent" in window) {
+    const prototypeOfSubmitEvent = window.SubmitEvent.prototype
+
+    if (/Apple Computer/.test(navigator.vendor) && !("submitter" in prototypeOfSubmitEvent)) {
+      prototype = prototypeOfSubmitEvent
+    } else {
+      return // polyfill not needed
+    }
+  }
+
+  addEventListener("click", clickCaptured, true)
+
+  Object.defineProperty(prototype, "submitter", {
+    get(): HTMLElement | undefined {
+      if (this.type == "submit" && this.target instanceof HTMLFormElement) {
+        return submittersByForm.get(this.target)
+      }
+    },
+  })
+})()
+
+// Ensure TypeScript parses this file as a module
+export {}

--- a/src/script_warning.ts
+++ b/src/script_warning.ts
@@ -1,0 +1,27 @@
+import { unindent } from "./util"
+;(() => {
+  let element: Element | null = document.currentScript
+  if (!element) return
+  if (element.hasAttribute("data-turbo-suppress-warning")) return
+
+  element = element.parentElement
+  while (element) {
+    if (element == document.body) {
+      return console.warn(
+        unindent`
+        You are loading Turbo from a <script> element inside the <body> element. This is probably not what you meant to do!
+
+        Load your application’s JavaScript bundle inside the <head> element instead. <script> elements in <body> are evaluated with each page change.
+
+        For more information, see: https://turbo.hotwired.dev/handbook/building#working-with-script-elements
+
+        ——
+        Suppress this warning by adding a "data-turbo-suppress-warning" attribute to: %s
+      `,
+        element.outerHTML
+      )
+    }
+
+    element = element.parentElement
+  }
+})()

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -1,4 +1,4 @@
-(function (eventNames) {
+(function(eventNames) {
   function serializeToChannel(object, visited = new Set()) {
     const returned = {}
 
@@ -10,7 +10,7 @@
       } else if (value instanceof Element) {
         returned[key] = value.outerHTML
       } else if (typeof value == "object") {
-        if (visited.has(value)) {
+        if (visited.has(value))  {
           returned[key] = "skipped to prevent infinitely recursing"
         } else {
           visited.add(value)
@@ -27,44 +27,36 @@
 
   window.eventLogs = []
 
-  for (let i = 0; i < eventNames.length; i++) {
-    const eventName = eventNames[i]
+  for (var i = 0; i < eventNames.length; i++) {
+    var eventName = eventNames[i]
     addEventListener(eventName, eventListener, false)
   }
 
   function eventListener(event) {
     const skipped = document.documentElement.getAttribute("data-skip-event-details") || ""
 
-    window.eventLogs.push([
-      event.type,
-      serializeToChannel(skipped.includes(event.type) ? {} : event.detail),
-      event.target.id
-    ])
+    eventLogs.push([event.type, serializeToChannel(skipped.includes(event.type) ? {} : event.detail), event.target.id])
   }
   window.mutationLogs = []
 
-  new MutationObserver((mutations) => {
-    for (const { attributeName, target } of mutations.filter(({ type }) => type == "attributes")) {
-      if (target instanceof Element) {
-        window.mutationLogs.push([attributeName, target.id, target.getAttribute(attributeName)])
-      }
-    }
-  }).observe(document, { subtree: true, childList: true, attributes: true })
+   new MutationObserver((mutations) => {
+     for (const { attributeName, target } of mutations.filter(({ type }) => type == "attributes")) {
+       if (target instanceof Element) {
+         mutationLogs.push([attributeName, target.id, target.getAttribute(attributeName)])
+       }
+     }
+   }).observe(document, { subtree: true, childList: true, attributes: true })
 
   window.bodyMutationLogs = []
-  addEventListener(
-    "turbo:load",
-    () => {
-      new MutationObserver((mutations) => {
-        for (const { addedNodes } of mutations) {
-          for (const { localName, outerHTML } of addedNodes) {
-            if (localName == "body") window.bodyMutationLogs.push([outerHTML])
-          }
+  addEventListener("turbo:load", () => {
+    new MutationObserver((mutations) => {
+      for (const { addedNodes } of mutations) {
+        for (const { localName, outerHTML } of addedNodes) {
+          if (localName == "body") bodyMutationLogs.push([outerHTML])
         }
-      }).observe(document.documentElement, { childList: true })
-    },
-    { once: true }
-  )
+      }
+    }).observe(document.documentElement, { childList: true })
+  }, { once: true })
 })([
   "turbo:click",
   "turbo:before-stream-render",
@@ -86,50 +78,41 @@
   "turbo:reload"
 ])
 
-customElements.define(
-  "custom-link-element",
-  class extends HTMLElement {
-    constructor() {
-      super()
-      this.attachShadow({ mode: "open" })
-    }
-    connectedCallback() {
-      this.shadowRoot.innerHTML = `
-      <a href="${this.getAttribute("link")}">
-        ${this.getAttribute("text") || `<slot></slot>`}
+customElements.define('custom-link-element', class extends HTMLElement {
+  constructor() {
+    super()
+    this.attachShadow({ mode: 'open' })
+  }
+  connectedCallback() {
+    this.shadowRoot.innerHTML = `
+      <a href="${this.getAttribute('link')}">
+        ${this.getAttribute('text') || `<slot></slot>`}
       </a>
     `
-    }
   }
-)
+})
 
-customElements.define(
-  "custom-button",
-  class extends HTMLElement {
-    constructor() {
-      super()
-      this.attachShadow({ mode: "open" }).innerHTML = `
+customElements.define('custom-button', class extends HTMLElement {
+  constructor() {
+    super()
+    this.attachShadow({ mode: 'open' }).innerHTML = `
       <span>
         Drive in Shadow DOM
       </span>
     `
-    }
   }
-)
+})
 
-customElements.define(
-  "turbo-toggle",
-  class extends HTMLElement {
-    constructor() {
-      super()
-      this.attachShadow({ mode: "open" })
-    }
-    connectedCallback() {
-      this.shadowRoot.innerHTML = `
-      <div data-turbo="${this.getAttribute("turbo") || "true"}">
+customElements.define('turbo-toggle', class extends HTMLElement {
+  constructor() {
+    super()
+    this.attachShadow({ mode: 'open' })
+  }
+  connectedCallback() {
+    this.shadowRoot.innerHTML = `
+      <div data-turbo="${this.getAttribute('turbo') || 'true'}">
         <slot></slot>
       </div>
     `
-    }
   }
-)
+})

--- a/src/tests/functional/async_script_tests.ts
+++ b/src/tests/functional/async_script_tests.ts
@@ -1,0 +1,20 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { readEventLogs, visitAction } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/async_script.html")
+  await readEventLogs(page)
+})
+
+test("test does not emit turbo:load when loaded asynchronously after DOMContentLoaded", async ({ page }) => {
+  const events = await readEventLogs(page)
+
+  assert.deepEqual(events, [])
+})
+
+test("test following a link when loaded asynchronously after DOMContentLoaded", async ({ page }) => {
+  await page.click("#async-link")
+
+  assert.equal(await visitAction(page), "advance")
+})

--- a/src/tests/functional/autofocus_tests.ts
+++ b/src/tests/functional/autofocus_tests.ts
@@ -1,0 +1,110 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { hasSelector, nextBeat } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/autofocus.html")
+})
+
+test("test autofocus first autofocus element on load", async ({ page }) => {
+  await nextBeat()
+  assert.ok(
+    await hasSelector(page, "#first-autofocus-element:focus"),
+    "focuses the first [autofocus] element on the page"
+  )
+  assert.notOk(
+    await hasSelector(page, "#second-autofocus-element:focus"),
+    "focuses the first [autofocus] element on the page"
+  )
+})
+
+test("test autofocus first [autofocus] element on visit", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/navigation.html")
+  await page.click("#autofocus-link")
+  await nextBeat()
+
+  assert.ok(
+    await hasSelector(page, "#first-autofocus-element:focus"),
+    "focuses the first [autofocus] element on the page"
+  )
+  assert.notOk(
+    await hasSelector(page, "#second-autofocus-element:focus"),
+    "focuses the first [autofocus] element on the page"
+  )
+})
+
+test("test navigating a frame with a descendant link autofocuses [autofocus]:first-of-type", async ({ page }) => {
+  await page.click("#frame-inner-link")
+  await nextBeat()
+
+  assert.ok(
+    await hasSelector(page, "#frames-form-first-autofocus-element:focus"),
+    "focuses the first [autofocus] element in frame"
+  )
+  assert.notOk(
+    await hasSelector(page, "#frames-form-second-autofocus-element:focus"),
+    "focuses the first [autofocus] element in frame"
+  )
+})
+
+test("test autofocus visible [autofocus] element on visit with inert elements", async ({ page }) => {
+  await page.click("#autofocus-inert-link")
+  await nextBeat()
+
+  assert.notOk(
+    await hasSelector(page, "#dialog-autofocus-element:focus"),
+    "autofocus element is ignored in a closed dialog"
+  )
+  assert.notOk(
+    await hasSelector(page, "#details-autofocus-element:focus"),
+    "autofocus element is ignored in a closed details"
+  )
+  assert.notOk(
+    await hasSelector(page, "#hidden-autofocus-element:focus"),
+    "autofocus element is ignored in a hidden div"
+  )
+  assert.notOk(
+    await hasSelector(page, "#inert-autofocus-element:focus"),
+    "autofocus element is ignored in an inert div"
+  )
+  assert.notOk(
+    await hasSelector(page, "#disabled-autofocus-element:focus"),
+    "autofocus element is ignored when disabled"
+  )
+  assert.ok(
+    await hasSelector(page, "#visible-autofocus-element:focus"),
+    "focuses the visible [autofocus] element on the page"
+  )
+})
+
+test("test navigating a frame with a link targeting the frame autofocuses [autofocus]:first-of-type", async ({
+  page,
+}) => {
+  await page.click("#frame-outer-link")
+  await nextBeat()
+
+  assert.ok(
+    await hasSelector(page, "#frames-form-first-autofocus-element:focus"),
+    "focuses the first [autofocus] element in frame"
+  )
+  assert.notOk(
+    await hasSelector(page, "#frames-form-second-autofocus-element:focus"),
+    "focuses the first [autofocus] element in frame"
+  )
+})
+
+test("test navigating a frame with a turbo-frame targeting the frame autofocuses [autofocus]:first-of-type", async ({
+  page,
+}) => {
+  await page.click("#drives-frame-target-link")
+  await nextBeat()
+
+  assert.ok(
+    await hasSelector(page, "#frames-form-first-autofocus-element:focus"),
+    "focuses the first [autofocus] element in frame"
+  )
+  assert.notOk(
+    await hasSelector(page, "#frames-form-second-autofocus-element:focus"),
+    "focuses the first [autofocus] element in frame"
+  )
+})

--- a/src/tests/functional/cache_observer_tests.ts
+++ b/src/tests/functional/cache_observer_tests.ts
@@ -1,0 +1,37 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { hasSelector, nextBody } from "../helpers/page"
+
+test("test removes temporary elements", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/cache_observer.html")
+
+  assert.equal(await page.textContent("#temporary"), "data-turbo-temporary")
+
+  await page.click("#link")
+  await nextBody(page)
+  await page.goBack()
+  await nextBody(page)
+
+  assert.notOk(await hasSelector(page, "#temporary"))
+})
+
+test("test removes temporary elements with deprecated turbo-cache=false selector", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/cache_observer.html")
+
+  assert.equal(await page.textContent("#temporary-with-deprecated-selector"), "data-turbo-cache=false")
+
+  await page.click("#link")
+  await nextBody(page)
+  await page.goBack()
+  await nextBody(page)
+
+  assert.notOk(await hasSelector(page, "#temporary-with-deprecated-selector"))
+})
+
+test("test following a redirect renders [data-turbo-temporary] elements before the cache removes", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/navigation.html")
+  await page.click("#redirect-to-cache-observer")
+  await nextBody(page)
+
+  assert.equal(await page.textContent("#temporary"), "data-turbo-temporary")
+})

--- a/src/tests/functional/drive_disabled_tests.ts
+++ b/src/tests/functional/drive_disabled_tests.ts
@@ -1,0 +1,60 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import {
+  getFromLocalStorage,
+  nextBody,
+  nextEventOnTarget,
+  pathname,
+  searchParams,
+  setLocalStorageFromEvent,
+  visitAction,
+} from "../helpers/page"
+
+const path = "/src/tests/fixtures/drive_disabled.html"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(path)
+})
+
+test("test drive disabled by default; click normal link", async ({ page }) => {
+  await page.click("#drive_disabled")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), path)
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test drive disabled by default; click link inside data-turbo='true'", async ({ page }) => {
+  await page.click("#drive_enabled")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), path)
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test drive disabled by default; submit form inside data-turbo='true'", async ({ page }) => {
+  await setLocalStorageFromEvent(page, "turbo:submit-start", "formSubmitted", "true")
+
+  await page.click("#no_submitter_drive_enabled a#requestSubmit")
+  await nextBody(page)
+
+  assert.ok(await getFromLocalStorage(page, "formSubmitted"))
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.equal(await searchParams(page.url()).get("greeting"), "Hello from a redirect")
+})
+
+test("test drive disabled by default; links within <turbo-frame> navigate with Turbo", async ({ page }) => {
+  await page.click("#frame a")
+  await nextEventOnTarget(page, "frame", "turbo:frame-render")
+})
+
+test("test drive disabled by default; forms within <turbo-frame> navigate with Turbo", async ({ page }) => {
+  await page.click("#frame button")
+  await nextEventOnTarget(page, "frame", "turbo:frame-render")
+})
+
+test("test drive disabled by default; slot within <turbo-frame> navigate with Turbo", async ({ page }) => {
+  await page.click("#frame-navigation-with-slot")
+  await nextEventOnTarget(page, "frame", "turbo:frame-render")
+})

--- a/src/tests/functional/drive_tests.ts
+++ b/src/tests/functional/drive_tests.ts
@@ -1,0 +1,34 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBody, pathname, visitAction } from "../helpers/page"
+
+const path = "/src/tests/fixtures/drive.html"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto(path)
+})
+
+test("test drive enabled by default; click normal link", async ({ page }) => {
+  page.click("#drive_enabled")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), path)
+})
+
+test("test drive to external link", async ({ page }) => {
+  await page.route("https://example.com", async (route) => {
+    await route.fulfill({ body: "Hello from the outside world" })
+  })
+
+  page.click("#drive_enabled_external")
+  await nextBody(page)
+
+  assert.equal(await page.evaluate(() => window.location.href), "https://example.com/")
+  assert.equal(await page.textContent("body"), "Hello from the outside world")
+})
+
+test("test drive enabled by default; click link inside data-turbo='false'", async ({ page }) => {
+  page.click("#drive_disabled")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), path)
+  assert.equal(await visitAction(page), "load")
+})

--- a/src/tests/functional/drive_view_transition_tests.ts
+++ b/src/tests/functional/drive_view_transition_tests.ts
@@ -1,0 +1,30 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBody } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/transitions/left.html")
+
+  await page.evaluate(`
+    document.startViewTransition = (callback) => {
+      window.startViewTransitionCalled = true
+      callback()
+    }
+  `)
+})
+
+test("navigating triggers the view transition", async ({ page }) => {
+  await page.locator("#go-right").click()
+  await nextBody(page)
+
+  const called = await page.evaluate(`window.startViewTransitionCalled`)
+  assert.isTrue(called)
+})
+
+test("navigating does not trigger a view transition when meta tag not present", async ({ page }) => {
+  await page.locator("#go-other").click()
+  await nextBody(page)
+
+  const called = await page.evaluate(`window.startViewTransitionCalled`)
+  assert.isUndefined(called)
+})

--- a/src/tests/functional/form_mode_tests.ts
+++ b/src/tests/functional/form_mode_tests.ts
@@ -1,0 +1,75 @@
+import { Page, test } from "@playwright/test"
+import { getFromLocalStorage, setLocalStorageFromEvent } from "../helpers/page"
+import { assert } from "chai"
+
+test("test form submission with form mode off", async ({ page }) => {
+  await gotoPageWithFormMode(page, "off")
+  await page.click("#turbo-enabled-form button")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission without submitter with form mode off", async ({ page }) => {
+  await gotoPageWithFormMode(page, "off")
+  await page.press("#turbo-enabled-form-without-submitter [type=text]", "Enter")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission with form mode off from submitter outside form", async ({ page }) => {
+  await gotoPageWithFormMode(page, "off")
+  await page.click("button[form=turbo-enabled-form]")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission with form mode optin and form not enabled", async ({ page }) => {
+  await gotoPageWithFormMode(page, "optin")
+  await page.click("#form button")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission without submitter with form mode optin and form not enabled", async ({ page }) => {
+  await gotoPageWithFormMode(page, "optin")
+  await page.press("#form-without-submitter [type=text]", "Enter")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission with form mode optin and form not enabled from submitter outside form", async ({ page }) => {
+  await gotoPageWithFormMode(page, "optin")
+  await page.click("button[form=form]")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission with form mode optin and form enabled", async ({ page }) => {
+  await gotoPageWithFormMode(page, "optin")
+  await page.click("#turbo-enabled-form button")
+
+  assert.ok(await formSubmitStarted(page))
+})
+
+test("test form submission without submitter with form mode optin and form enabled", async ({ page }) => {
+  await gotoPageWithFormMode(page, "optin")
+  await page.press("#turbo-enabled-form-without-submitter [type=text]", "Enter")
+
+  assert.ok(await formSubmitStarted(page))
+})
+
+test("test form submission with form mode optin and form enabled from submitter outside form", async ({ page }) => {
+  await gotoPageWithFormMode(page, "optin")
+  await page.click("button[form=turbo-enabled-form]")
+
+  assert.ok(await formSubmitStarted(page))
+})
+
+async function gotoPageWithFormMode(page: Page, formMode: "on" | "off" | "optin") {
+  await page.goto(`/src/tests/fixtures/form_mode.html?formMode=${formMode}`)
+  await setLocalStorageFromEvent(page, "turbo:submit-start", "formSubmitStarted", "true")
+}
+
+function formSubmitStarted(page: Page) {
+  return getFromLocalStorage(page, "formSubmitStarted")
+}

--- a/src/tests/functional/form_submission_tests.ts
+++ b/src/tests/functional/form_submission_tests.ts
@@ -1,0 +1,1173 @@
+import { Page, test } from "@playwright/test"
+import { assert } from "chai"
+import {
+  getFromLocalStorage,
+  getSearchParam,
+  hasSelector,
+  isScrolledToTop,
+  nextAttributeMutationNamed,
+  nextBeat,
+  nextBody,
+  nextEventNamed,
+  nextEventOnTarget,
+  noNextEventNamed,
+  outerHTMLForSelector,
+  pathname,
+  readEventLogs,
+  scrollToSelector,
+  search,
+  searchParams,
+  setLocalStorageFromEvent,
+  visitAction,
+  waitUntilSelector,
+  waitUntilNoSelector,
+} from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/form.html")
+  await setLocalStorageFromEvent(page, "turbo:submit-start", "formSubmitStarted", "true")
+  await setLocalStorageFromEvent(page, "turbo:submit-end", "formSubmitEnded", "true")
+  await readEventLogs(page)
+})
+
+test("test standard form submission renders a progress bar", async ({ page }) => {
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(0))
+  await page.click("#standard form.sleep input[type=submit]")
+
+  await waitUntilSelector(page, ".turbo-progress-bar")
+  assert.ok(await hasSelector(page, ".turbo-progress-bar"), "displays progress bar")
+
+  await nextBody(page)
+  await waitUntilNoSelector(page, ".turbo-progress-bar")
+
+  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
+})
+
+test("test form submission with confirmation confirmed", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Are you sure?")
+    alert.accept()
+  })
+
+  await page.click("#standard form.confirm input[type=submit]")
+
+  await nextEventNamed(page, "turbo:load")
+  assert.ok(await formSubmitStarted(page))
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+})
+
+test("test form submission with confirmation cancelled", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Are you sure?")
+    alert.dismiss()
+  })
+  await page.click("#standard form.confirm input[type=submit]")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission with secondary submitter click - confirmation confirmed", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Are you really sure?")
+    alert.accept()
+  })
+
+  await page.click("#standard form.confirm #secondary_submitter")
+
+  await nextEventNamed(page, "turbo:load")
+  assert.ok(await formSubmitStarted(page))
+  assert.equal(await pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.equal(getSearchParam(page.url(), "greeting"), "secondary_submitter")
+})
+
+test("test form submission with secondary submitter click - confirmation cancelled", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Are you really sure?")
+    alert.dismiss()
+  })
+
+  await page.click("#standard form.confirm #secondary_submitter")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test from submission with confirmation overridden", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Overridden message")
+    alert.accept()
+  })
+
+  await page.evaluate(() => window.Turbo.setConfirmMethod(() => Promise.resolve(confirm("Overridden message"))))
+  await page.click("#standard form.confirm input[type=submit]")
+
+  assert.ok(await formSubmitStarted(page))
+})
+
+test("test standard form submission does not render a progress bar before expiring the delay", async ({ page }) => {
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(500))
+  await page.click("#standard form.redirect input[type=submit]")
+
+  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "does not show progress bar before delay")
+})
+
+test("test standard POST form submission with redirect response", async ({ page }) => {
+  await page.click("#standard form.redirect input[type=submit]")
+  await nextBody(page)
+
+  assert.ok(await formSubmitStarted(page))
+  assert.equal(await pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a redirect")
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    "true",
+    "sets [aria-busy] on the document element"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    null,
+    "removes [aria-busy] from the document element"
+  )
+})
+
+test("test standard POST form submission events", async ({ page }) => {
+  await page.click("#standard-post-form-submit")
+
+  assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+
+  await nextEventNamed(page, "turbo:before-fetch-response")
+
+  assert.ok(await formSubmitEnded(page), "fires turbo:submit-end")
+
+  await nextEventNamed(page, "turbo:before-visit")
+  await nextEventNamed(page, "turbo:visit")
+  await nextEventNamed(page, "turbo:before-render")
+  await nextEventNamed(page, "turbo:render")
+  await nextEventNamed(page, "turbo:load")
+})
+
+test("test standard POST form submission merges values from both searchParams and body", async ({ page }) => {
+  await page.click("#form-action-post-redirect-self-q-b")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(getSearchParam(page.url(), "q"), "b")
+  assert.equal(getSearchParam(page.url(), "sort"), "asc")
+})
+
+test("test standard POST form submission toggles submitter [disabled] attribute", async ({ page }) => {
+  await page.click("#standard-post-form-submit")
+
+  assert.equal(
+    await nextAttributeMutationNamed(page, "standard-post-form-submit", "disabled"),
+    "",
+    "sets [disabled] on the submitter"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "standard-post-form-submit", "disabled"),
+    null,
+    "removes [disabled] from the submitter"
+  )
+})
+
+test("replaces input value with data-turbo-submits-with on form submission", async ({ page }) => {
+  page.click("#submits-with-form-input")
+
+  assert.equal(
+    await nextAttributeMutationNamed(page, "submits-with-form-input", "value"),
+    "Saving...",
+    "sets data-turbo-submits-with on the submitter"
+  )
+
+  assert.equal(
+    await nextAttributeMutationNamed(page, "submits-with-form-input", "value"),
+    "Save",
+    "restores the original submitter text value"
+  )
+})
+
+test("replaces button innerHTML with data-turbo-submits-with on form submission", async ({ page }) => {
+  await page.click("#submits-with-form-button")
+
+  await nextEventNamed(page, "turbo:submit-start")
+  assert.equal(
+    await page.textContent("#submits-with-form-button"),
+    "Saving...",
+    "sets data-turbo-submits-with on the submitter"
+  )
+
+  await nextEventNamed(page, "turbo:submit-end")
+  assert.equal(
+    await page.textContent("#submits-with-form-button"),
+    "Save",
+    "sets data-turbo-submits-with on the submitter"
+  )
+})
+
+test("test standard GET form submission", async ({ page }) => {
+  await page.click("#standard form.greeting input[type=submit]")
+  await nextBody(page)
+
+  assert.ok(await formSubmitStarted(page))
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a form")
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    "true",
+    "sets [aria-busy] on the document element"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    null,
+    "removes [aria-busy] from the document element"
+  )
+})
+
+test("test standard GET HTMLFormElement.requestSubmit() with Turbo Action", async ({ page }) => {
+  await page.evaluate(() => {
+    const formControl = document.querySelector<HTMLSelectElement>("#external-select")
+
+    if (formControl && formControl.form) formControl.form.requestSubmit()
+  })
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("h1"), "Form", "Retains original page state")
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "navigates #hello turbo frame")
+  assert.equal(await visitAction(page), "replace", "reads Turbo Action from <form>")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html", "promotes frame navigation to page Visit")
+  assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a replace Visit", "encodes <form> into request")
+})
+
+test("test GET HTMLFormElement.requestSubmit() triggered by javascript", async ({ page }) => {
+  await page.click("#request-submit-trigger")
+
+  await nextEventNamed(page, "turbo:load")
+
+  assert.notEqual(pathname(page.url()), "/src/tests/fixtures/one.html", "SubmitEvent was triggered without a submitter")
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "navigates #hello turbo frame")
+})
+
+test("test standard GET form submission with [data-turbo-stream] declared on the form", async ({ page }) => {
+  await page.click("#standard-get-form-with-stream-opt-in-submit")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+})
+
+test("test standard GET form submission with [data-turbo-stream] declared on submitter", async ({ page }) => {
+  await page.click("#standard-get-form-with-stream-opt-in-submitter")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+})
+
+test("test standard GET form submission events", async ({ page }) => {
+  await page.click("#standard-get-form-submit")
+
+  assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.notOk(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+
+  await nextEventNamed(page, "turbo:before-fetch-response")
+
+  assert.ok(await formSubmitEnded(page), "fires turbo:submit-end")
+
+  await nextEventNamed(page, "turbo:before-visit")
+  await nextEventNamed(page, "turbo:visit")
+  await nextEventNamed(page, "turbo:before-cache")
+  await nextEventNamed(page, "turbo:before-render")
+  await nextEventNamed(page, "turbo:render")
+  await nextEventNamed(page, "turbo:load")
+})
+
+test("test standard GET form submission does not incorporate the current page's URLSearchParams values into the submission", async ({
+  page,
+}) => {
+  await page.click("#form-action-self-sort")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(search(page.url()), "?sort=asc")
+
+  await page.click("#form-action-none-q-a")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(search(page.url()), "?q=a", "navigates without omitted keys")
+})
+
+test("test standard GET form submission does not merge values into the [action] attribute", async ({ page }) => {
+  await page.click("#form-action-self-sort")
+  await nextBody(page)
+
+  assert.equal(await pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(await search(page.url()), "?sort=asc")
+
+  await page.click("#form-action-self-q-b")
+  await nextBody(page)
+
+  assert.equal(await pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(await search(page.url()), "?q=b", "navigates without omitted keys")
+})
+
+test("test standard GET form submission omits the [action] value's URLSearchParams from the submission", async ({
+  page,
+}) => {
+  await page.click("#form-action-self-submit")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(search(page.url()), "")
+})
+
+test("test standard GET form submission toggles submitter [disabled] attribute", async ({ page }) => {
+  await page.click("#standard-get-form-submit")
+
+  assert.equal(
+    await nextAttributeMutationNamed(page, "standard-get-form-submit", "disabled"),
+    "",
+    "sets [disabled] on the submitter"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "standard-get-form-submit", "disabled"),
+    null,
+    "removes [disabled] from the submitter"
+  )
+})
+
+test("test standard GET form submission appending keys", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/form.html?query=1")
+  await page.click("#standard form.conflicting-values input[type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(getSearchParam(page.url(), "query"), "2")
+})
+
+test("test standard form submission with empty created response", async ({ page }) => {
+  const htmlBefore = await outerHTMLForSelector(page, "body")
+  const button = await page.locator("#standard form.created input[type=submit]")
+  await button.click()
+  await nextBeat()
+
+  const htmlAfter = await outerHTMLForSelector(page, "body")
+  assert.equal(htmlAfter, htmlBefore)
+})
+
+test("test standard form submission with empty no-content response", async ({ page }) => {
+  const htmlBefore = await outerHTMLForSelector(page, "body")
+  const button = await page.locator("#standard form.no-content input[type=submit]")
+  await button.click()
+  await nextBeat()
+
+  const htmlAfter = await outerHTMLForSelector(page, "body")
+  assert.equal(htmlAfter, htmlBefore)
+})
+
+test("test standard POST form submission with multipart/form-data enctype", async ({ page }) => {
+  await page.click("#standard form[method=post][enctype] input[type=submit]")
+  await nextBeat()
+
+  const enctype = getSearchParam(page.url(), "enctype")
+  assert.ok(enctype?.startsWith("multipart/form-data"), "submits a multipart/form-data request")
+})
+
+test("test standard GET form submission ignores enctype", async ({ page }) => {
+  await page.click("#standard form[method=get][enctype] input[type=submit]")
+  await nextBeat()
+
+  const enctype = getSearchParam(page.url(), "enctype")
+  assert.notOk(enctype, "GET form submissions ignore enctype")
+})
+
+test("test standard POST form submission without an enctype", async ({ page }) => {
+  await page.click("#standard form[method=post].no-enctype input[type=submit]")
+  await nextBeat()
+
+  const enctype = getSearchParam(page.url(), "enctype")
+  assert.ok(
+    enctype?.startsWith("application/x-www-form-urlencoded"),
+    "submits a application/x-www-form-urlencoded request"
+  )
+})
+
+test("test no-action form submission with single parameter", async ({ page }) => {
+  await page.click("#no-action form.single input[type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(getSearchParam(page.url(), "query"), "1")
+
+  await page.click("#no-action form.single input[type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(getSearchParam(page.url(), "query"), "1")
+
+  await page.goto("/src/tests/fixtures/form.html?query=2")
+  await page.click("#no-action form.single input[type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(getSearchParam(page.url(), "query"), "1")
+})
+
+test("test no-action form submission with multiple parameters", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/form.html?query=2")
+  await page.click("#no-action form.multiple input[type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.deepEqual(searchParams(page.url()).getAll("query"), ["1", "2"])
+
+  await page.click("#no-action form.multiple input[type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.deepEqual(searchParams(page.url()).getAll("query"), ["1", "2"])
+})
+
+test("test no-action form submission submitter parameters", async ({ page }) => {
+  await page.click("#no-action form.button-param [type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(getSearchParam(page.url(), "query"), "1")
+  assert.deepEqual(searchParams(page.url()).getAll("button"), [""])
+
+  await page.click("#no-action form.button-param [type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(getSearchParam(page.url(), "query"), "1")
+  assert.deepEqual(searchParams(page.url()).getAll("button"), [""])
+})
+
+test("test submitter with blank formaction submits to the current page", async ({ page }) => {
+  await page.click("#blank-formaction button")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.ok(await hasSelector(page, "#blank-formaction"), "overrides form[action] navigation")
+})
+
+test("test input named action with no action attribute", async ({ page }) => {
+  await page.click("#action-input form.no-action [type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.equal(getSearchParam(page.url(), "action"), "1")
+  assert.equal(getSearchParam(page.url(), "query"), "1")
+})
+
+test("test input named action with action attribute", async ({ page }) => {
+  await page.click("#action-input form.action [type=submit]")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(getSearchParam(page.url(), "action"), "1")
+  assert.equal(getSearchParam(page.url(), "query"), "1")
+})
+
+test("test invalid form submission with unprocessable entity status", async ({ page }) => {
+  await page.click("#reject form.unprocessable_entity input[type=submit]")
+  await nextBody(page)
+
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "Unprocessable Entity", "renders the response HTML")
+  assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
+})
+
+test("test invalid form submission with long form", async ({ page }) => {
+  await scrollToSelector(page, "#reject form.unprocessable_entity_with_tall_form input[type=submit]")
+  await page.click("#reject form.unprocessable_entity_with_tall_form input[type=submit]")
+  await nextBody(page)
+
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "Unprocessable Entity", "renders the response HTML")
+  assert(await isScrolledToTop(page), "page is scrolled to the top")
+  assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
+})
+
+test("test invalid form submission with server error status", async ({ page }) => {
+  assert(await hasSelector(page, "head > #form-fixture-styles"))
+  await page.click("#reject form.internal_server_error input[type=submit]")
+  await nextBody(page)
+
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "Internal Server Error", "renders the response HTML")
+  assert.notOk(await hasSelector(page, "head > #form-fixture-styles"), "replaces head")
+  assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
+})
+
+test("test form submission with network error", async ({ page }) => {
+  await page.context().setOffline(true)
+  await page.click("#reject-form [type=submit]")
+  await nextEventOnTarget(page, "reject-form", "turbo:fetch-request-error")
+})
+
+test("test submitter form submission reads button attributes", async ({ page }) => {
+  const button = await page.locator("#submitter form button[type=submit][formmethod=post]")
+  await button.click()
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/two.html")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test submitter POST form submission with multipart/form-data formenctype", async ({ page }) => {
+  await page.click("#submitter form[method=post]:not([enctype]) input[formenctype]")
+  await nextBeat()
+
+  const enctype = getSearchParam(page.url(), "enctype")
+  assert.ok(enctype?.startsWith("multipart/form-data"), "submits a multipart/form-data request")
+})
+
+test("test submitter GET submission from submitter with data-turbo-frame", async ({ page }) => {
+  await page.click("#submitter form[method=get] [type=submit][data-turbo-frame]")
+  await nextBeat()
+
+  const message = await page.locator("#frame div.message")
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "Form")
+  assert.equal(await message.textContent(), "Frame redirected")
+})
+
+test("test submitter POST submission from submitter with data-turbo-frame", async ({ page }) => {
+  await page.click("#submitter form[method=post] [type=submit][data-turbo-frame]")
+  await nextBeat()
+
+  const message = await page.locator("#frame div.message")
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "Form")
+  assert.equal(await message.textContent(), "Frame redirected")
+})
+
+test("test frame form GET submission from submitter with data-turbo-frame=_top", async ({ page }) => {
+  await page.click("#frame form[method=get] [type=submit][data-turbo-frame=_top]")
+  await nextBody(page)
+
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "One")
+})
+
+test("test frame form POST submission from submitter with data-turbo-frame=_top", async ({ page }) => {
+  await page.click("#frame form[method=post] [type=submit][data-turbo-frame=_top]")
+  await nextBody(page)
+
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "One")
+})
+
+test("test frame POST form targeting frame submission", async ({ page }) => {
+  await page.click("#targets-frame-post-form-submit")
+
+  assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal("frame", fetchOptions.headers["Turbo-Frame"])
+
+  await nextEventNamed(page, "turbo:before-fetch-response")
+
+  assert.ok(await formSubmitEnded(page), "fires turbo:submit-end")
+
+  await nextEventNamed(page, "turbo:frame-render")
+  await nextEventNamed(page, "turbo:frame-load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+
+  const src = (await page.getAttribute("#frame", "src")) || ""
+  assert.equal(new URL(src).pathname, "/src/tests/fixtures/frames/frame.html")
+})
+
+test("test frame POST form targeting frame toggles submitter's [disabled] attribute", async ({ page }) => {
+  await page.click("#targets-frame-post-form-submit")
+
+  assert.equal(
+    await nextAttributeMutationNamed(page, "targets-frame-post-form-submit", "disabled"),
+    "",
+    "sets [disabled] on the submitter"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "targets-frame-post-form-submit", "disabled"),
+    null,
+    "removes [disabled] from the submitter"
+  )
+})
+
+test("test frame GET form targeting frame submission", async ({ page }) => {
+  await page.click("#targets-frame-get-form-submit")
+
+  assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.notOk(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal("frame", fetchOptions.headers["Turbo-Frame"])
+
+  await nextEventNamed(page, "turbo:before-fetch-response")
+
+  assert.ok(await formSubmitEnded(page), "fires turbo:submit-end")
+
+  await nextEventNamed(page, "turbo:frame-render")
+  await nextEventNamed(page, "turbo:frame-load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+
+  const src = (await page.getAttribute("#frame", "src")) || ""
+  assert.equal(new URL(src).pathname, "/src/tests/fixtures/frames/frame.html")
+})
+
+test("test frame GET form targeting frame toggles submitter's [disabled] attribute", async ({ page }) => {
+  await page.click("#targets-frame-get-form-submit")
+
+  assert.equal(
+    await nextAttributeMutationNamed(page, "targets-frame-get-form-submit", "disabled"),
+    "",
+    "sets [disabled] on the submitter"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "targets-frame-get-form-submit", "disabled"),
+    null,
+    "removes [disabled] from the submitter"
+  )
+})
+
+test("test frame form GET submission from submitter referencing another frame", async ({ page }) => {
+  await page.click("#frame form[method=get] [type=submit][data-turbo-frame=hello]")
+  await nextBeat()
+
+  const title = await page.locator("h1")
+  const frameTitle = await page.locator("#hello h2")
+  assert.equal(await frameTitle.textContent(), "Hello from a frame")
+  assert.equal(await title.textContent(), "Form")
+})
+
+test("test frame form POST submission from submitter referencing another frame", async ({ page }) => {
+  await page.click("#frame form[method=post] [type=submit][data-turbo-frame=hello]")
+  await nextBeat()
+
+  const title = await page.locator("h1")
+  const frameTitle = await page.locator("#hello h2")
+  assert.equal(await frameTitle.textContent(), "Hello from a frame")
+  assert.equal(await title.textContent(), "Form")
+})
+
+test("test frame form submission with redirect response", async ({ page }) => {
+  const path = (await page.getAttribute("#frame form.redirect input[name=path]", "value")) || ""
+  const url = new URL(path, "http://localhost:9000")
+  url.searchParams.set("enctype", "application/x-www-form-urlencoded;charset=UTF-8")
+
+  const button = await page.locator("#frame form.redirect input[type=submit]")
+  await button.click()
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  const message = await page.locator("#frame div.message")
+  assert.notOk(await hasSelector(page, "#frame form.redirect"))
+  assert.equal(await message.textContent(), "Frame redirected")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html", "does not redirect _top")
+  assert.notOk(search(page.url()), "does not redirect _top")
+  assert.equal(await page.getAttribute("#frame", "src"), url.href, "redirects the target frame")
+})
+
+test("test frame POST form submission toggles the ancestor frame's [aria-busy] attribute", async ({ page }) => {
+  await page.click("#frame form.redirect input[type=submit]")
+  await nextBeat()
+
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "busy"), "", "sets [busy] on the #frame")
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "aria-busy"), "true", "sets [aria-busy] on the #frame")
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "busy"), null, "removes [busy] from the #frame")
+  assert.equal(
+    await nextAttributeMutationNamed(page, "frame", "aria-busy"),
+    null,
+    "removes [aria-busy] from the #frame"
+  )
+})
+
+test("test frame POST form submission toggles the target frame's [aria-busy] attribute", async ({ page }) => {
+  await page.click('#targets-frame form.frame [type="submit"]')
+  await nextBeat()
+
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "busy"), "", "sets [busy] on the #frame")
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "aria-busy"), "true", "sets [aria-busy] on the #frame")
+
+  const title = await page.locator("#frame h2")
+  assert.equal(await title.textContent(), "Frame: Loaded")
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "busy"), null, "removes [busy] from the #frame")
+  assert.equal(
+    await nextAttributeMutationNamed(page, "frame", "aria-busy"),
+    null,
+    "removes [aria-busy] from the #frame"
+  )
+})
+
+test("test frame form submission with empty created response", async ({ page }) => {
+  const htmlBefore = await outerHTMLForSelector(page, "#frame")
+  const button = await page.locator("#frame form.created input[type=submit]")
+  await button.click()
+  await nextBeat()
+
+  const htmlAfter = await outerHTMLForSelector(page, "#frame")
+  assert.equal(htmlAfter, htmlBefore)
+})
+
+test("test frame form submission with empty no-content response", async ({ page }) => {
+  const htmlBefore = await outerHTMLForSelector(page, "#frame")
+  const button = await page.locator("#frame form.no-content input[type=submit]")
+  await button.click()
+  await nextBeat()
+
+  const htmlAfter = await outerHTMLForSelector(page, "#frame")
+  assert.equal(htmlAfter, htmlBefore)
+})
+
+test("test frame form submission within a frame submits the Turbo-Frame header", async ({ page }) => {
+  await page.click("#frame form.redirect input[type=submit]")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
+})
+
+test("test invalid frame form submission with unprocessable entity status", async ({ page }) => {
+  await page.click("#frame form.unprocessable_entity input[type=submit]")
+
+  assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+  await nextEventNamed(page, "turbo:before-fetch-response")
+  assert.ok(await formSubmitEnded(page), "fires turbo:submit-end")
+  await nextEventNamed(page, "turbo:frame-render")
+  await nextEventNamed(page, "turbo:frame-load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+
+  const title = await page.locator("#frame h2")
+  assert.ok(await hasSelector(page, "#reject form"), "only replaces frame")
+  assert.equal(await title.textContent(), "Frame: Unprocessable Entity")
+})
+
+test("test invalid frame form submission with internal server error status", async ({ page }) => {
+  await page.click("#frame form.internal_server_error input[type=submit]")
+
+  assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+  await nextEventNamed(page, "turbo:before-fetch-response")
+  assert.ok(await formSubmitEnded(page), "fires turbo:submit-end")
+  await nextEventNamed(page, "turbo:frame-render")
+  await nextEventNamed(page, "turbo:frame-load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+
+  assert.ok(await hasSelector(page, "#reject form"), "only replaces frame")
+  assert.equal(await page.textContent("#frame h2"), "Frame: Internal Server Error")
+})
+
+test("test frame form submission with stream response", async ({ page }) => {
+  const button = await page.locator("#frame form.stream[method=post] input[type=submit]")
+  await button.click()
+  await nextBeat()
+
+  const message = await page.locator("#frame div.message")
+  assert.ok(await hasSelector(page, "#frame form.redirect"))
+  assert.equal(await message.textContent(), "Hello!")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.notOk(await page.getAttribute("#frame", "src"), "does not change frame's src")
+})
+
+test("test frame form submission with HTTP verb other than GET or POST", async ({ page }) => {
+  await page.click("#frame form.put.stream input[type=submit]")
+  await nextBeat()
+
+  assert.ok(await hasSelector(page, "#frame form.redirect"))
+  assert.equal(await page.textContent("#frame div.message"), "1: Hello!")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+})
+
+test("test frame form submission with [data-turbo=false] on the form", async ({ page }) => {
+  await page.click('#frame form[data-turbo="false"] input[type=submit]')
+  await waitUntilSelector(page, "#element-id")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test frame form submission with [data-turbo=false] on the submitter", async ({ page }) => {
+  await page.click('#frame form:not([data-turbo]) input[data-turbo="false"]')
+  await waitUntilSelector(page, "#element-id")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test frame form submission ignores submissions with their defaultPrevented", async ({ page }) => {
+  await page.evaluate(() => document.addEventListener("submit", (event) => event.preventDefault(), true))
+  await page.click("#frame .redirect [type=submit]")
+  await nextBeat()
+
+  assert.equal(await page.textContent("#frame h2"), "Frame: Form")
+  assert.equal(await page.getAttribute("#frame", "src"), null, "does not navigate frame")
+})
+
+test("test form submission with [data-turbo=false] on the form", async ({ page }) => {
+  await page.click('#turbo-false form[data-turbo="false"] input[type=submit]')
+  await waitUntilSelector(page, "#element-id")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission with [data-turbo=false] on the submitter", async ({ page }) => {
+  await page.click('#turbo-false form:not([data-turbo]) input[data-turbo="false"]')
+  await waitUntilSelector(page, "#element-id")
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission skipped within method=dialog", async ({ page }) => {
+  await page.click('#dialog-method [type="submit"]')
+  await nextBeat()
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission skipped with submitter formmethod=dialog", async ({ page }) => {
+  await page.click('#dialog-formmethod-turbo-frame [formmethod="dialog"]')
+  await nextBeat()
+
+  assert.notOk(await formSubmitEnded(page))
+})
+
+test("test form submission targeting frame skipped within method=dialog", async ({ page }) => {
+  await page.click("#dialog-method-turbo-frame button")
+  await nextBeat()
+
+  assert.notOk(await formSubmitEnded(page))
+})
+
+test("test form submission targeting frame skipped with submitter formmethod=dialog", async ({ page }) => {
+  await page.click('#dialog-formmethod [formmethod="dialog"]')
+  await nextBeat()
+
+  assert.notOk(await formSubmitStarted(page))
+})
+
+test("test form submission targets disabled frame", async ({ page }) => {
+  await page.evaluate(() => document.getElementById("frame")?.setAttribute("disabled", ""))
+  await page.click('#targets-frame form.one [type="submit"]')
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+})
+
+test("test form submission targeting a frame submits the Turbo-Frame header", async ({ page }) => {
+  await page.click('#targets-frame [type="submit"]')
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
+})
+
+test("test link method form submission dispatches events from a connected <form> element", async ({ page }) => {
+  await page.evaluate(() =>
+    new MutationObserver(([record]) => {
+      for (const form of record.addedNodes) {
+        if (form instanceof HTMLFormElement) form.id = "a-form-link"
+      }
+    }).observe(document.body, { childList: true })
+  )
+
+  await page.click("#stream-link-method-within-form-outside-frame")
+  await nextEventOnTarget(page, "a-form-link", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "a-form-link", "turbo:submit-start")
+  await nextEventOnTarget(page, "a-form-link", "turbo:before-fetch-response")
+  await nextEventOnTarget(page, "a-form-link", "turbo:submit-end")
+
+  assert.notOk(await hasSelector(page, "a-form-link"), "the <form> is removed")
+})
+
+test("test link method form submission submits a single request", async ({ page }) => {
+  let requestCounter = 0
+  page.on("request", () => requestCounter++)
+
+  await page.click("#stream-link-method-within-form-outside-frame")
+  await nextBeat()
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(requestCounter, 1, "submits a single HTTP request")
+})
+
+test("test link method form submission inside frame submits a single request", async ({ page }) => {
+  let requestCounter = 0
+  page.on("request", () => requestCounter++)
+
+  await page.click("#stream-link-method-inside-frame")
+  await nextBeat()
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(requestCounter, 1, "submits a single HTTP request")
+})
+
+test("test link method form submission targeting frame submits a single request", async ({ page }) => {
+  let requestCounter = 0
+  page.on("request", () => requestCounter++)
+
+  await page.click("#turbo-method-post-to-targeted-frame")
+  await nextBeat()
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(requestCounter, 2, "submits a single HTTP request then follows a redirect")
+})
+
+test("test link method form submission inside frame", async ({ page }) => {
+  await page.click("#link-method-inside-frame")
+  await nextBeat()
+
+  assert.equal(await page.textContent("#frame h2"), "Frame: Loaded")
+  assert.notOk(await hasSelector(page, "#nested-child"))
+})
+
+test("test link method form submission inside frame with data-turbo-frame=_top", async ({ page }) => {
+  await page.click("#link-method-inside-frame-target-top")
+  await nextBody(page)
+
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "Hello")
+})
+
+test("test link method form submission inside frame with data-turbo-frame target", async ({ page }) => {
+  await page.click("#link-method-inside-frame-with-target")
+  await nextBeat()
+
+  const title = await page.locator("h1")
+  const frameTitle = await page.locator("#hello h2")
+  assert.equal(await frameTitle.textContent(), "Hello from a frame")
+  assert.equal(await title.textContent(), "Form")
+})
+
+test("test stream link method form submission inside frame", async ({ page }) => {
+  await page.click("#stream-link-method-inside-frame")
+  await nextBeat()
+
+  const message = page.locator("#frame div.message")
+  assert.equal(await message.textContent(), "Link!")
+})
+
+test("test stream link GET method form submission inside frame", async ({ page }) => {
+  await page.click("#stream-link-get-method-inside-frame")
+
+  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+})
+
+test("test stream link inside frame", async ({ page }) => {
+  await page.click("#stream-link-inside-frame")
+
+  const { fetchOptions, url } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal(getSearchParam(url, "content"), "Link!")
+})
+
+test("test link method form submission within form inside frame", async ({ page }) => {
+  await page.click("#stream-link-method-within-form-inside-frame")
+  await nextBeat()
+
+  const message = page.locator("#frame div.message")
+  assert.equal(await message.textContent(), "Link!")
+})
+
+test("test link method form submission inside frame with confirmation confirmed", async ({ page }) => {
+  page.on("dialog", (dialog) => {
+    assert.equal(dialog.message(), "Are you sure?")
+    dialog.accept()
+  })
+
+  await page.click("#link-method-inside-frame-with-confirmation")
+  await nextBeat()
+
+  const message = page.locator("#frame div.message")
+  assert.equal(await message.textContent(), "Link!")
+})
+
+test("test link method form submission inside frame with confirmation cancelled", async ({ page }) => {
+  page.on("dialog", (dialog) => {
+    assert.equal(dialog.message(), "Are you sure?")
+    dialog.dismiss()
+  })
+
+  await page.click("#link-method-inside-frame-with-confirmation")
+  await nextBeat()
+
+  assert.notOk(await hasSelector(page, "#frame div.message"), "Not confirming form submission does not submit the form")
+})
+
+test("test link method form submission outside frame", async ({ page }) => {
+  await page.click("#link-method-outside-frame")
+  await nextBody(page)
+
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "Hello")
+})
+
+test("test following a link with [data-turbo-method] set and a target set navigates the target frame", async ({
+  page,
+}) => {
+  await page.click("#turbo-method-post-to-targeted-frame")
+
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "drives the turbo-frame")
+})
+
+test("test following a link with [data-turbo-method] and [data-turbo=true] set when html[data-turbo=false]", async ({
+  page,
+}) => {
+  const html = await page.locator("html")
+  await html.evaluate((html) => html.setAttribute("data-turbo", "false"))
+
+  const link = await page.locator("#turbo-method-post-to-targeted-frame")
+  await link.evaluate((link) => link.setAttribute("data-turbo", "true"))
+
+  await link.click()
+
+  assert.equal(await page.textContent("h1"), "Form", "does not navigate the full page")
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "drives the turbo-frame")
+})
+
+test("test following a link with [data-turbo-method] and [data-turbo=true] set when Turbo.session.drive = false", async ({
+  page,
+}) => {
+  await page.evaluate(() => (window.Turbo.session.drive = false))
+
+  const link = await page.locator("#turbo-method-post-to-targeted-frame")
+  await link.evaluate((link) => link.setAttribute("data-turbo", "true"))
+
+  await link.click()
+
+  assert.equal(await page.textContent("h1"), "Form", "does not navigate the full page")
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "drives the turbo-frame")
+})
+
+test("test following a link with [data-turbo-method] set when html[data-turbo=false]", async ({ page }) => {
+  const html = await page.locator("html")
+  await html.evaluate((html) => html.setAttribute("data-turbo", "false"))
+
+  await page.click("#turbo-method-post-to-targeted-frame")
+
+  assert.equal(await page.textContent("h1"), "Hello", "treats link as a full-page navigation")
+})
+
+test("test following a link with [data-turbo-method] set when Turbo.session.drive = false", async ({ page }) => {
+  await page.evaluate(() => (window.Turbo.session.drive = false))
+  await page.click("#turbo-method-post-to-targeted-frame")
+
+  assert.equal(await page.textContent("h1"), "Hello", "treats link as a full-page navigation")
+})
+
+test("test stream link method form submission outside frame", async ({ page }) => {
+  await page.click("#stream-link-method-outside-frame")
+  await nextBeat()
+
+  const message = page.locator("#frame div.message")
+  assert.equal(await message.textContent(), "Link!")
+})
+
+test("test link method form submission within form outside frame", async ({ page }) => {
+  await page.click("#link-method-within-form-outside-frame")
+  await nextBody(page)
+
+  const title = await page.locator("h1")
+  assert.equal(await title.textContent(), "Hello")
+})
+
+test("test stream link method form submission within form outside frame", async ({ page }) => {
+  await page.click("#stream-link-method-within-form-outside-frame")
+  await nextBeat()
+
+  assert.equal(await page.textContent("#frame div.message"), "Link!")
+})
+
+test("test turbo:before-fetch-request fires on the form element", async ({ page }) => {
+  await page.click('#targets-frame form.one [type="submit"]')
+  assert.ok(await nextEventOnTarget(page, "form_one", "turbo:before-fetch-request"))
+})
+
+test("test turbo:before-fetch-response fires on the form element", async ({ page }) => {
+  await page.click('#targets-frame form.one [type="submit"]')
+  assert.ok(await nextEventOnTarget(page, "form_one", "turbo:before-fetch-response"))
+})
+
+test("test POST to external action ignored", async ({ page }) => {
+  await page.click("#submit-external")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+
+  await nextBody(page)
+
+  assert.equal(page.url(), "https://httpbin.org/post")
+})
+
+test("test POST to external action within frame ignored", async ({ page }) => {
+  await page.click("#submit-external-within-ignored")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+
+  await nextBody(page)
+
+  assert.equal(page.url(), "https://httpbin.org/post")
+})
+
+test("test POST to external action targeting frame ignored", async ({ page }) => {
+  await page.click("#submit-external-target-ignored")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+
+  await nextBody(page)
+
+  assert.equal(page.url(), "https://httpbin.org/post")
+})
+
+test("test form submission skipped with form[target]", async ({ page }) => {
+  await page.click("#skipped form[target] button")
+  await nextBeat()
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.notOk(await formSubmitEnded(page))
+})
+
+test("test form submission skipped with submitter button[formtarget]", async ({ page }) => {
+  await page.click("#skipped [formtarget]")
+  await nextBeat()
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
+  assert.notOk(await formSubmitEnded(page))
+})
+
+function formSubmitStarted(page: Page) {
+  return getFromLocalStorage(page, "formSubmitStarted")
+}
+
+function formSubmitEnded(page: Page) {
+  return getFromLocalStorage(page, "formSubmitEnded")
+}

--- a/src/tests/functional/frame_navigation_tests.ts
+++ b/src/tests/functional/frame_navigation_tests.ts
@@ -1,0 +1,106 @@
+import { test } from "@playwright/test"
+import { getFromLocalStorage, nextEventNamed, nextEventOnTarget, pathname, scrollToSelector } from "../helpers/page"
+import { assert } from "chai"
+
+test("test frame navigation with descendant link", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
+  await page.click("#inside")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+})
+
+test("test frame navigation with self link", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
+  await page.click("#self")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+})
+
+test("test frame navigation with exterior link", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
+  await page.click("#outside")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+})
+
+test("test frame navigation with exterior link in Shadow DOM", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
+  await page.click("#outside-in-shadow-dom")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+})
+
+test("test frame navigation emits fetch-request-error event when offline", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/tabs.html")
+  await page.context().setOffline(true)
+  await page.click("#tab-2")
+  await nextEventOnTarget(page, "tab-frame", "turbo:fetch-request-error")
+})
+
+test("test lazy-loaded frame promotes navigation", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
+
+  assert.equal(await page.textContent("#eager-loaded-frame h2"), "Eager-loaded frame: Not Loaded")
+
+  await scrollToSelector(page, "#eager-loaded-frame")
+  await nextEventOnTarget(page, "eager-loaded-frame", "turbo:frame-load")
+
+  assert.equal(await page.textContent("#eager-loaded-frame h2"), "Eager-loaded frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame_for_eager.html")
+})
+
+test("test promoted frame navigation updates the URL before rendering", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/tabs.html")
+
+  page.evaluate(() => {
+    addEventListener("turbo:before-frame-render", () => {
+      localStorage.setItem("beforeRenderUrl", window.location.pathname)
+      localStorage.setItem("beforeRenderContent", document.querySelector("#tab-content")?.textContent || "")
+    })
+  })
+
+  await page.click("#tab-2")
+  await nextEventNamed(page, "turbo:before-frame-render")
+
+  assert.equal(await getFromLocalStorage(page, "beforeRenderUrl"), "/src/tests/fixtures/tabs/two.html")
+  assert.equal(await getFromLocalStorage(page, "beforeRenderContent"), "One")
+
+  await nextEventNamed(page, "turbo:frame-render")
+
+  assert.equal(await pathname(page.url()), "/src/tests/fixtures/tabs/two.html")
+  assert.equal(await page.textContent("#tab-content"), "Two")
+})
+
+test("test promoted frame navigations are cached", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/tabs.html")
+
+  await page.click("#tab-2")
+  await nextEventOnTarget(page, "tab-frame", "turbo:frame-load")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("#tab-content"), "Two")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "sets [complete]")
+
+  await page.click("#tab-3")
+  await nextEventOnTarget(page, "tab-frame", "turbo:frame-load")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("#tab-content"), "Three")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/three.html")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "sets [complete]")
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("#tab-content"), "Two")
+  assert.equal(pathname((await page.getAttribute("#tab-frame", "src")) || ""), "/src/tests/fixtures/tabs/two.html")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), "", "caches two.html with [complete]")
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("#tab-content"), "One")
+  assert.equal(await page.getAttribute("#tab-frame", "src"), null, "caches one.html without #tab-frame[src]")
+  assert.equal(await page.getAttribute("#tab-frame", "complete"), null, "caches one.html without [complete]")
+})

--- a/src/tests/functional/frame_tests.ts
+++ b/src/tests/functional/frame_tests.ts
@@ -1,0 +1,956 @@
+import { Page, test, expect } from "@playwright/test"
+import { assert, Assertion } from "chai"
+import {
+  attributeForSelector,
+  hasSelector,
+  listenForEventOnTarget,
+  nextAttributeMutationNamed,
+  noNextAttributeMutationNamed,
+  nextBeat,
+  nextEventNamed,
+  nextEventOnTarget,
+  noNextEventNamed,
+  noNextEventOnTarget,
+  pathname,
+  propertyForSelector,
+  readEventLogs,
+  scrollPosition,
+  scrollToSelector,
+  searchParams,
+} from "../helpers/page"
+
+declare global {
+  namespace Chai {
+    interface AssertStatic {
+      equalIgnoringWhitespace(actual: string | null | undefined, expected: string, message?: string): void
+    }
+  }
+}
+
+assert.equalIgnoringWhitespace = function (actual: string | null | undefined, expected: string, message?: string) {
+  new Assertion(actual?.trim()).to.equal(expected.trim(), message)
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frames.html")
+  await readEventLogs(page)
+})
+
+test("test navigating a frame with Turbo.visit", async ({ page }) => {
+  const pathname = "/src/tests/fixtures/frames/frame.html"
+
+  await page.locator("#frame").evaluate((frame) => frame.setAttribute("disabled", ""))
+  await page.evaluate((pathname) => window.Turbo.visit(pathname, { frame: "frame" }), pathname)
+  await nextBeat()
+
+  assert.equal(await page.textContent("#frame h2"), "Frames: #frame", "does not navigate a disabled frame")
+
+  await page.locator("#frame").evaluate((frame) => frame.removeAttribute("disabled"))
+  await page.evaluate((pathname) => window.Turbo.visit(pathname, { frame: "frame" }), pathname)
+  await nextBeat()
+
+  assert.equal(await page.textContent("#frame h2"), "Frame: Loaded", "navigates the target frame")
+})
+
+test("test navigating a frame a second time does not leak event listeners", async ({ page }) => {
+  await withoutChangingEventListenersCount(page, async () => {
+    await page.click("#outer-frame-link")
+    await nextEventOnTarget(page, "frame", "turbo:frame-load")
+    await page.click("#outside-frame-form")
+    await nextEventOnTarget(page, "frame", "turbo:frame-load")
+    await page.click("#outer-frame-link")
+    await nextEventOnTarget(page, "frame", "turbo:frame-load")
+  })
+})
+
+test("test following a link preserves the current <turbo-frame> element's attributes", async ({ page }) => {
+  const currentPath = pathname(page.url())
+
+  await page.click("#hello a")
+  await nextBeat()
+
+  const frame = await page.locator("turbo-frame#frame")
+  assert.equal(await frame.getAttribute("data-loaded-from"), currentPath)
+  assert.equal(await frame.getAttribute("src"), await propertyForSelector(page, "#hello a", "href"))
+})
+
+test("test following a link sets the frame element's [src]", async ({ page }) => {
+  await page.click("#link-frame-with-search-params")
+
+  const { url } = await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
+  const fetchRequestUrl = new URL(url)
+
+  assert.equal(fetchRequestUrl.pathname, "/src/tests/fixtures/frames/frame.html")
+  assert.equal(fetchRequestUrl.searchParams.get("key"), "value", "fetch request encodes query parameters")
+
+  await nextBeat()
+  const src = new URL((await attributeForSelector(page, "#frame", "src")) || "")
+
+  assert.equal(src.pathname, "/src/tests/fixtures/frames/frame.html")
+  assert.equal(src.searchParams.get("key"), "value", "[src] attribute encodes query parameters")
+})
+
+test("test a frame whose src references itself does not infinitely loop", async ({ page }) => {
+  await page.click("#frame-self")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+})
+
+test("test following a link driving a frame toggles the [aria-busy=true] attribute", async ({ page }) => {
+  await page.click("#hello a")
+
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "busy"), "", "sets [busy] on the #frame")
+  assert.equal(
+    await nextAttributeMutationNamed(page, "frame", "aria-busy"),
+    "true",
+    "sets [aria-busy=true] on the #frame"
+  )
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "busy"), null, "removes [busy] on the #frame")
+  assert.equal(
+    await nextAttributeMutationNamed(page, "frame", "aria-busy"),
+    null,
+    "removes [aria-busy] from the #frame"
+  )
+})
+
+test("test following an a[data-turbo-frame=_top] does not toggle the frame's [aria-busy=true] attribute", async ({
+  page,
+}) => {
+  await page.click("#frame #link-top")
+
+  assert.ok(await noNextAttributeMutationNamed(page, "frame", "busy"), "does not toggle [busy] on parent frame")
+  assert.ok(
+    await noNextAttributeMutationNamed(page, "frame", "aria-busy"),
+    "does not toggle [aria-busy=true] on parent frame"
+  )
+})
+
+test("test submitting a form[data-turbo-frame=_top] does not toggle the frame's [aria-busy=true] attribute", async ({
+  page,
+}) => {
+  await page.click("#frame #form-submit-top")
+
+  assert.ok(await noNextAttributeMutationNamed(page, "frame", "busy"), "does not toggle [busy] on parent frame")
+  assert.ok(
+    await noNextAttributeMutationNamed(page, "frame", "aria-busy"),
+    "does not toggle [aria-busy=true] on parent frame"
+  )
+})
+
+test("successfully following a link to a page without a matching frame dispatches a turbo:frame-missing event", async ({
+  page,
+}) => {
+  await page.click("#missing-frame-link")
+  const { response } = await nextEventOnTarget(page, "missing", "turbo:frame-missing")
+
+  assert.equal(200, response.status)
+})
+
+test("successfully following a link to a page without a matching frame shows an error and throws an exception", async ({
+  page,
+}) => {
+  let error: Error | undefined = undefined
+  page.once("pageerror", (e) => (error = e))
+
+  await page.click("#missing-frame-link")
+
+  assert.match(await page.innerText("#missing"), /Content missing/)
+
+  assert.exists(error)
+  assert.include(error!.message, `The response (200) did not contain the expected <turbo-frame id="missing">`)
+})
+
+test("successfully following a link to a page with `turbo-visit-control` `reload` performs a full page reload", async ({
+  page,
+}) => {
+  await page.click("#unvisitable-page-link")
+  await page.getByText("Unvisitable page loaded").waitFor()
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/unvisitable.html")
+})
+
+test("failing to follow a link to a page without a matching frame dispatches a turbo:frame-missing event", async ({
+  page,
+}) => {
+  await page.click("#missing-page-link")
+  const { response } = await nextEventOnTarget(page, "missing", "turbo:frame-missing")
+
+  assert.equal(404, response.status)
+})
+
+test("failing to follow a link to a page without a matching frame shows an error and throws an exception", async ({
+  page,
+}) => {
+  let error: Error | undefined = undefined
+  page.once("pageerror", (e) => (error = e))
+
+  await page.click("#missing-page-link")
+
+  assert.match(await page.innerText("#missing"), /Content missing/)
+
+  assert.exists(error)
+  assert.include(error!.message, `The response (404) did not contain the expected <turbo-frame id="missing">`)
+})
+
+test("test the turbo:frame-missing event following a link to a page without a matching frame can be handled", async ({
+  page,
+}) => {
+  await page.locator("#missing").evaluate((frame) => {
+    frame.addEventListener(
+      "turbo:frame-missing",
+      ((event) => {
+        if (event.target instanceof Element) {
+          event.preventDefault()
+          event.target.textContent = "Overridden"
+        }
+      }) as EventListener,
+      { once: true }
+    )
+  })
+  await page.click("#missing-frame-link")
+  await nextEventOnTarget(page, "missing", "turbo:frame-missing")
+
+  assert.equal(await page.textContent("#missing"), "Overridden")
+})
+
+test("test the turbo:frame-missing event following a link to a page without a matching frame can drive a Visit", async ({
+  page,
+}) => {
+  await page.locator("#missing").evaluate((frame) => {
+    frame.addEventListener(
+      "turbo:frame-missing",
+      ((event: CustomEvent) => {
+        event.preventDefault()
+        const { response, visit } = event.detail
+
+        visit(response)
+      }) as EventListener,
+      { once: true }
+    )
+  })
+  await page.click("#missing-frame-link")
+  await nextEventOnTarget(page, "missing", "turbo:frame-missing")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("h1"), "Frames: #frame")
+  assert.notOk(await hasSelector(page, "turbo-frame#missing"))
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames.html")
+  assert.ok(await hasSelector(page, "#missing-frame-link"))
+})
+
+test("test following a link to a page with a matching frame does not dispatch a turbo:frame-missing event", async ({
+  page,
+}) => {
+  await page.click("#link-frame")
+
+  assert.ok(await noNextEventNamed(page, "turbo:frame-missing"))
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  const src = await attributeForSelector(page, "#frame", "src")
+  assert(
+    src?.includes("/src/tests/fixtures/frames/frame.html"),
+    "navigates frame without dispatching turbo:frame-missing"
+  )
+})
+
+test("test following a link within a frame with a target set navigates the target frame", async ({ page }) => {
+  await page.click("#hello a")
+  await nextBeat()
+
+  const frameText = await page.textContent("#frame h2")
+  assert.equal(frameText, "Frame: Loaded")
+})
+
+test("test following a link in rapid succession cancels the previous request", async ({ page }) => {
+  await page.click("#outside-frame-form")
+  await page.click("#outer-frame-link")
+  await nextBeat()
+
+  const frameText = await page.textContent("#frame h2")
+  assert.equal(frameText, "Frame: Loaded")
+})
+
+test("test following a link within a descendant frame whose ancestor declares a target set navigates the descendant frame", async ({
+  page,
+}) => {
+  const selector = "#nested-root[target=frame] #nested-child a:not([data-turbo-frame])"
+  const link = await page.locator(selector)
+  const href = await propertyForSelector(page, selector, "href")
+
+  await link.click()
+  await nextBeat()
+
+  const frame = await page.textContent("#frame h2")
+  const nestedRoot = await page.textContent("#nested-root h2")
+  const nestedChild = await page.textContent("#nested-child")
+  assert.equal(frame, "Frames: #frame")
+  assert.equal(nestedRoot, "Frames: #nested-root")
+  assert.equalIgnoringWhitespace(nestedChild, "Frame: Loaded")
+  assert.equal(await attributeForSelector(page, "#frame", "src"), null)
+  assert.equal(await attributeForSelector(page, "#nested-root", "src"), null)
+  assert.equal(await attributeForSelector(page, "#nested-child", "src"), href || "")
+})
+
+test("test following a link that declares data-turbo-frame within a frame whose ancestor respects the override", async ({
+  page,
+}) => {
+  await page.click("#nested-root[target=frame] #nested-child a[data-turbo-frame]")
+  await nextBeat()
+
+  const frameText = await page.textContent("body > h1")
+  assert.equal(frameText, "One")
+  assert.notOk(await hasSelector(page, "#frame"))
+  assert.notOk(await hasSelector(page, "#nested-root"))
+  assert.notOk(await hasSelector(page, "#nested-child"))
+})
+
+test("test following a form within a nested frame with form target top", async ({ page }) => {
+  await page.click("#nested-child-navigate-form-top-submit")
+  await nextBeat()
+
+  const frameText = await page.textContent("body > h1")
+  assert.equal(frameText, "One")
+  assert.notOk(await hasSelector(page, "#frame"))
+  assert.notOk(await hasSelector(page, "#nested-root"))
+  assert.notOk(await hasSelector(page, "#nested-child"))
+})
+
+test("test following a form within a nested frame with child frame target top", async ({ page }) => {
+  await page.click("#nested-child-navigate-top-submit")
+  await nextBeat()
+
+  const frameText = await page.textContent("body > h1")
+  assert.equal(frameText, "One")
+  assert.notOk(await hasSelector(page, "#frame"))
+  assert.notOk(await hasSelector(page, "#nested-root"))
+  assert.notOk(await hasSelector(page, "#nested-child-navigate-top"))
+})
+
+test("test following a link within a frame with target=_top navigates the page", async ({ page }) => {
+  assert.equal(await attributeForSelector(page, "#navigate-top", "src"), null)
+
+  await page.click("#navigate-top a:not([data-turbo-frame])")
+  await nextBeat()
+
+  const frameText = await page.textContent("body > h1")
+  assert.equal(frameText, "One")
+  assert.notOk(await hasSelector(page, "#navigate-top a"))
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await searchParams(page.url()).get("key"), "value")
+})
+
+test("test following a link that declares data-turbo-frame='_self' within a frame with target=_top navigates the frame itself", async ({
+  page,
+}) => {
+  assert.equal(await attributeForSelector(page, "#navigate-top", "src"), null)
+
+  await page.click("#navigate-top a[data-turbo-frame='_self']")
+  await nextBeat()
+
+  const title = await page.textContent("body > h1")
+  assert.equal(title, "Frames")
+  assert.ok(await hasSelector(page, "#navigate-top"))
+  const frame = await page.textContent("#navigate-top")
+  assert.equalIgnoringWhitespace(frame, "Replaced only the frame")
+})
+
+test("test following a link to a page with a <turbo-frame recurse> which lazily loads a matching frame", async ({
+  page,
+}) => {
+  await page.click("#recursive summary")
+
+  assert.ok(await hasSelector(page, "#recursive details[open]"))
+
+  await page.click("#recursive a")
+  await nextEventOnTarget(page, "recursive", "turbo:frame-load")
+  await nextEventOnTarget(page, "composer", "turbo:frame-load")
+
+  assert.ok(await hasSelector(page, "#recursive details:not([open])"))
+})
+
+test("test submitting a form that redirects to a page with a <turbo-frame recurse> which lazily loads a matching frame", async ({
+  page,
+}) => {
+  await page.click("#recursive summary")
+
+  assert.ok(await hasSelector(page, "#recursive details[open]"))
+
+  await page.click("#recursive input[type=submit]")
+  await nextEventOnTarget(page, "recursive", "turbo:frame-load")
+  await nextEventOnTarget(page, "composer", "turbo:frame-load")
+
+  assert.ok(await hasSelector(page, "#recursive details:not([open])"))
+})
+
+test("test removing [disabled] attribute from eager-loaded frame navigates it", async ({ page }) => {
+  await page.evaluate(() => document.getElementById("frame")?.setAttribute("disabled", ""))
+  await page.evaluate(() =>
+    document.getElementById("frame")?.setAttribute("src", "/src/tests/fixtures/frames/frame.html")
+  )
+
+  assert.ok(
+    await noNextEventOnTarget(page, "frame", "turbo:before-fetch-request"),
+    "[disabled] frames do not submit requests"
+  )
+
+  await page.evaluate(() => document.getElementById("frame")?.removeAttribute("disabled"))
+
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
+})
+
+test("test evaluates frame script elements on each render", async ({ page }) => {
+  assert.equal(await frameScriptEvaluationCount(page), undefined)
+
+  await page.click("#body-script-link")
+  await nextEventOnTarget(page, "body-script", "turbo:frame-load")
+  assert.equal(await frameScriptEvaluationCount(page), 1)
+
+  await page.click("#body-script-link")
+  await nextEventOnTarget(page, "body-script", "turbo:frame-load")
+  assert.equal(await frameScriptEvaluationCount(page), 2)
+})
+
+test("test does not evaluate data-turbo-eval=false scripts", async ({ page }) => {
+  await page.click("#eval-false-script-link")
+  await nextBeat()
+  assert.equal(await frameScriptEvaluationCount(page), undefined)
+})
+
+test("test redirecting in a form is still navigatable after redirect", async ({ page }) => {
+  await page.click("#navigate-form-redirect")
+  await nextEventOnTarget(page, "form-redirect", "turbo:frame-load")
+  assert.equal(await page.textContent("turbo-frame#form-redirect h2"), "Form Redirect")
+
+  await page.click("#submit-form")
+  await nextEventOnTarget(page, "form-redirect", "turbo:frame-load")
+  assert.equal(await page.textContent("turbo-frame#form-redirect h2"), "Form Redirected")
+
+  await page.click("#navigate-form-redirect")
+  await nextEventOnTarget(page, "form-redirect", "turbo:frame-load")
+
+  assert.equal(await page.textContent("turbo-frame#form-redirect h2"), "Form Redirect")
+})
+
+test("test 'turbo:frame-render' is triggered after frame has finished rendering", async ({ page }) => {
+  await page.click("#frame-part")
+
+  await nextEventNamed(page, "turbo:frame-render") // recursive
+  const { fetchResponse } = await nextEventNamed(page, "turbo:frame-render")
+
+  assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/part.html")
+})
+
+test("test navigating a frame from an outer form fires events", async ({ page }) => {
+  await page.click("#outside-frame-form")
+
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-response")
+  const { fetchResponse } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/form.html")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+})
+
+test("test navigating a frame from an outer link fires events", async ({ page }) => {
+  await listenForEventOnTarget(page, "outside-frame-form", "turbo:click")
+  await page.click("#outside-frame-form")
+
+  await nextEventOnTarget(page, "outside-frame-form", "turbo:click")
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-response")
+  const { fetchResponse } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/form.html")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+})
+
+test("test navigating a frame from an inner link fires events", async ({ page }) => {
+  await listenForEventOnTarget(page, "link-frame", "turbo:click")
+  await page.click("#link-frame")
+
+  await nextEventOnTarget(page, "link-frame", "turbo:click")
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-response")
+  const { fetchResponse } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/frame.html")
+
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+})
+
+test("test navigating a frame targeting _top from an outer link fires events", async ({ page }) => {
+  await listenForEventOnTarget(page, "outside-navigate-top-link", "turbo:click")
+  await page.click("#outside-navigate-top-link")
+
+  await nextEventOnTarget(page, "outside-navigate-top-link", "turbo:click")
+  await nextEventOnTarget(page, "html", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "html", "turbo:before-fetch-response")
+  await nextEventOnTarget(page, "html", "turbo:before-render")
+  await nextEventOnTarget(page, "html", "turbo:render")
+  await nextEventOnTarget(page, "html", "turbo:load")
+
+  const otherEvents = await readEventLogs(page)
+  assert.equal(otherEvents.length, 0, "no more events")
+})
+
+test("test invoking .reload() re-fetches the frame's content", async ({ page }) => {
+  await page.click("#link-frame")
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+  await page.evaluate(() => (document.getElementById("frame") as any).reload())
+
+  const dispatchedEvents = await readEventLogs(page)
+
+  assert.deepEqual(
+    dispatchedEvents.map(([name, _, id]) => [id, name]),
+    [
+      ["frame", "turbo:before-fetch-request"],
+      ["frame", "turbo:before-fetch-response"],
+      ["frame", "turbo:before-frame-render"],
+      ["frame", "turbo:frame-render"],
+      ["frame", "turbo:frame-load"],
+    ]
+  )
+})
+
+test("test following inner link reloads frame on every click", async ({ page }) => {
+  await page.click("#hello a")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+
+  await page.click("#hello a")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+})
+
+test("test following outer link reloads frame on every click", async ({ page }) => {
+  await page.click("#outer-frame-link")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+
+  await page.click("#outer-frame-link")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+})
+
+test("test following outer form reloads frame on every submit", async ({ page }) => {
+  await page.click("#outer-frame-submit")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+
+  await page.click("#outer-frame-submit")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+})
+
+test("test an inner/outer link reloads frame on every click", async ({ page }) => {
+  await page.click("#inner-outer-frame-link")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+
+  await page.click("#inner-outer-frame-link")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+})
+
+test("test an inner/outer form reloads frame on every submit", async ({ page }) => {
+  await page.click("#inner-outer-frame-submit")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+
+  await page.click("#inner-outer-frame-submit")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+})
+
+test("test reconnecting after following a link does not reload the frame", async ({ page }) => {
+  await page.click("#hello a")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+
+  await page.evaluate(() => {
+    window.savedElement = document.querySelector("#frame")
+    window.savedElement?.remove()
+  })
+  await nextBeat()
+
+  await page.evaluate(() => {
+    if (window.savedElement) {
+      document.body.appendChild(window.savedElement)
+    }
+  })
+  await nextBeat()
+
+  const eventLogs = await readEventLogs(page)
+  const requestLogs = eventLogs.filter(([name]) => name == "turbo:before-fetch-request")
+  assert.equal(requestLogs.length, 0)
+})
+
+test("test navigating pushing URL state from a frame navigation fires events", async ({ page }) => {
+  await page.click("#link-outside-frame-action-advance")
+
+  assert.equal(
+    await nextAttributeMutationNamed(page, "frame", "aria-busy"),
+    "true",
+    "sets aria-busy on the <turbo-frame>"
+  )
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "frame", "turbo:before-fetch-response")
+  await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+  assert.notOk(await nextAttributeMutationNamed(page, "frame", "aria-busy"), "removes aria-busy from the <turbo-frame>")
+
+  assert.equal(await nextAttributeMutationNamed(page, "html", "aria-busy"), "true", "sets aria-busy on the <html>")
+  await nextEventOnTarget(page, "html", "turbo:before-visit")
+  await nextEventOnTarget(page, "html", "turbo:visit")
+  await nextEventOnTarget(page, "html", "turbo:before-cache")
+  await nextEventOnTarget(page, "html", "turbo:before-render")
+  await nextEventOnTarget(page, "html", "turbo:render")
+  await nextEventOnTarget(page, "html", "turbo:load")
+  assert.notOk(await nextAttributeMutationNamed(page, "html", "aria-busy"), "removes aria-busy from the <html>")
+})
+
+test("test navigating a frame with a form[method=get] that does not redirect still updates the [src]", async ({
+  page,
+}) => {
+  await page.click("#frame-form-get-no-redirect")
+  await nextEventNamed(page, "turbo:before-fetch-request")
+  await nextEventNamed(page, "turbo:before-fetch-response")
+  await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
+
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+  assert.equal(await page.textContent("h1"), "Frames")
+  assert.equal(await page.textContent("#frame h2"), "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames.html")
+})
+
+test("test navigating turbo-frame[data-turbo-action=advance] from within pushes URL state", async ({ page }) => {
+  await page.click("#add-turbo-action-to-frame")
+  await page.click("#link-frame")
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
+})
+
+test("test navigating turbo-frame[data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
+  page,
+}) => {
+  await page.click("#link-outside-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+  await page.click("#link-outside-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+  await page.click("#link-outside-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await attributeForSelector(page, "#frame", "aria-busy"), null, "clears turbo-frame[aria-busy]")
+  assert.equal(await attributeForSelector(page, "#html", "aria-busy"), null, "clears html[aria-busy]")
+  assert.equal(await attributeForSelector(page, "#html", "data-turbo-preview"), null, "clears html[aria-busy]")
+})
+
+test("test navigating a turbo-frame with an a[data-turbo-action=advance] preserves page state", async ({ page }) => {
+  await scrollToSelector(page, "#below-the-fold-input")
+  await page.fill("#below-the-fold-input", "a value")
+  await page.click("#below-the-fold-link-frame-action")
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
+  assert.equal(await propertyForSelector(page, "#below-the-fold-input", "value"), "a value", "preserves page state")
+
+  const { y } = await scrollPosition(page)
+  assert.notEqual(y, 0, "preserves Y scroll position")
+})
+
+test("test a turbo-frame that has been driven by a[data-turbo-action] can be navigated normally", async ({ page }) => {
+  await page.click("#remove-target-from-hello")
+  await page.click("#link-hello-advance")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("h1"), "Frames")
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html")
+
+  await page.click("#hello a")
+  await nextEventOnTarget(page, "hello", "turbo:frame-load")
+
+  assert.ok(await noNextEventNamed(page, "turbo:load"))
+  assert.equal(await page.textContent("#hello h2"), "Frames: #hello")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html")
+})
+
+test("test navigating turbo-frame from within with a[data-turbo-action=advance] pushes URL state", async ({ page }) => {
+  await page.click("#link-nested-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
+  assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
+})
+
+test("test navigating frame with a[data-turbo-action=advance] pushes URL state", async ({ page }) => {
+  await page.click("#link-outside-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
+  assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
+})
+
+test("test navigating frame with form[method=get][data-turbo-action=advance] pushes URL state", async ({ page }) => {
+  await page.click("#form-get-frame-action-advance button")
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
+  assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
+})
+
+test("test navigating frame with form[method=get][data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
+  page,
+}) => {
+  await page.click("#form-get-frame-action-advance button")
+  await nextEventNamed(page, "turbo:load")
+  await page.click("#form-get-frame-action-advance button")
+  await nextEventNamed(page, "turbo:load")
+  await page.click("#form-get-frame-action-advance button")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await attributeForSelector(page, "#frame", "aria-busy"), null, "clears turbo-frame[aria-busy]")
+  assert.equal(await attributeForSelector(page, "#html", "aria-busy"), null, "clears html[aria-busy]")
+  assert.equal(await attributeForSelector(page, "#html", "data-turbo-preview"), null, "clears html[aria-busy]")
+})
+
+test("test navigating frame with form[method=post][data-turbo-action=advance] pushes URL state", async ({ page }) => {
+  await page.click("#form-post-frame-action-advance button")
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
+  assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
+})
+
+test("test navigating frame with form[method=post][data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
+  page,
+}) => {
+  await page.click("#form-post-frame-action-advance button")
+  await nextEventNamed(page, "turbo:load")
+  await page.click("#form-post-frame-action-advance button")
+  await nextEventNamed(page, "turbo:load")
+  await page.click("#form-post-frame-action-advance button")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await attributeForSelector(page, "#frame", "aria-busy"), null, "clears turbo-frame[aria-busy]")
+  assert.equal(await attributeForSelector(page, "#html", "aria-busy"), null, "clears html[aria-busy]")
+  assert.equal(await attributeForSelector(page, "#html", "data-turbo-preview"), null, "clears html[aria-busy]")
+  assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
+})
+
+test("test navigating frame with button[data-turbo-action=advance] pushes URL state", async ({ page }) => {
+  await page.click("#button-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
+  assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
+})
+
+test("test navigating back after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames previous contents", async ({
+  page,
+}) => {
+  await page.click("#add-turbo-action-to-frame")
+  await page.click("#link-frame")
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frames: #frame")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames.html")
+  assert.equal(await attributeForSelector(page, "#frame", "src"), null)
+  assert.equal(await propertyForSelector(page, "#frame", "src"), null)
+})
+
+test("test navigating back then forward after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames next contents", async ({
+  page,
+}) => {
+  await page.click("#add-turbo-action-to-frame")
+  await page.click("#link-frame")
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+  await page.goForward()
+  await nextEventNamed(page, "turbo:load")
+
+  const title = await page.textContent("h1")
+  const frameTitle = await page.textContent("#frame h2")
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame.html"), "updates src attribute")
+  assert.equal(title, "Frames")
+  assert.equal(frameTitle, "Frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
+  assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
+})
+
+test("test turbo:before-fetch-request fires on the frame element", async ({ page }) => {
+  await page.click("#hello a")
+  assert.ok(await nextEventOnTarget(page, "frame", "turbo:before-fetch-request"))
+})
+
+test("test turbo:before-fetch-response fires on the frame element", async ({ page }) => {
+  await page.click("#hello a")
+  assert.ok(await nextEventOnTarget(page, "frame", "turbo:before-fetch-response"))
+})
+
+test("test navigating a eager frame with a link[method=get] that does not fetch eager frame twice", async ({
+  page,
+}) => {
+  await page.click("#link-to-eager-loaded-frame")
+
+  await nextBeat()
+
+  const eventLogs = await readEventLogs(page)
+  const fetchLogs = eventLogs.filter(
+    ([name, options]) =>
+      name == "turbo:before-fetch-request" && options?.url?.includes("/src/tests/fixtures/frames/frame_for_eager.html")
+  )
+  assert.equal(fetchLogs.length, 1)
+
+  const src = (await attributeForSelector(page, "#eager-loaded-frame", "src")) ?? ""
+  assert.ok(src.includes("/src/tests/fixtures/frames/frame_for_eager.html"), "updates src attribute")
+  assert.equal(await page.textContent("h1"), "Eager-loaded frame")
+  assert.equal(await page.textContent("#eager-loaded-frame h2"), "Eager-loaded frame: Loaded")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/page_with_eager_frame.html")
+})
+
+test("form submissions from frames clear snapshot cache", async ({ page }) => {
+  await page.evaluate(() => {
+    document.querySelector("h1")!.textContent = "Changed"
+  })
+
+  await expect(page.locator("h1")).toHaveText("Changed")
+
+  await page.click("#navigate-form-redirect-as-new")
+  await expect(page.locator("h1")).toHaveText("Page One Form")
+  await page.click("#submit-form")
+  await expect(page.locator("h2")).toHaveText("Form Redirected")
+  await page.goBack()
+
+  await expect(page.locator("h1")).not.toHaveText("Changed")
+})
+
+async function withoutChangingEventListenersCount(page: Page, callback: () => Promise<void>) {
+  const name = "eventListenersAttachedToDocument"
+  const setup = () => {
+    return page.evaluate((name) => {
+      const context = window as any
+      context[name] = 0
+      context.originals = {
+        addEventListener: document.addEventListener,
+        removeEventListener: document.removeEventListener,
+      }
+
+      document.addEventListener = (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions
+      ) => {
+        context.originals.addEventListener.call(document, type, listener, options)
+        context[name] += 1
+      }
+
+      document.removeEventListener = (
+        type: string,
+        listener: EventListenerOrEventListenerObject,
+        options?: boolean | AddEventListenerOptions
+      ) => {
+        context.originals.removeEventListener.call(document, type, listener, options)
+        context[name] -= 1
+      }
+
+      return context[name] || 0
+    }, name)
+  }
+
+  const teardown = () => {
+    return page.evaluate((name) => {
+      const context = window as any
+      const { addEventListener, removeEventListener } = context.originals
+
+      document.addEventListener = addEventListener
+      document.removeEventListener = removeEventListener
+
+      return context[name] || 0
+    }, name)
+  }
+
+  const originalCount = await setup()
+  await callback()
+  const finalCount = await teardown()
+
+  assert.equal(finalCount, originalCount, "expected callback not to leak event listeners")
+}
+
+function frameScriptEvaluationCount(page: Page): Promise<number | undefined> {
+  return page.evaluate(() => window.frameScriptEvaluationCount)
+}
+
+declare global {
+  interface Window {
+    frameScriptEvaluationCount?: number
+  }
+}

--- a/src/tests/functional/import_tests.ts
+++ b/src/tests/functional/import_tests.ts
@@ -1,0 +1,10 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+
+test("test window variable with ESM", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/esm.html")
+  const type = await page.evaluate(() => {
+    return typeof window.Turbo
+  })
+  assert.equal(type, "object")
+})

--- a/src/tests/functional/loading_tests.ts
+++ b/src/tests/functional/loading_tests.ts
@@ -1,0 +1,214 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import {
+  attributeForSelector,
+  hasSelector,
+  nextAttributeMutationNamed,
+  nextBeat,
+  nextBody,
+  nextEventNamed,
+  nextEventOnTarget,
+  noNextEventOnTarget,
+  readEventLogs,
+} from "../helpers/page"
+
+declare global {
+  interface Window {
+    savedElement: Element | null
+  }
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/loading.html")
+  await readEventLogs(page)
+})
+
+test("test eager loading within a details element", async ({ page }) => {
+  await nextBeat()
+  assert.ok(await hasSelector(page, "#loading-eager turbo-frame#frame h2"))
+  assert.ok(await hasSelector(page, "#loading-eager turbo-frame[complete]"), "has [complete] attribute")
+})
+
+test("test lazy loading within a details element", async ({ page }) => {
+  await nextBeat()
+
+  const frameContents = "#loading-lazy turbo-frame h2"
+  assert.notOk(await hasSelector(page, frameContents))
+  assert.ok(await hasSelector(page, "#loading-lazy turbo-frame:not([complete])"))
+
+  await page.click("#loading-lazy summary")
+  await nextBeat()
+
+  const contents = await page.locator(frameContents)
+  assert.equal(await contents.textContent(), "Hello from a frame")
+  assert.ok(await hasSelector(page, "#loading-lazy turbo-frame[complete]"), "has [complete] attribute")
+})
+
+test("test changing loading attribute from lazy to eager loads frame", async ({ page }) => {
+  const frameContents = "#loading-lazy turbo-frame h2"
+  await nextBeat()
+
+  assert.notOk(await hasSelector(page, frameContents))
+
+  await page.evaluate(() => document.querySelector("#loading-lazy turbo-frame")?.setAttribute("loading", "eager"))
+  await nextBeat()
+
+  const contents = await page.locator(frameContents)
+  await page.click("#loading-lazy summary")
+  assert.equal(await contents.textContent(), "Hello from a frame")
+})
+
+test("test navigating a visible frame with loading=lazy navigates", async ({ page }) => {
+  await page.click("#loading-lazy summary")
+  await nextBeat()
+
+  const initialContents = await page.locator("#hello h2")
+  assert.equal(await initialContents.textContent(), "Hello from a frame")
+
+  await page.click("#hello a")
+  await nextBeat()
+
+  const navigatedContents = await page.locator("#hello h2")
+  assert.equal(await navigatedContents.textContent(), "Frames: #hello")
+})
+
+test("test changing src attribute on a frame with loading=lazy defers navigation", async ({ page }) => {
+  const frameContents = "#loading-lazy turbo-frame h2"
+  await nextBeat()
+
+  await page.evaluate(() =>
+    document.querySelector("#loading-lazy turbo-frame")?.setAttribute("src", "/src/tests/fixtures/frames.html")
+  )
+  assert.notOk(await hasSelector(page, frameContents))
+
+  await page.click("#loading-lazy summary")
+  await nextBeat()
+
+  const contents = await page.locator(frameContents)
+  assert.equal(await contents.textContent(), "Frames: #hello")
+})
+
+test("test changing src attribute on a frame with loading=eager navigates", async ({ page }) => {
+  const frameContents = "#loading-eager turbo-frame h2"
+  await nextBeat()
+
+  await page.evaluate(() =>
+    document.querySelector("#loading-eager turbo-frame")?.setAttribute("src", "/src/tests/fixtures/frames.html")
+  )
+
+  await page.click("#loading-eager summary")
+  await nextBeat()
+
+  const contents = await page.locator(frameContents)
+  assert.equal(await contents.textContent(), "Frames: #frame")
+})
+
+test("test reloading a frame reloads the content", async ({ page }) => {
+  await page.click("#loading-eager summary")
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  const frameContent = "#loading-eager turbo-frame#frame h2"
+  assert.ok(await hasSelector(page, frameContent))
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "complete"), "", "has [complete] attribute")
+
+  await page.evaluate(() => (document.querySelector("#loading-eager turbo-frame") as any)?.reload())
+  assert.ok(await hasSelector(page, frameContent))
+  assert.equal(await nextAttributeMutationNamed(page, "frame", "complete"), null, "clears [complete] attribute")
+})
+
+test("test navigating away from a page does not reload its frames", async ({ page }) => {
+  await page.click("#one")
+  await nextBody(page)
+
+  const eventLogs = await readEventLogs(page)
+  const requestLogs = eventLogs.filter(([name]) => name == "turbo:before-fetch-request")
+  assert.equal(requestLogs.length, 1)
+})
+
+test("test removing the [complete] attribute of an eager frame reloads the content", async ({ page }) => {
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+  await page.evaluate(() => document.querySelector("#loading-eager turbo-frame")?.removeAttribute("complete"))
+  await nextEventOnTarget(page, "frame", "turbo:frame-load")
+
+  assert.ok(
+    await hasSelector(page, "#loading-eager turbo-frame[complete]"),
+    "sets the [complete] attribute after re-loading"
+  )
+})
+
+test("test changing [src] attribute on a [complete] frame with loading=lazy defers navigation", async ({ page }) => {
+  await page.click("#loading-lazy summary")
+  await nextEventOnTarget(page, "hello", "turbo:frame-load")
+
+  assert.ok(await hasSelector(page, "#loading-lazy turbo-frame[complete]"), "lazy frame is complete")
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame")
+
+  await page.click("#loading-lazy summary")
+  await page.click("#one")
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert.ok(await noNextEventOnTarget(page, "hello", "turbo:frame-load"))
+
+  let src = new URL((await attributeForSelector(page, "#hello", "src")) || "")
+
+  assert.ok(await hasSelector(page, "#loading-lazy turbo-frame[complete]"), "lazy frame is complete")
+  assert.equal(src.pathname, "/src/tests/fixtures/frames/hello.html", "lazy frame retains [src]")
+
+  await page.click("#link-lazy-frame")
+
+  assert.ok(await noNextEventOnTarget(page, "hello", "turbo:frame-load"))
+  assert.ok(await hasSelector(page, "#loading-lazy turbo-frame:not([complete])"), "lazy frame is not complete")
+
+  await page.click("#loading-lazy summary")
+  await nextEventOnTarget(page, "hello", "turbo:frame-load")
+
+  src = new URL((await attributeForSelector(page, "#hello", "src")) || "")
+
+  assert.equal(await page.textContent("#loading-lazy turbo-frame h2"), "Frames: #hello")
+  assert.ok(await hasSelector(page, "#loading-lazy turbo-frame[complete]"), "lazy frame is complete")
+  assert.equal(src.pathname, "/src/tests/fixtures/frames.html", "lazy frame navigates")
+})
+
+test("test navigating away from a page and then back does not reload its frames", async ({ page }) => {
+  await page.click("#one")
+  await nextBody(page)
+  await readEventLogs(page)
+  await page.goBack()
+  await nextBody(page)
+
+  const eventLogs = await readEventLogs(page)
+  const requestLogs = eventLogs.filter(([name]) => name == "turbo:before-fetch-request")
+  const requestsOnEagerFrame = requestLogs.filter((record) => record[2] == "frame")
+  const requestsOnLazyFrame = requestLogs.filter((record) => record[2] == "hello")
+
+  assert.equal(requestsOnEagerFrame.length, 0, "does not reload eager frame")
+  assert.equal(requestsOnLazyFrame.length, 0, "does not reload lazy frame")
+
+  await page.click("#loading-lazy summary")
+  await nextEventOnTarget(page, "hello", "turbo:before-fetch-request")
+  await nextEventOnTarget(page, "hello", "turbo:frame-render")
+  await nextEventOnTarget(page, "hello", "turbo:frame-load")
+})
+
+test("test disconnecting and reconnecting a frame does not reload the frame", async ({ page }) => {
+  await nextBeat()
+
+  await page.evaluate(() => {
+    window.savedElement = document.querySelector("#loading-eager")
+    window.savedElement?.remove()
+  })
+  await nextBeat()
+
+  await page.evaluate(() => {
+    if (window.savedElement) {
+      document.body.appendChild(window.savedElement)
+    }
+  })
+  await nextBeat()
+
+  const eventLogs = await readEventLogs(page)
+  const requestLogs = eventLogs.filter(([name]) => name == "turbo:before-fetch-request")
+  assert.equal(requestLogs.length, 0)
+})

--- a/src/tests/functional/navigation_tests.ts
+++ b/src/tests/functional/navigation_tests.ts
@@ -1,0 +1,494 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import {
+  clickWithoutScrolling,
+  getSearchParam,
+  hash,
+  hasSelector,
+  isScrolledToSelector,
+  nextAttributeMutationNamed,
+  nextBeat,
+  nextBody,
+  nextEventNamed,
+  noNextEventNamed,
+  pathname,
+  pathnameForIFrame,
+  readEventLogs,
+  search,
+  selectorHasFocus,
+  visitAction,
+  waitUntilSelector,
+  waitUntilNoSelector,
+  willChangeBody,
+} from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/navigation.html")
+  await readEventLogs(page)
+})
+
+test("test navigating renders a progress bar", async ({ page }) => {
+  assert.equal(
+    await page.locator("style").evaluate((style) => style.nonce),
+    "123",
+    "renders progress bar stylesheet inline with nonce"
+  )
+
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(0))
+  await page.click("#delayed-link")
+
+  await waitUntilSelector(page, ".turbo-progress-bar")
+  assert.ok(await hasSelector(page, ".turbo-progress-bar"), "displays progress bar")
+
+  await nextEventNamed(page, "turbo:load")
+  await waitUntilNoSelector(page, ".turbo-progress-bar")
+
+  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
+})
+
+test("test navigating does not render a progress bar before expiring the delay", async ({ page }) => {
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(1000))
+  await page.click("#same-origin-unannotated-link")
+
+  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "does not show progress bar before delay")
+})
+
+test("test after loading the page", async ({ page }) => {
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test following a same-origin unannotated link", async ({ page }) => {
+  page.click("#same-origin-unannotated-link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    "true",
+    "sets [aria-busy] on the document element"
+  )
+  assert.equal(
+    await nextAttributeMutationNamed(page, "html", "aria-busy"),
+    null,
+    "removes [aria-busy] from the document element"
+  )
+})
+
+test("test following a same-origin unannotated custom element link", async ({ page }) => {
+  await nextBeat()
+  await page.evaluate(() => {
+    const shadowRoot = document.querySelector("#custom-link-element")?.shadowRoot
+    const link = shadowRoot?.querySelector("a")
+    link?.click()
+  })
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(search(page.url()), "")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test drive enabled; click an element in the shadow DOM wrapped by a link in the light DOM", async ({ page }) => {
+  page.click("#shadow-dom-drive-enabled span")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test drive disabled; click an element in the shadow DOM within data-turbo='false'", async ({ page }) => {
+  page.click("#shadow-dom-drive-disabled span")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test drive enabled; click an element in the slot", async ({ page }) => {
+  page.click("#element-in-slot")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test drive disabled; click an element in the slot within data-turbo='false'", async ({ page }) => {
+  page.click("#element-in-slot-disabled")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test drive disabled; click an element in the nested slot within data-turbo='false'", async ({ page }) => {
+  page.click("#element-in-nested-slot-disabled")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test following a same-origin unannotated link with search params", async ({ page }) => {
+  page.click("#same-origin-unannotated-link-search-params")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(search(page.url()), "?key=value")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test following a same-origin unannotated form[method=GET]", async ({ page }) => {
+  page.click("#same-origin-unannotated-form button")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test following a same-origin data-turbo-method=get link", async ({ page }) => {
+  await page.click("#same-origin-get-link-form")
+  await nextEventNamed(page, "turbo:submit-start")
+  await nextEventNamed(page, "turbo:submit-end")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(getSearchParam(page.url(), "a"), "one")
+  assert.equal(getSearchParam(page.url(), "b"), "two")
+})
+
+test("test following a same-origin data-turbo-action=replace link", async ({ page }) => {
+  page.click("#same-origin-replace-link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "replace")
+})
+
+test("test following a same-origin GET form[data-turbo-action=replace]", async ({ page }) => {
+  page.click("#same-origin-replace-form-get button")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "replace")
+})
+
+test("test following a same-origin GET form button[data-turbo-action=replace]", async ({ page }) => {
+  page.click("#same-origin-replace-form-submitter-get button")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "replace")
+})
+
+test("test following a same-origin POST form[data-turbo-action=replace]", async ({ page }) => {
+  page.click("#same-origin-replace-form-post button")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "replace")
+})
+
+test("test following a same-origin POST form button[data-turbo-action=replace]", async ({ page }) => {
+  await page.click("#same-origin-replace-form-submitter-post button")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "replace")
+})
+
+test("test following a POST form clears cache", async ({ page }) => {
+  await page.evaluate(() => {
+    const cachedElement = document.createElement("some-cached-element")
+    document.body.appendChild(cachedElement)
+  })
+
+  await page.click("#form-post-submit")
+  await nextBeat() // 301 redirect response
+  await nextBeat() // 200 response
+  await page.goBack()
+  assert.notOk(await hasSelector(page, "some-cached-element"))
+})
+
+test("test following a same-origin POST link with data-turbo-action=replace", async ({ page }) => {
+  page.click("#same-origin-replace-post-link")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "replace")
+})
+
+test("test following a same-origin data-turbo=false link", async ({ page }) => {
+  await page.click("#same-origin-false-link")
+  await page.waitForEvent("load")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test following a same-origin unannotated link inside a data-turbo=false container", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link-inside-false-container")
+  await page.waitForEvent("load")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test following a same-origin data-turbo=true link inside a data-turbo=false container", async ({ page }) => {
+  page.click("#same-origin-true-link-inside-false-container")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test following a same-origin anchored link", async ({ page }) => {
+  await page.click("#same-origin-anchored-link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(hash(page.url()), "#element-id")
+  assert.equal(await visitAction(page), "advance")
+  assert(await isScrolledToSelector(page, "#element-id"))
+})
+
+test("test following a same-origin link to a named anchor", async ({ page }) => {
+  await page.click("#same-origin-anchored-link-named")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(hash(page.url()), "#named-anchor")
+  assert.equal(await visitAction(page), "advance")
+  assert(await isScrolledToSelector(page, "[name=named-anchor]"))
+})
+
+test("test following a cross-origin unannotated link", async ({ page }) => {
+  await page.click("#cross-origin-unannotated-link")
+  await nextBody(page)
+  assert.equal(page.url(), "about:blank")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test following a same-origin [target] link", async ({ page }) => {
+  const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#same-origin-targeted-link")])
+
+  assert.equal(pathname(popup.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(popup), "load")
+})
+
+test("test following a same-origin [download] link", async ({ page }) => {
+  assert.notOk<boolean>(
+    await willChangeBody(page, async () => {
+      await page.click("#same-origin-download-link")
+      await nextBeat()
+    })
+  )
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test following a same-origin link inside an SVG element", async ({ page }) => {
+  await page.click("#same-origin-link-inside-svg-element", { force: true })
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test following a cross-origin link inside an SVG element", async ({ page }) => {
+  await page.click("#cross-origin-link-inside-svg-element", { force: true })
+  await nextBody(page)
+  assert.equal(page.url(), "about:blank")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test clicking the back button", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link")
+  await nextBody(page)
+  await page.goBack()
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(await visitAction(page), "restore")
+})
+
+test("test clicking the forward button", async ({ page }) => {
+  await page.click("#same-origin-unannotated-link")
+  await nextBody(page)
+  await page.goBack()
+  await page.goForward()
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "restore")
+})
+
+test("test link targeting a disabled turbo-frame navigates the page", async ({ page }) => {
+  await page.click("#link-to-disabled-frame")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html")
+})
+
+test("test skip link with hash-only path scrolls to the anchor without a visit", async ({ page }) => {
+  assert.notOk<boolean>(
+    await willChangeBody(page, async () => {
+      await page.click('a[href="#main"]')
+      await nextBeat()
+    })
+  )
+
+  assert.ok(await isScrolledToSelector(page, "#main"), "scrolled to #main")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(hash(page.url()), "#main")
+})
+
+test("test skip link with hash-only path moves focus and changes tab order", async ({ page }) => {
+  await page.click('a[href="#main"]')
+  await nextBeat()
+  await page.press("#main", "Tab")
+
+  assert.notOk(await selectorHasFocus(page, "#ignored-link"), "skips interactive elements before #main")
+  assert.ok(await selectorHasFocus(page, "#main *:focus"), "moves focus inside #main")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(hash(page.url()), "#main")
+})
+
+test("test same-page anchored replace link assumes the intention was a refresh", async ({ page }) => {
+  await page.click("#refresh-link")
+  await nextBody(page)
+  assert.ok(await isScrolledToSelector(page, "#main"), "scrolled to #main")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(hash(page.url()), "#main")
+})
+
+test("test navigating back to anchored URL", async ({ page }) => {
+  await clickWithoutScrolling(page, 'a[href="#main"]', { hasText: "Skip Link" })
+  await nextBeat()
+
+  await clickWithoutScrolling(page, "#same-origin-unannotated-link")
+  await nextBody(page)
+  await nextBeat()
+
+  await page.goBack()
+  await nextBody(page)
+
+  assert.ok(await isScrolledToSelector(page, "#main"), "scrolled to #main")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(hash(page.url()), "#main")
+})
+
+test("test following a redirection", async ({ page }) => {
+  await page.click("#redirection-link")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "replace")
+})
+
+test("test clicking the back button after redirection", async ({ page }) => {
+  await page.click("#redirection-link")
+  await nextBody(page)
+  await page.goBack()
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(await visitAction(page), "restore")
+})
+
+test("test same-page anchor visits do not trigger visit events", async ({ page }) => {
+  const events = [
+    "turbo:before-visit",
+    "turbo:visit",
+    "turbo:before-cache",
+    "turbo:before-render",
+    "turbo:render",
+    "turbo:load",
+  ]
+
+  for (const eventName in events) {
+    await page.goto("/src/tests/fixtures/navigation.html")
+    await page.click('a[href="#main"]')
+    assert.ok(await noNextEventNamed(page, eventName), `same-page links do not trigger ${eventName} events`)
+  }
+})
+
+test("test correct referrer header", async ({ page }) => {
+  page.click("#headers-link")
+  await nextBody(page)
+  const pre = await page.textContent("pre")
+  const headers = await JSON.parse(pre || "")
+  assert.equal(
+    headers.referer,
+    "http://localhost:9000/src/tests/fixtures/navigation.html",
+    `referer header is correctly set`
+  )
+})
+
+test("test double-clicking on a link", async ({ page }) => {
+  await page.click("#delayed-link", { clickCount: 2 })
+  await nextBeat()
+
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/__turbo/delayed_response")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test does not fire turbo:load twice after following a redirect", async ({ page }) => {
+  page.click("#redirection-link")
+
+  await nextBeat() // 301 redirect response
+
+  assert.ok(await noNextEventNamed(page, "turbo:load"))
+
+  await nextBeat() // 200 response
+  await nextBody(page)
+  await nextEventNamed(page, "turbo:load")
+})
+
+test("test navigating back whilst a visit is in-flight", async ({ page }) => {
+  page.click("#delayed-link")
+  await nextEventNamed(page, "turbo:before-render")
+  await page.goBack()
+
+  assert.ok(
+    await nextEventNamed(page, "turbo:visit"),
+    "navigating back whilst a visit is in-flight starts a non-silent Visit"
+  )
+
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(await visitAction(page), "restore")
+})
+
+test("test ignores links with a [target] attribute that target an iframe with a matching [name]", async ({ page }) => {
+  await page.click("#link-target-iframe")
+  await nextBeat()
+  await noNextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
+})
+
+test("test ignores links with a [target] attribute that targets an iframe with [name='']", async ({ page }) => {
+  await page.click("#link-target-empty-name-iframe")
+  await nextBeat()
+  await noNextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+})
+
+test("test ignores forms with a [target] attribute that targets an iframe with a matching [name]", async ({ page }) => {
+  await page.click("#form-target-iframe button")
+  await nextBeat()
+  await noNextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
+})
+
+test("test ignores forms with a button[formtarget] attribute that targets an iframe with [name='']", async ({
+  page,
+}) => {
+  await page.click("#form-target-empty-name-iframe button")
+  await nextBeat()
+  await noNextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+})
+
+test("test ignores forms with a button[formtarget] attribute that targets an iframe with a matching [name]", async ({
+  page,
+}) => {
+  await page.click("#button-formtarget-iframe")
+  await nextBeat()
+  await noNextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
+  assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
+})
+
+test("test ignores forms with a [target] attribute that target an iframe with [name='']", async ({ page }) => {
+  await page.click("#button-formtarget-empty-name-iframe")
+  await nextBeat()
+  await noNextEventNamed(page, "turbo:load")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+})

--- a/src/tests/functional/pausable_rendering_tests.ts
+++ b/src/tests/functional/pausable_rendering_tests.ts
@@ -1,0 +1,50 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBeat } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/pausable_rendering.html")
+})
+
+test("test pauses and resumes rendering", async ({ page }) => {
+  page.on("dialog", (dialog) => {
+    assert.strictEqual(dialog.message(), "Continue rendering?")
+    dialog.accept()
+  })
+
+  await page.click("#link")
+  await nextBeat()
+
+  assert.equal(await page.textContent("h1"), "One")
+})
+
+test("test aborts rendering", async ({ page }) => {
+  const [firstDialog] = await Promise.all([page.waitForEvent("dialog"), page.click("#link")])
+
+  assert.strictEqual(firstDialog.message(), "Continue rendering?")
+
+  firstDialog.dismiss()
+
+  assert.equal(await page.textContent("h1"), "Pausable Rendering")
+})
+
+test("test pauses and resumes rendering a Frame", async ({ page }) => {
+  page.on("dialog", (dialog) => {
+    assert.strictEqual(dialog.message(), "Continue rendering?")
+    dialog.accept()
+  })
+
+  await page.click("#frame-link")
+  await nextBeat()
+
+  assert.equal(await page.textContent("#hello h2"), "Hello from a frame")
+})
+
+test("test aborts rendering a Frame", async ({ page }) => {
+  page.on("dialog", (dialog) => {
+    assert.strictEqual(dialog.message(), "Continue rendering?")
+    dialog.dismiss()
+  })
+
+  assert.equal(await page.textContent("#hello h2"), "Pausable Frame Rendering")
+})

--- a/src/tests/functional/pausable_requests_tests.ts
+++ b/src/tests/functional/pausable_requests_tests.ts
@@ -1,0 +1,38 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBeat } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/pausable_requests.html")
+})
+
+test("test pauses and resumes request", async ({ page }) => {
+  page.once("dialog", (dialog) => {
+    assert.strictEqual(dialog.message(), "Continue request?")
+    dialog.accept()
+  })
+
+  await page.click("#link")
+  await nextBeat()
+
+  assert.equal(await page.textContent("h1"), "One")
+})
+
+test("test aborts request", async ({ page }) => {
+  page.once("dialog", (dialog) => {
+    assert.strictEqual(dialog.message(), "Continue request?")
+    dialog.dismiss()
+  })
+
+  await page.click("#link")
+  await nextBeat()
+
+  page.once("dialog", (dialog) => {
+    assert.strictEqual(dialog.message(), "Request aborted")
+    dialog.accept()
+  })
+
+  await nextBeat()
+
+  assert.equal(await page.textContent("h1"), "Pausable Requests")
+})

--- a/src/tests/functional/preloader_tests.ts
+++ b/src/tests/functional/preloader_tests.ts
@@ -1,0 +1,53 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBeat } from "../helpers/page"
+
+test("test preloads snapshot on initial load", async ({ page }) => {
+  // contains `a[rel="preload"][href="http://localhost:9000/src/tests/fixtures/preloaded.html"]`
+  await page.goto("/src/tests/fixtures/preloading.html")
+  await nextBeat()
+
+  assert.ok(
+    await page.evaluate(() => {
+      const preloadedUrl = "http://localhost:9000/src/tests/fixtures/preloaded.html"
+      const cache = window.Turbo.session.preloader.snapshotCache.snapshots
+
+      return preloadedUrl in cache
+    })
+  )
+})
+
+test("test preloads snapshot on page visit", async ({ page }) => {
+  // contains `a[rel="preload"][href="http://localhost:9000/src/tests/fixtures/preloading.html"]`
+  await page.goto("/src/tests/fixtures/hot_preloading.html")
+
+  // contains `a[rel="preload"][href="http://localhost:9000/src/tests/fixtures/preloaded.html"]`
+  await page.click("#hot_preload_anchor")
+  await page.waitForSelector("#preload_anchor")
+  await nextBeat()
+
+  assert.ok(
+    await page.evaluate(() => {
+      const preloadedUrl = "http://localhost:9000/src/tests/fixtures/preloaded.html"
+      const cache = window.Turbo.session.preloader.snapshotCache.snapshots
+
+      return preloadedUrl in cache
+    })
+  )
+})
+
+test("test navigates to preloaded snapshot from frame", async ({ page }) => {
+  // contains `a[rel="preload"][href="http://localhost:9000/src/tests/fixtures/preloaded.html"]`
+  await page.goto("/src/tests/fixtures/frame_preloading.html")
+  await page.waitForSelector("#frame_preload_anchor")
+  await nextBeat()
+
+  assert.ok(
+    await page.evaluate(() => {
+      const preloadedUrl = "http://localhost:9000/src/tests/fixtures/preloaded.html"
+      const cache = window.Turbo.session.preloader.snapshotCache.snapshots
+
+      return preloadedUrl in cache
+    })
+  )
+})

--- a/src/tests/functional/rendering_tests.ts
+++ b/src/tests/functional/rendering_tests.ts
@@ -1,0 +1,646 @@
+import { JSHandle, Page, test } from "@playwright/test"
+import { assert } from "chai"
+import {
+  clearLocalStorage,
+  disposeAll,
+  isScrolledToTop,
+  nextBeat,
+  nextBody,
+  nextBodyMutation,
+  nextEventNamed,
+  noNextBodyMutation,
+  pathname,
+  propertyForSelector,
+  readEventLogs,
+  scrollToSelector,
+  selectorHasFocus,
+  sleep,
+  strictElementEquals,
+  textContent,
+  visitAction,
+} from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/rendering.html")
+  await clearLocalStorage(page)
+  await readEventLogs(page)
+})
+
+test("test triggers before-render and render events", async ({ page }) => {
+  await page.click("#same-origin-link")
+  const { newBody } = await nextEventNamed(page, "turbo:before-render")
+
+  assert.equal(await page.textContent("h1"), "One")
+
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await newBody, await page.evaluate(() => document.body.outerHTML))
+})
+
+test("test includes isPreview in render event details", async ({ page }) => {
+  await page.click("#same-origin-link")
+
+  const { isPreview } = await nextEventNamed(page, "turbo:before-render")
+  assert.equal(isPreview, false)
+
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await isPreview, false)
+})
+
+test("test triggers before-render, render, and load events for error pages", async ({ page }) => {
+  await page.click("#nonexistent-link")
+  const { newBody } = await nextEventNamed(page, "turbo:before-render")
+
+  assert.equal(await textContent(page, newBody), "\nCannot GET /nonexistent\n\n\n")
+
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await newBody, await page.evaluate(() => document.body.outerHTML))
+
+  await nextEventNamed(page, "turbo:load")
+})
+
+test("test reloads when tracked elements change", async ({ page }) => {
+  await page.evaluate(() =>
+    window.addEventListener(
+      "turbo:reload",
+      (e: any) => {
+        localStorage.setItem("reloadReason", e.detail.reason)
+      },
+      { once: true }
+    )
+  )
+
+  await page.click("#tracked-asset-change-link")
+  await nextBody(page)
+
+  const reason = await page.evaluate(() => localStorage.getItem("reloadReason"))
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/tracked_asset_change.html")
+  assert.equal(await visitAction(page), "load")
+  assert.equal(reason, "tracked_element_mismatch")
+})
+
+test("test reloads when tracked elements change due to failed form submission", async ({ page }) => {
+  await page.click("#tracked-asset-change-form button")
+  await nextBeat()
+
+  await page.evaluate(() => {
+    window.addEventListener(
+      "turbo:reload",
+      (e: any) => {
+        localStorage.setItem("reason", e.detail.reason)
+      },
+      { once: true }
+    )
+
+    window.addEventListener(
+      "beforeunload",
+      () => {
+        localStorage.setItem("unloaded", "true")
+      },
+      { once: true }
+    )
+  })
+
+  await page.click("#tracked-asset-change-form button")
+  await nextBeat()
+
+  const reason = await page.evaluate(() => localStorage.getItem("reason"))
+  const unloaded = await page.evaluate(() => localStorage.getItem("unloaded"))
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/rendering.html")
+  assert.equal(await visitAction(page), "load")
+  assert.equal(reason, "tracked_element_mismatch")
+  assert.equal(unloaded, "true")
+})
+
+test("test before-render event supports custom render function", async ({ page }) => {
+  await page.evaluate(() =>
+    addEventListener("turbo:before-render", (event) => {
+      const { detail } = event as CustomEvent
+      const { render } = detail
+      detail.render = (currentElement: HTMLBodyElement, newElement: HTMLBodyElement) => {
+        newElement.insertAdjacentHTML("beforeend", `<span id="custom-rendered">Custom Rendered</span>`)
+        render(currentElement, newElement)
+      }
+    })
+  )
+  await page.click("#same-origin-link")
+  await nextBody(page)
+
+  const customRendered = await page.locator("#custom-rendered")
+  assert.equal(await customRendered.textContent(), "Custom Rendered", "renders with custom function")
+})
+
+test("test before-render event supports async custom render function", async ({ page }) => {
+  await page.evaluate(() => {
+    const nextEventLoopTick = () =>
+      new Promise<void>((resolve) => {
+        setTimeout(() => resolve(), 0)
+      })
+
+    addEventListener("turbo:before-render", (event) => {
+      const { detail } = event as CustomEvent
+      const { render } = detail
+      detail.render = async (currentElement: HTMLBodyElement, newElement: HTMLBodyElement) => {
+        await nextEventLoopTick()
+
+        newElement.insertAdjacentHTML("beforeend", `<span id="custom-rendered">Custom Rendered</span>`)
+        render(currentElement, newElement)
+      }
+    })
+
+    addEventListener("turbo:load", () => {
+      localStorage.setItem("renderedElement", document.getElementById("custom-rendered")?.textContent || "")
+    })
+  })
+  await page.click("#same-origin-link")
+  await nextEventNamed(page, "turbo:load")
+
+  const renderedElement = await page.evaluate(() => localStorage.getItem("renderedElement"))
+
+  assert.equal(renderedElement, "Custom Rendered", "renders with custom function")
+})
+
+test("test wont reload when tracked elements has a nonce", async ({ page }) => {
+  await page.click("#tracked-nonce-tag-link")
+  await nextBody(page)
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/tracked_nonce_tag.html")
+  assert.equal(await visitAction(page), "advance")
+})
+
+test("test reloads when turbo-visit-control setting is reload", async ({ page }) => {
+  await page.evaluate(() =>
+    window.addEventListener(
+      "turbo:reload",
+      (e: any) => {
+        localStorage.setItem("reloadReason", e.detail.reason)
+      },
+      { once: true }
+    )
+  )
+
+  await page.click("#visit-control-reload-link")
+  await nextBody(page)
+
+  const reason = await page.evaluate(() => localStorage.getItem("reloadReason"))
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/visit_control_reload.html")
+  assert.equal(await visitAction(page), "load")
+  assert.equal(reason, "turbo_visit_control_is_reload")
+})
+
+test("test maintains scroll position before visit when turbo-visit-control setting is reload", async ({ page }) => {
+  await scrollToSelector(page, "#below-the-fold-visit-control-reload-link")
+  assert.notOk(await isScrolledToTop(page), "scrolled down")
+
+  await page.evaluate(() => localStorage.setItem("scrolls", "false"))
+
+  page.evaluate(() =>
+    addEventListener("click", () => {
+      addEventListener("scroll", () => {
+        localStorage.setItem("scrolls", "true")
+      })
+    })
+  )
+
+  page.click("#below-the-fold-visit-control-reload-link")
+
+  await nextBody(page)
+
+  const scrolls = await page.evaluate(() => localStorage.getItem("scrolls"))
+  assert.equal(scrolls, "false", "scroll position is preserved")
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/visit_control_reload.html")
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test accumulates asset elements in head", async ({ page }) => {
+  const assetElements = () => page.$$('script, style, link[rel="stylesheet"]')
+  const originalElements = await assetElements()
+
+  await page.click("#additional-assets-link")
+  await nextBody(page)
+  const newElements = await assetElements()
+  assert.notOk(await deepElementsEqual(page, newElements, originalElements))
+
+  await page.goBack()
+  await nextBody(page)
+  const finalElements = await assetElements()
+  assert.ok(await deepElementsEqual(page, finalElements, newElements))
+
+  await disposeAll(...originalElements, ...newElements, ...finalElements)
+})
+
+test("test replaces provisional elements in head", async ({ page }) => {
+  const provisionalElements = () => page.$$('head :not(script), head :not(style), head :not(link[rel="stylesheet"])')
+  const originalElements = await provisionalElements()
+  assert.equal(await page.locator("meta[name=test]").count(), 0)
+
+  await page.click("#same-origin-link")
+  await nextBody(page)
+  const newElements = await provisionalElements()
+  assert.notOk(await deepElementsEqual(page, newElements, originalElements))
+  assert.equal(await page.locator("meta[name=test]").count(), 1)
+
+  await page.goBack()
+  await nextBody(page)
+  const finalElements = await provisionalElements()
+  assert.notOk(await deepElementsEqual(page, finalElements, newElements))
+  assert.equal(await page.locator("meta[name=test]").count(), 0)
+
+  await disposeAll(...originalElements, ...newElements, ...finalElements)
+})
+
+test("test evaluates head stylesheet elements", async ({ page }) => {
+  assert.equal(await isStylesheetEvaluated(page), false)
+
+  await page.click("#additional-assets-link")
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await isStylesheetEvaluated(page), true)
+})
+
+test("test does not evaluate head stylesheet elements inside noscript elements", async ({ page }) => {
+  assert.equal(await isNoscriptStylesheetEvaluated(page), false)
+
+  await page.click("#additional-assets-link")
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await isNoscriptStylesheetEvaluated(page), false)
+})
+
+test("test waits for CSS to be loaded before rendering", async ({ page }) => {
+  let finishLoadingCSS = (_value?: unknown) => {}
+  const promise = new Promise((resolve) => {
+    finishLoadingCSS = resolve
+  })
+  page.route("**/*.css", async (route) => {
+    await promise
+    route.continue()
+  })
+
+  await page.click("#additional-assets-link")
+
+  assert.equal(await isStylesheetEvaluated(page), false)
+  assert.notEqual(await page.textContent("h1"), "Additional assets")
+
+  finishLoadingCSS()
+
+  await nextEventNamed(page, "turbo:render")
+
+  assert.equal(await page.textContent("h1"), "Additional assets")
+  assert.equal(await isStylesheetEvaluated(page), true)
+})
+
+test("test waits for CSS to fail before rendering", async ({ page }) => {
+  let finishLoadingCSS = (_value?: unknown) => {}
+  const promise = new Promise((resolve) => {
+    finishLoadingCSS = resolve
+  })
+  page.route("**/*.css", async (route) => {
+    await promise
+    route.abort()
+  })
+
+  await page.click("#additional-assets-link")
+
+  assert.equal(await isStylesheetEvaluated(page), false)
+  assert.notEqual(await page.textContent("h1"), "Additional assets")
+
+  finishLoadingCSS()
+
+  await nextEventNamed(page, "turbo:render")
+
+  assert.equal(await page.textContent("h1"), "Additional assets")
+  assert.equal(await isStylesheetEvaluated(page), false)
+})
+
+test("test waits for some time, but renders if CSS takes too much to load", async ({ page }) => {
+  let finishLoadingCSS = (_value?: unknown) => {}
+  const promise = new Promise((resolve) => {
+    finishLoadingCSS = resolve
+  })
+  page.route("**/*.css", async (route) => {
+    await promise
+    route.continue()
+  })
+
+  await page.click("#additional-assets-link")
+  await nextEventNamed(page, "turbo:render")
+
+  assert.equal(await page.textContent("h1"), "Additional assets")
+  assert.equal(await isStylesheetEvaluated(page), false)
+
+  finishLoadingCSS()
+  await nextBeat()
+
+  assert.equal(await isStylesheetEvaluated(page), true)
+})
+
+test("skip evaluates head script elements once", async ({ page }) => {
+  assert.equal(await headScriptEvaluationCount(page), undefined)
+
+  await page.click("#head-script-link")
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await headScriptEvaluationCount(page), 1)
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await headScriptEvaluationCount(page), 1)
+
+  await page.click("#head-script-link")
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await headScriptEvaluationCount(page), 1)
+})
+
+test("test evaluates body script elements on each render", async ({ page }) => {
+  assert.equal(await bodyScriptEvaluationCount(page), undefined)
+
+  await page.click("#body-script-link")
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await bodyScriptEvaluationCount(page), 1)
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await bodyScriptEvaluationCount(page), 1)
+
+  await page.click("#body-script-link")
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await bodyScriptEvaluationCount(page), 2)
+})
+
+test("test does not evaluate data-turbo-eval=false scripts", async ({ page }) => {
+  await page.click("#eval-false-script-link")
+  await nextEventNamed(page, "turbo:render")
+  assert.equal(await bodyScriptEvaluationCount(page), undefined)
+})
+
+test("test preserves permanent elements", async ({ page }) => {
+  const permanentElement = await page.locator("#permanent")
+  assert.equal(await permanentElement.textContent(), "Rendering")
+
+  await page.click("#permanent-element-link")
+  await nextEventNamed(page, "turbo:render")
+  assert.ok(await strictElementEquals(permanentElement, await page.locator("#permanent")))
+  assert.equal(await permanentElement!.textContent(), "Rendering")
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:render")
+  assert.ok(await strictElementEquals(permanentElement, await page.locator("#permanent")))
+})
+
+test("test restores focus during page rendering when transposing the activeElement", async ({ page }) => {
+  await page.press("#permanent-input", "Enter")
+  await nextBody(page)
+
+  assert.ok(await selectorHasFocus(page, "#permanent-input"), "restores focus after page loads")
+})
+
+test("test restores focus during page rendering when transposing an ancestor of the activeElement", async ({
+  page,
+}) => {
+  await page.press("#permanent-descendant-input", "Enter")
+  await nextBody(page)
+
+  assert.ok(await selectorHasFocus(page, "#permanent-descendant-input"), "restores focus after page loads")
+})
+
+test("test before-frame-render event supports custom render function within turbo-frames", async ({ page }) => {
+  const frame = await page.locator("#frame")
+  await frame.evaluate((frame) =>
+    frame.addEventListener("turbo:before-frame-render", (event) => {
+      const { detail } = event as CustomEvent
+      const { render } = detail
+      detail.render = (currentElement: Element, newElement: Element) => {
+        newElement.insertAdjacentHTML("beforeend", `<span id="custom-rendered">Custom Rendered Frame</span>`)
+        render(currentElement, newElement)
+      }
+    })
+  )
+
+  await page.click("#permanent-in-frame-element-link")
+  await nextBeat()
+
+  const customRendered = await page.locator("#frame #custom-rendered")
+  assert.equal(await customRendered.textContent(), "Custom Rendered Frame", "renders with custom function")
+})
+
+test("test preserves permanent elements within turbo-frames", async ({ page }) => {
+  assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
+
+  await page.click("#permanent-in-frame-element-link")
+  await nextBeat()
+
+  assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
+})
+
+test("test preserves permanent elements within turbo-frames rendered without layouts", async ({ page }) => {
+  assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
+
+  await page.click("#permanent-in-frame-without-layout-element-link")
+  await nextBeat()
+
+  assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
+})
+
+test("test restores focus during turbo-frame rendering when transposing the activeElement", async ({ page }) => {
+  await page.press("#permanent-input-in-frame", "Enter")
+  await nextBeat()
+
+  assert.ok(await selectorHasFocus(page, "#permanent-input-in-frame"), "restores focus after page loads")
+})
+
+test("test restores focus during turbo-frame rendering when transposing a descendant of the activeElement", async ({
+  page,
+}) => {
+  await page.press("#permanent-descendant-input-in-frame", "Enter")
+  await nextBeat()
+
+  assert.ok(await selectorHasFocus(page, "#permanent-descendant-input-in-frame"), "restores focus after page loads")
+})
+
+test("test preserves permanent element video playback", async ({ page }) => {
+  const videoElement = await page.locator("#permanent-video")
+  await page.click("#permanent-video-button")
+  await sleep(500)
+
+  const timeBeforeRender = await videoElement.evaluate((video: HTMLVideoElement) => video.currentTime)
+  assert.notEqual(timeBeforeRender, 0, "playback has started")
+
+  await page.click("#permanent-element-link")
+  await nextBody(page)
+
+  const timeAfterRender = await videoElement.evaluate((video: HTMLVideoElement) => video.currentTime)
+  assert.equal(timeAfterRender, timeBeforeRender, "element state is preserved")
+})
+
+test("test preserves permanent element through Turbo Stream update", async ({ page }) => {
+  await page.evaluate(() => {
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="update" target="frame">
+        <template>
+          <div id="permanent-in-frame" data-turbo-permanent>Ignored</div>
+        </template>
+      </turbo-stream>
+    `)
+  })
+  await nextBeat()
+
+  assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
+})
+
+test("test preserves permanent element through Turbo Stream append", async ({ page }) => {
+  await page.evaluate(() => {
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="append" target="frame">
+        <template>
+          <div id="permanent-in-frame" data-turbo-permanent>Ignored</div>
+        </template>
+      </turbo-stream>
+    `)
+  })
+  await nextBeat()
+
+  assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
+})
+
+test("test preserves input values", async ({ page }) => {
+  await page.fill("#text-input", "test")
+  await page.click("#checkbox-input")
+  await page.click("#radio-input")
+  await page.fill("#textarea", "test")
+  await page.selectOption("#select", "2")
+  await page.selectOption("#select-multiple", "2")
+
+  await page.click("#same-origin-link")
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await propertyForSelector(page, "#text-input", "value"), "test")
+  assert.equal(await propertyForSelector(page, "#checkbox-input", "checked"), true)
+  assert.equal(await propertyForSelector(page, "#radio-input", "checked"), true)
+  assert.equal(await propertyForSelector(page, "#textarea", "value"), "test")
+  assert.equal(await propertyForSelector(page, "#select", "value"), "2")
+  assert.equal(await propertyForSelector(page, "#select-multiple", "value"), "2")
+})
+
+test("test does not preserve password values", async ({ page }) => {
+  await page.fill("#password-input", "test")
+
+  await page.click("#same-origin-link")
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await propertyForSelector(page, "#password-input", "value"), "")
+})
+
+test("test <input type='reset'> clears values when restored from cache", async ({ page }) => {
+  await page.fill("#text-input", "test")
+  await page.click("#checkbox-input")
+  await page.click("#radio-input")
+  await page.fill("#textarea", "test")
+  await page.selectOption("#select", "2")
+  await page.selectOption("#select-multiple", "2")
+
+  await page.click("#same-origin-link")
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  await page.click("#reset-input")
+
+  assert.equal(await propertyForSelector(page, "#text-input", "value"), "")
+  assert.equal(await propertyForSelector(page, "#checkbox-input", "checked"), false)
+  assert.equal(await propertyForSelector(page, "#radio-input", "checked"), false)
+  assert.equal(await propertyForSelector(page, "#textarea", "value"), "")
+  assert.equal(await propertyForSelector(page, "#select", "value"), "1")
+  assert.equal(await propertyForSelector(page, "#select-multiple", "value"), "")
+})
+
+test("test before-cache event", async ({ page }) => {
+  await page.evaluate(() => {
+    addEventListener("turbo:before-cache", () => (document.body.innerHTML = "Modified"), { once: true })
+  })
+  await page.click("#same-origin-link")
+  await nextBody(page)
+  await page.goBack()
+
+  assert.equal(await page.textContent("body"), "Modified")
+})
+
+test("test mutation record as before-cache notification", async ({ page }) => {
+  await modifyBodyAfterRemoval(page)
+  await page.click("#same-origin-link")
+  await nextBody(page)
+  await page.goBack()
+
+  assert.equal(await page.textContent("body"), "Modified")
+})
+
+test("test error pages", async ({ page }) => {
+  await page.click("#nonexistent-link")
+  await nextBody(page)
+  assert.equal(await page.textContent("body"), "\nCannot GET /nonexistent\n\n\n")
+})
+
+test("test rendering a redirect response replaces the body once and only once", async ({ page }) => {
+  await page.click("#redirect-link")
+  await nextBodyMutation(page)
+
+  assert.ok(await noNextBodyMutation(page), "replaces <body> element once")
+})
+
+function deepElementsEqual(
+  page: Page,
+  left: JSHandle<SVGElement | HTMLElement>[],
+  right: JSHandle<SVGElement | HTMLElement>[]
+): Promise<boolean> {
+  return page.evaluate(
+    ([left, right]) => left.length == right.length && left.every((element) => right.includes(element)),
+    [left, right]
+  )
+}
+
+function headScriptEvaluationCount(page: Page): Promise<number | undefined> {
+  return page.evaluate(() => window.headScriptEvaluationCount)
+}
+
+function bodyScriptEvaluationCount(page: Page): Promise<number | undefined> {
+  return page.evaluate(() => window.bodyScriptEvaluationCount)
+}
+
+function isStylesheetEvaluated(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () => getComputedStyle(document.body).getPropertyValue("--black-if-evaluated").trim() === "black"
+  )
+}
+
+function isNoscriptStylesheetEvaluated(page: Page): Promise<boolean> {
+  return page.evaluate(
+    () => getComputedStyle(document.body).getPropertyValue("--black-if-noscript-evaluated").trim() === "black"
+  )
+}
+
+function modifyBodyAfterRemoval(page: Page) {
+  return page.evaluate(() => {
+    const { documentElement, body } = document
+    const observer = new MutationObserver((records) => {
+      for (const record of records) {
+        if (Array.from(record.removedNodes).indexOf(body) > -1) {
+          body.innerHTML = "Modified"
+          observer.disconnect()
+          break
+        }
+      }
+    })
+    observer.observe(documentElement, { childList: true })
+  })
+}
+
+declare global {
+  interface Window {
+    headScriptEvaluationCount?: number
+    bodyScriptEvaluationCount?: number
+  }
+}

--- a/src/tests/functional/scroll_restoration_tests.ts
+++ b/src/tests/functional/scroll_restoration_tests.ts
@@ -1,0 +1,31 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBeat, scrollPosition, scrollToSelector } from "../helpers/page"
+
+test("test landing on an anchor", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_restoration.html#three")
+  await nextBeat()
+  const { y: yAfterLoading } = await scrollPosition(page)
+  assert.notEqual(yAfterLoading, 0)
+})
+
+test("test reloading after scrolling", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_restoration.html")
+  await scrollToSelector(page, "#three")
+  const { y: yAfterScrolling } = await scrollPosition(page)
+  assert.notEqual(yAfterScrolling, 0)
+
+  await page.reload()
+  const { y: yAfterReloading } = await scrollPosition(page)
+  assert.notEqual(yAfterReloading, 0)
+})
+
+test("test returning from history", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_restoration.html")
+  await scrollToSelector(page, "#three")
+  await page.goto("/src/tests/fixtures/bare.html")
+  await page.goBack()
+
+  const { y: yAfterReturning } = await scrollPosition(page)
+  assert.notEqual(yAfterReturning, 0)
+})

--- a/src/tests/functional/stream_tests.ts
+++ b/src/tests/functional/stream_tests.ts
@@ -1,0 +1,123 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBeat, nextEventNamed, readEventLogs, waitUntilNoSelector, waitUntilText } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/stream.html")
+  await readEventLogs(page)
+})
+
+test("test receiving a stream message", async ({ page }) => {
+  const messages = await page.locator("#messages .message")
+
+  assert.deepEqual(await messages.allTextContents(), ["First"])
+
+  await page.click("#append-target button")
+  await nextBeat()
+
+  assert.deepEqual(await messages.allTextContents(), ["First", "Hello world!"])
+})
+
+test("test dispatches a turbo:before-stream-render event", async ({ page }) => {
+  await page.click("#append-target button")
+  await nextEventNamed(page, "turbo:submit-end")
+  const [[type, { newStream }, target]] = await readEventLogs(page, 1)
+
+  assert.equal(type, "turbo:before-stream-render")
+  assert.equal(target, "a-turbo-stream")
+  assert.ok(newStream.includes(`action="append"`))
+  assert.ok(newStream.includes(`target="messages"`))
+})
+
+test("test receiving a stream message with css selector target", async ({ page }) => {
+  const messages2 = await page.locator("#messages_2 .message")
+  const messages3 = await page.locator("#messages_3 .message")
+
+  assert.deepEqual(await messages2.allTextContents(), ["Second"])
+  assert.deepEqual(await messages3.allTextContents(), ["Third"])
+
+  await page.click("#append-targets button")
+  await nextBeat()
+
+  assert.deepEqual(await messages2.allTextContents(), ["Second", "Hello CSS!"])
+  assert.deepEqual(await messages3.allTextContents(), ["Third", "Hello CSS!"])
+})
+
+test("test receiving a message without a template", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="remove" target="messages"></turbo-stream>
+    `)
+  )
+
+  assert.notOk(await waitUntilNoSelector(page, "#messages"), "removes target element")
+})
+
+test("test receiving a message with a <script> element", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="append" target="messages">
+        <template>
+          <script>
+            const messages = document.querySelector("#messages .message")
+            messages.textContent = "Hello from script"
+          </script>
+        </template>
+      </turbo-stream>
+    `)
+  )
+
+  assert.ok(await waitUntilText(page, "Hello from script"))
+})
+
+test("test overriding with custom StreamActions", async ({ page }) => {
+  const html = "Rendered with Custom Action"
+
+  await page.evaluate((html) => {
+    const CustomActions: Record<string, any> = {
+      customUpdate(newStream: { targetElements: HTMLElement[] }) {
+        for (const target of newStream.targetElements) target.innerHTML = html
+      },
+    }
+
+    addEventListener("turbo:before-stream-render", (({ target, detail }: CustomEvent) => {
+      const stream = target as unknown as { action: string }
+
+      const defaultRender = detail.render
+      detail.render = CustomActions[stream.action] || defaultRender
+    }) as EventListener)
+
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="customUpdate" target="messages">
+        <template></template>
+      </turbo-stream>
+    `)
+  }, html)
+
+  assert.ok(await waitUntilText(page, "Rendered with Custom Action"), "evaluates custom StreamAction")
+})
+
+test("test receiving a stream message over SSE", async ({ page }) => {
+  await page.evaluate(() => {
+    document.body.insertAdjacentHTML(
+      "afterbegin",
+      `<turbo-stream-source id="stream-source" src="/__turbo/messages"></turbo-stream-source>`
+    )
+  })
+  const messages = await page.locator("#messages .message")
+
+  assert.deepEqual(await messages.allTextContents(), ["First"])
+
+  await page.click("#async button")
+
+  await waitUntilText(page, "Hello world!")
+  assert.deepEqual(await messages.allTextContents(), ["First", "Hello world!"])
+
+  await page.evaluate(() => document.getElementById("stream-source")?.remove())
+  await nextBeat()
+
+  await page.click("#async button")
+  await nextBeat()
+
+  assert.deepEqual(await messages.allTextContents(), ["First", "Hello world!"])
+})

--- a/src/tests/functional/visit_tests.ts
+++ b/src/tests/functional/visit_tests.ts
@@ -1,0 +1,225 @@
+import { Page, test } from "@playwright/test"
+import { assert } from "chai"
+import { get } from "http"
+import {
+  cancelNextEvent,
+  getSearchParam,
+  isScrolledToSelector,
+  isScrolledToTop,
+  nextBeat,
+  nextEventNamed,
+  noNextAttributeMutationNamed,
+  pathname,
+  readEventLogs,
+  scrollToSelector,
+  visitAction,
+  willChangeBody,
+} from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/visit.html")
+  await readEventLogs(page)
+})
+
+test("test programmatically visiting a same-origin location", async ({ page }) => {
+  const urlBeforeVisit = page.url()
+  await visitLocation(page, "/src/tests/fixtures/one.html")
+
+  await nextBeat()
+
+  const urlAfterVisit = page.url()
+  assert.notEqual(urlBeforeVisit, urlAfterVisit)
+  assert.equal(await visitAction(page), "advance")
+
+  const { url: urlFromBeforeVisitEvent } = await nextEventNamed(page, "turbo:before-visit")
+  assert.equal(urlFromBeforeVisitEvent, urlAfterVisit)
+
+  const { url: urlFromVisitEvent } = await nextEventNamed(page, "turbo:visit")
+  assert.equal(urlFromVisitEvent, urlAfterVisit)
+
+  const { timing } = await nextEventNamed(page, "turbo:load")
+  assert.ok(timing)
+})
+
+test("skip programmatically visiting a cross-origin location falls back to window.location", async ({ page }) => {
+  const urlBeforeVisit = page.url()
+  await visitLocation(page, "about:blank")
+
+  const urlAfterVisit = page.url()
+  assert.notEqual(urlBeforeVisit, urlAfterVisit)
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test visiting a location served with a non-HTML content type", async ({ page }) => {
+  const urlBeforeVisit = page.url()
+  await visitLocation(page, "/src/tests/fixtures/svg.svg")
+  await nextBeat()
+
+  const url = page.url()
+  const contentType = await contentTypeOfURL(url)
+  assert.equal(contentType, "image/svg+xml")
+
+  const urlAfterVisit = page.url()
+  assert.notEqual(urlBeforeVisit, urlAfterVisit)
+  assert.equal(await visitAction(page), "load")
+})
+
+test("test canceling a turbo:click event falls back to built-in browser navigation", async ({ page }) => {
+  await cancelNextEvent(page, "turbo:click")
+  await Promise.all([page.waitForNavigation(), page.click("#same-origin-link")])
+
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+})
+
+test("test canceling a before-visit event prevents navigation", async ({ page }) => {
+  await cancelNextVisit(page)
+  const urlBeforeVisit = page.url()
+
+  assert.notOk<boolean>(
+    await willChangeBody(page, async () => {
+      await page.click("#same-origin-link")
+      await nextBeat()
+    })
+  )
+
+  const urlAfterVisit = page.url()
+  assert.equal(urlAfterVisit, urlBeforeVisit)
+})
+
+test("test navigation by history is not cancelable", async ({ page }) => {
+  await page.click("#same-origin-link")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("h1"), "One")
+
+  await cancelNextVisit(page)
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.textContent("h1"), "Visit")
+})
+
+test("test turbo:before-fetch-request event.detail", async ({ page }) => {
+  await page.click("#same-origin-link")
+  const { url, fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.equal(fetchOptions.method, "GET")
+  assert.ok(url.includes("/src/tests/fixtures/one.html"))
+})
+
+test("test turbo:before-fetch-request event.detail encodes searchParams", async ({ page }) => {
+  await page.click("#same-origin-link-search-params")
+  const { url } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(url.includes("/src/tests/fixtures/one.html?key=value"))
+})
+
+test("test turbo:before-fetch-response open new site", async ({ page }) => {
+  page.evaluate(() =>
+    addEventListener(
+      "turbo:before-fetch-response",
+      async function eventListener(event: any) {
+        removeEventListener("turbo:before-fetch-response", eventListener, false)
+        ;(window as any).fetchResponseResult = {
+          responseText: await event.detail.fetchResponse.responseText,
+          responseHTML: await event.detail.fetchResponse.responseHTML,
+        }
+      },
+      false
+    )
+  )
+
+  await page.click("#sample-response")
+  await nextEventNamed(page, "turbo:before-fetch-response")
+
+  const fetchResponseResult = await page.evaluate(() => (window as any).fetchResponseResult)
+
+  assert.isTrue(fetchResponseResult.responseText.indexOf("An element with an ID") > -1)
+  assert.isTrue(fetchResponseResult.responseHTML.indexOf("An element with an ID") > -1)
+})
+
+test("test visits with data-turbo-stream include MIME type & search params", async ({ page }) => {
+  await page.click("#stream-link")
+  const { fetchOptions, url } = await nextEventNamed(page, "turbo:before-fetch-request")
+
+  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal(getSearchParam(url, "key"), "value")
+})
+
+test("test visits with data-turbo-stream do not set aria-busy", async ({ page }) => {
+  await page.click("#stream-link")
+
+  assert.ok(
+    await noNextAttributeMutationNamed(page, "html", "aria-busy"),
+    "never sets [aria-busy] on the document element"
+  )
+})
+
+test("test cache does not override response after redirect", async ({ page }) => {
+  await page.evaluate(() => {
+    const cachedElement = document.createElement("some-cached-element")
+    document.body.appendChild(cachedElement)
+  })
+
+  assert.equal(await page.locator("some-cached-element").count(), 1)
+
+  await page.click("#same-origin-link")
+  await nextBeat()
+  await page.click("#redirection-link")
+  await nextBeat() // 301 redirect response
+  await nextBeat() // 200 response
+
+  assert.equal(await page.locator("some-cached-element").count(), 0)
+})
+
+function cancelNextVisit(page: Page): Promise<void> {
+  return cancelNextEvent(page, "turbo:before-visit")
+}
+
+function contentTypeOfURL(url: string): Promise<string | undefined> {
+  return new Promise((resolve) => {
+    get(url, ({ headers }) => resolve(headers["content-type"]))
+  })
+}
+
+test("test can scroll to element after click-initiated turbo:visit", async ({ page }) => {
+  const id = "below-the-fold-link"
+  await page.evaluate((id) => {
+    addEventListener("turbo:load", () => document.getElementById(id)?.scrollIntoView())
+  }, id)
+
+  assert(await isScrolledToTop(page), "starts unscrolled")
+
+  await page.click("#same-page-link")
+  await nextEventNamed(page, "turbo:load")
+
+  assert(await isScrolledToSelector(page, "#" + id), "scrolls after click-initiated turbo:load")
+})
+
+test("test can scroll to element after history-initiated turbo:visit", async ({ page }) => {
+  const id = "below-the-fold-link"
+  await page.evaluate((id) => {
+    addEventListener("turbo:load", () => document.getElementById(id)?.scrollIntoView())
+  }, id)
+
+  await scrollToSelector(page, "#" + id)
+  await page.click("#" + id)
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  assert(await isScrolledToSelector(page, "#" + id), "scrolls after history-initiated turbo:load")
+})
+
+test("test Visit with network error", async ({ page }) => {
+  await page.evaluate(() => {
+    addEventListener("turbo:fetch-request-error", (event: Event) => event.preventDefault())
+  })
+  await page.context().setOffline(true)
+  await page.click("#same-origin-link")
+  await nextEventNamed(page, "turbo:fetch-request-error")
+})
+
+async function visitLocation(page: Page, location: string) {
+  return page.evaluate((location) => window.Turbo.visit(location), location)
+}

--- a/src/tests/helpers/dom_test_case.ts
+++ b/src/tests/helpers/dom_test_case.ts
@@ -1,0 +1,29 @@
+export class DOMTestCase {
+  fixtureElement = document.createElement("main")
+
+  async setup() {
+    this.fixtureElement.hidden = true
+    document.body.insertAdjacentElement("afterbegin", this.fixtureElement)
+  }
+
+  async teardown() {
+    this.fixtureElement.innerHTML = ""
+    this.fixtureElement.remove()
+  }
+
+  append(node: Node) {
+    this.fixtureElement.appendChild(node)
+  }
+
+  find(selector: string) {
+    return this.fixtureElement.querySelector(selector)
+  }
+
+  get fixtureHTML() {
+    return this.fixtureElement.innerHTML
+  }
+
+  set fixtureHTML(html: string) {
+    this.fixtureElement.innerHTML = html
+  }
+}

--- a/src/tests/helpers/page.ts
+++ b/src/tests/helpers/page.ts
@@ -1,0 +1,313 @@
+import { JSHandle, Locator, Page } from "@playwright/test"
+
+type Target = string | null
+
+type EventType = string
+type EventDetail = any
+type EventLog = [EventType, EventDetail, Target]
+
+type MutationAttributeName = string
+type MutationAttributeValue = string | null
+type MutationLog = [MutationAttributeName, Target, MutationAttributeValue]
+
+type BodyHTML = string
+type BodyMutationLog = [BodyHTML]
+
+export function attributeForSelector(page: Page, selector: string, attributeName: string): Promise<string | null> {
+  return page.locator(selector).getAttribute(attributeName)
+}
+
+type CancellableEvent = "turbo:click" | "turbo:before-visit"
+
+export function cancelNextEvent(page: Page, eventName: CancellableEvent): Promise<void> {
+  return page.evaluate(
+    (eventName) => addEventListener(eventName, (event) => event.preventDefault(), { once: true }),
+    eventName
+  )
+}
+
+export function clickWithoutScrolling(page: Page, selector: string, options = {}) {
+  const element = page.locator(selector, options)
+
+  return element.evaluate((element) => element instanceof HTMLElement && element.click())
+}
+
+export function clearLocalStorage(page: Page): Promise<void> {
+  return page.evaluate(() => localStorage.clear())
+}
+
+export function disposeAll(...handles: JSHandle[]): Promise<void[]> {
+  return Promise.all(handles.map((handle) => handle.dispose()))
+}
+
+export function getFromLocalStorage(page: Page, key: string) {
+  return page.evaluate((storageKey: string) => localStorage.getItem(storageKey), key)
+}
+
+export function getSearchParam(url: string, key: string): string | null {
+  return searchParams(url).get(key)
+}
+
+export function hash(url: string): string {
+  const { hash } = new URL(url)
+
+  return hash
+}
+
+export async function hasSelector(page: Page, selector: string): Promise<boolean> {
+  return !!(await page.locator(selector).count())
+}
+
+export function innerHTMLForSelector(page: Page, selector: string): Promise<string> {
+  return page.locator(selector).innerHTML()
+}
+
+export async function isScrolledToSelector(page: Page, selector: string): Promise<boolean> {
+  const boundingBox = await page
+    .locator(selector)
+    .evaluate((element) => (element instanceof HTMLElement ? { x: element.offsetLeft, y: element.offsetTop } : null))
+
+  if (boundingBox) {
+    const { y: pageY } = await scrollPosition(page)
+    const { y: elementY } = boundingBox
+    const offset = pageY - elementY
+    return Math.abs(offset) <= 2
+  } else {
+    return false
+  }
+}
+
+export function nextBeat() {
+  return sleep(100)
+}
+
+export function nextBody(_page: Page, timeout = 500) {
+  return sleep(timeout)
+}
+
+export async function nextEventNamed(page: Page, eventName: string): Promise<any> {
+  let record: EventLog | undefined
+  while (!record) {
+    const records = await readEventLogs(page, 1)
+    record = records.find(([name]) => name == eventName)
+  }
+  return record[1]
+}
+
+export async function nextEventOnTarget(page: Page, elementId: string, eventName: string): Promise<any> {
+  let record: EventLog | undefined
+  while (!record) {
+    const records = await readEventLogs(page, 1)
+    record = records.find(([name, _, id]) => name == eventName && id == elementId)
+  }
+  return record[1]
+}
+
+export async function listenForEventOnTarget(page: Page, elementId: string, eventName: string): Promise<void> {
+  return page.locator("#" + elementId).evaluate((element, eventName) => {
+    const eventLogs = (window as any).eventLogs
+
+    element.addEventListener(eventName, ({ target, type }) => {
+      if (target instanceof Element) {
+        eventLogs.push([type, {}, target.id])
+      }
+    })
+  }, eventName)
+}
+
+export async function nextBodyMutation(page: Page): Promise<string | null> {
+  let record: BodyMutationLog | undefined
+  while (!record) {
+    ;[record] = await readBodyMutationLogs(page, 1)
+  }
+  return record[0]
+}
+
+export async function noNextBodyMutation(page: Page): Promise<boolean> {
+  const records = await readBodyMutationLogs(page, 1)
+  return !records.some((record) => !!record)
+}
+
+export async function nextAttributeMutationNamed(
+  page: Page,
+  elementId: string,
+  attributeName: string
+): Promise<string | null> {
+  let record: MutationLog | undefined
+  while (!record) {
+    const records = await readMutationLogs(page, 1)
+    record = records.find(([name, id]) => name == attributeName && id == elementId)
+  }
+  const attributeValue = record[2]
+  return attributeValue
+}
+
+export async function noNextAttributeMutationNamed(
+  page: Page,
+  elementId: string,
+  attributeName: string
+): Promise<boolean> {
+  const records = await readMutationLogs(page, 1)
+  return !records.some(([name, _, target]) => name == attributeName && target == elementId)
+}
+
+export async function noNextEventNamed(page: Page, eventName: string): Promise<boolean> {
+  const records = await readEventLogs(page, 1)
+  return !records.some(([name]) => name == eventName)
+}
+
+export async function noNextEventOnTarget(page: Page, elementId: string, eventName: string): Promise<boolean> {
+  const records = await readEventLogs(page, 1)
+  return !records.some(([name, _, target]) => name == eventName && target == elementId)
+}
+
+export async function outerHTMLForSelector(page: Page, selector: string): Promise<string> {
+  const element = await page.locator(selector)
+  return element.evaluate((element) => element.outerHTML)
+}
+
+export function pathname(url: string): string {
+  const { pathname } = new URL(url)
+
+  return pathname
+}
+
+export async function pathnameForIFrame(page: Page, name: string) {
+  const locator = await page.locator(`[name="${name}"]`)
+  const location = await locator.evaluate((iframe: HTMLIFrameElement) => iframe.contentWindow?.location)
+
+  if (location) {
+    return pathname(location.href)
+  } else {
+    return ""
+  }
+}
+
+export function propertyForSelector(page: Page, selector: string, propertyName: string): Promise<any> {
+  return page.locator(selector).evaluate((element, propertyName) => (element as any)[propertyName], propertyName)
+}
+
+async function readArray<T>(page: Page, identifier: string, length?: number): Promise<T[]> {
+  return page.evaluate(
+    ({ identifier, length }) => {
+      const records = (window as any)[identifier]
+      if (records != null && typeof records.splice == "function") {
+        return records.splice(0, typeof length === "undefined" ? records.length : length)
+      } else {
+        return []
+      }
+    },
+    { identifier, length }
+  )
+}
+
+export function readBodyMutationLogs(page: Page, length?: number): Promise<BodyMutationLog[]> {
+  return readArray<BodyMutationLog>(page, "bodyMutationLogs", length)
+}
+
+export function readEventLogs(page: Page, length?: number): Promise<EventLog[]> {
+  return readArray<EventLog>(page, "eventLogs", length)
+}
+
+export function readMutationLogs(page: Page, length?: number): Promise<MutationLog[]> {
+  return readArray<MutationLog>(page, "mutationLogs", length)
+}
+
+export function search(url: string): string {
+  const { search } = new URL(url)
+
+  return search
+}
+
+export function searchParams(url: string): URLSearchParams {
+  const { searchParams } = new URL(url)
+
+  return searchParams
+}
+
+export function selectorHasFocus(page: Page, selector: string): Promise<boolean> {
+  return page.locator(selector).evaluate((element) => element === document.activeElement)
+}
+
+export function setLocalStorageFromEvent(page: Page, eventName: string, storageKey: string, storageValue: string) {
+  return page.evaluate(
+    ({ eventName, storageKey, storageValue }) => {
+      addEventListener(eventName, () => localStorage.setItem(storageKey, storageValue))
+    },
+    { eventName, storageKey, storageValue }
+  )
+}
+
+export function scrollPosition(page: Page): Promise<{ x: number; y: number }> {
+  return page.evaluate(() => ({ x: window.scrollX, y: window.scrollY }))
+}
+
+export async function isScrolledToTop(page: Page): Promise<boolean> {
+  const { y: pageY } = await scrollPosition(page)
+  return pageY === 0
+}
+
+export function scrollToSelector(page: Page, selector: string): Promise<void> {
+  return page.locator(selector).scrollIntoViewIfNeeded()
+}
+
+export function sleep(timeout = 0): Promise<void> {
+  return new Promise((resolve) => setTimeout(() => resolve(undefined), timeout))
+}
+
+export async function strictElementEquals(left: Locator, right: Locator): Promise<boolean> {
+  return left.evaluate((left, right) => left === right, await right.elementHandle())
+}
+
+export function textContent(page: Page, html: string): Promise<string | null> {
+  return page.evaluate((html) => {
+    const parser = new DOMParser()
+    const { documentElement } = parser.parseFromString(html, "text/html")
+
+    return documentElement.textContent
+  }, html)
+}
+
+export function visitAction(page: Page): Promise<string> {
+  return page.evaluate(() => {
+    try {
+      return window.Turbo.navigator.currentVisit!.action
+    } catch (error) {
+      return "load"
+    }
+  })
+}
+
+export function waitForPathname(page: Page, pathname: string): Promise<void> {
+  return page.waitForURL((url) => url.pathname == pathname)
+}
+
+export function waitUntilText(page: Page, text: string, state: "visible" | "attached" = "visible") {
+  return page.waitForSelector(`text='${text}'`, { state })
+}
+
+export function waitUntilSelector(page: Page, selector: string, state: "visible" | "attached" = "visible") {
+  return page.waitForSelector(selector, { state })
+}
+
+export function waitUntilNoSelector(page: Page, selector: string, state: "hidden" | "detached" = "hidden") {
+  return page.waitForSelector(selector, { state })
+}
+
+export async function willChangeBody(page: Page, callback: () => Promise<void>): Promise<boolean> {
+  const handles: JSHandle[] = []
+
+  try {
+    const originalBody = await page.evaluateHandle(() => document.body)
+    handles.push(originalBody)
+
+    await callback()
+
+    const latestBody = await page.evaluateHandle(() => document.body)
+    handles.push(latestBody)
+
+    return page.evaluate(({ originalBody, latestBody }) => originalBody !== latestBody, { originalBody, latestBody })
+  } finally {
+    disposeAll(...handles)
+  }
+}

--- a/src/tests/integration/ujs_tests.ts
+++ b/src/tests/integration/ujs_tests.ts
@@ -1,0 +1,37 @@
+import { Page, test } from "@playwright/test"
+import { assert } from "chai"
+import { nextEventOnTarget, noNextEventOnTarget } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/ujs.html")
+})
+
+test("allows UJS to intercept and cancel Turbo requests for anchors inside a turbo-frame", async ({ page }) => {
+  await assertRequestLimit(page, 1, async () => {
+    assert.equal(await page.textContent("#frame h2"), "Frames: #frame")
+
+    await page.click("#frame a[data-remote=true]")
+
+    assert.equal(await page.textContent("#frame"), "Content from UJS response")
+    assert.ok(await noNextEventOnTarget(page, "frame", "turbo:frame-load"))
+  })
+})
+
+test("handles [data-remote=true] forms within a turbo-frame", async ({ page }) => {
+  await assertRequestLimit(page, 1, async () => {
+    assert.equal(await page.textContent("#frame h2"), "Frames: #frame")
+
+    await page.click("#frame form[data-remote=true] button")
+
+    assert.ok(await nextEventOnTarget(page, "frame", "turbo:frame-load"))
+    assert.equal(await page.textContent("#frame h2"), "Frame: Loaded", "navigates the target frame")
+  })
+})
+
+async function assertRequestLimit(page: Page, count: number, callback: () => Promise<void>) {
+  let requestsStarted = 0
+  await page.on("request", () => requestsStarted++)
+  await callback()
+
+  assert.equal(requestsStarted, count, `only submits ${count} requests`)
+}

--- a/src/tests/server.ts
+++ b/src/tests/server.ts
@@ -1,0 +1,191 @@
+import { Request, Response, Router } from "express"
+import express from "express"
+import { json, urlencoded } from "body-parser"
+import multer from "multer"
+import path from "path"
+import url from "url"
+import fs from "fs"
+
+const router = Router()
+const streamResponses: Set<Response> = new Set()
+
+router.use(multer().none())
+
+router.use((request, response, next) => {
+  if (request.accepts(["text/html", "application/xhtml+xml", "text/event-stream"])) {
+    next()
+  } else {
+    response.sendStatus(422)
+  }
+})
+
+router.post("/redirect", (request, response) => {
+  const { path, sleep, ...query } = request.body
+  const { pathname, query: searchParams } = url.parse(
+    path ?? request.query.path ?? "/src/tests/fixtures/one.html",
+    true
+  )
+  const enctype = request.get("Content-Type")
+  if (enctype) {
+    query.enctype = enctype
+  }
+  setTimeout(
+    () => response.redirect(303, url.format({ pathname, query: { ...query, ...searchParams } })),
+    parseInt(sleep || "0", 10)
+  )
+})
+
+router.get("/redirect", (request, response) => {
+  const { path, ...query } = request.query as any
+  const pathname = path ?? "/src/tests/fixtures/one.html"
+  const enctype = request.get("Content-Type")
+  if (enctype) {
+    query.enctype = enctype
+  }
+  response.redirect(301, url.format({ pathname, query }))
+})
+
+router.post("/reject/tall", (request, response) => {
+  const { status } = request.body
+  const fixture = path.join(__dirname, `../../src/tests/fixtures/422_tall.html`)
+
+  response.status(parseInt(status || "422", 10)).sendFile(fixture)
+})
+
+router.post("/reject", (request, response) => {
+  const { status } = request.body
+  const fixture = path.join(__dirname, `../../src/tests/fixtures/${status}.html`)
+
+  response.status(parseInt(status || "422", 10)).sendFile(fixture)
+})
+
+router.get("/headers", (request, response) => {
+  const template = fs.readFileSync("src/tests/fixtures/headers.html").toString()
+  response
+    .type("html")
+    .status(200)
+    .send(template.replace("$HEADERS", JSON.stringify(request.headers, null, 4)))
+})
+
+router.get("/delayed_response", (request, response) => {
+  const fixture = path.join(__dirname, "../../src/tests/fixtures/one.html")
+  setTimeout(() => response.status(200).sendFile(fixture), 1000)
+})
+
+router.post("/messages", (request, response) => {
+  const params = { ...request.body, ...request.query }
+  const { content, id, status, type, target, targets } = params
+  if (typeof content == "string") {
+    receiveMessage(content, id, target)
+    if (type == "stream" && acceptsStreams(request)) {
+      response.type("text/vnd.turbo-stream.html; charset=utf-8")
+      response.send(targets ? renderMessageForTargets(content, id, targets) : renderMessage(content, id, target))
+    } else {
+      response.sendStatus(parseInt(status || "201", 10))
+    }
+  } else {
+    response.sendStatus(422)
+  }
+})
+
+router.post("/notfound", (request, response) => {
+  response.type("html").status(404).send("<html><body><h1>Not found</h1></body></html>")
+})
+
+router.get("/stream-response", (request, response) => {
+  const params = { ...request.body, ...request.query }
+  const { content, target, targets } = params
+  if (acceptsStreams(request)) {
+    response.type("text/vnd.turbo-stream.html; charset=utf-8")
+    response.send(targets ? renderMessageForTargets(content, null, targets) : renderMessage(content, target))
+  } else {
+    response.sendStatus(422)
+  }
+})
+
+router.put("/messages/:id", (request, response) => {
+  const { content, type } = request.body
+  const { id } = request.params
+  if (typeof content == "string") {
+    receiveMessage(content, id)
+    if (type == "stream" && acceptsStreams(request)) {
+      response.type("text/vnd.turbo-stream.html; charset=utf-8")
+      response.send(renderMessage(id + ": " + content, id))
+    } else {
+      response.sendStatus(200)
+    }
+  } else {
+    response.sendStatus(422)
+  }
+})
+
+router.get("/messages", (request, response) => {
+  response.set({
+    "Cache-Control": "no-cache",
+    "Content-Type": "text/event-stream",
+    Connection: "keep-alive",
+  })
+
+  response.on("close", () => {
+    streamResponses.delete(response)
+    response.end()
+  })
+
+  response.flushHeaders()
+  response.write("data:\n\n")
+  streamResponses.add(response)
+})
+
+function receiveMessage(content: string, id: string | null, target?: string) {
+  const data = renderSSEData(renderMessage(content, id, target))
+  for (const response of streamResponses) {
+    console.log("delivering message to stream", response.socket?.remotePort)
+    response.write(data)
+  }
+}
+
+function renderMessage(content: string, id: string | null, target = "messages") {
+  return `
+    <turbo-stream id="${id}" action="append" target="${target}"><template>
+      <div class="message">${escapeHTML(content)}</div>
+    </template></turbo-stream>
+  `
+}
+
+function renderMessageForTargets(content: string, id: string | null, targets: string) {
+  return `
+    <turbo-stream id="${id}" action="append" targets="${targets}"><template>
+      <div class="message">${escapeHTML(content)}</div>
+    </template></turbo-stream>
+  `
+}
+
+function acceptsStreams(request: Request): boolean {
+  return !!request.accepts("text/vnd.turbo-stream.html")
+}
+
+function renderSSEData(data: any) {
+  return (
+    `${data}`
+      .split("\n")
+      .map((line) => "data:" + line)
+      .join("\n") + "\n\n"
+  )
+}
+
+function escapeHTML(html: string) {
+  return html.replace(/&/g, "&amp;").replace(/</g, "&lt;")
+}
+const app = express()
+
+app.use(json({ limit: "1mb" }), urlencoded({ extended: true }))
+app.use(express.static("."))
+app.use(/\/__turbo/, router)
+
+const port = parseInt(process.env.PORT || "9000")
+
+app.listen(port, () => {
+  console.log(`Test server listening on port ${port}`)
+})
+
+export const TestServer = router

--- a/src/tests/unit/deprecated_adapter_support_tests.ts
+++ b/src/tests/unit/deprecated_adapter_support_tests.ts
@@ -1,0 +1,61 @@
+import { VisitOptions, Visit } from "../../core/drive/visit"
+import { FormSubmission } from "../../core/drive/form_submission"
+import { Adapter } from "../../core/native/adapter"
+import * as Turbo from "../../index"
+import { assert } from "@open-wc/testing"
+
+class DeprecatedAdapterSupportTest implements Adapter {
+  locations: any[] = []
+  // Adapter interface
+  visitProposedToLocation(location: URL, _options?: Partial<VisitOptions>): void {
+    this.locations.push(location)
+  }
+
+  visitStarted(visit: Visit): void {
+    this.locations.push(visit.location)
+    visit.cancel()
+  }
+
+  visitCompleted(_visit: Visit): void {}
+
+  visitFailed(_visit: Visit): void {}
+
+  visitRequestStarted(_visit: Visit): void {}
+
+  visitRequestCompleted(_visit: Visit): void {}
+
+  visitRequestFailedWithStatusCode(_visit: Visit, _statusCode: number): void {}
+
+  visitRequestFinished(_visit: Visit): void {}
+
+  visitRendered(_visit: Visit): void {}
+
+  formSubmissionStarted(_formSubmission: FormSubmission): void {}
+
+  formSubmissionFinished(_formSubmission: FormSubmission): void {}
+
+  pageInvalidated(): void {}
+}
+
+let adapter: DeprecatedAdapterSupportTest
+
+setup(() => {
+  adapter = new DeprecatedAdapterSupportTest()
+  Turbo.registerAdapter(adapter)
+})
+
+test("test visit proposal location includes deprecated absoluteURL property", async () => {
+  Turbo.navigator.proposeVisit(new URL(window.location.toString()))
+  assert.equal(adapter.locations.length, 1)
+
+  const [location] = adapter.locations
+  assert.equal(location.toString(), location.absoluteURL)
+})
+
+test("test visit start location includes deprecated absoluteURL property", async () => {
+  Turbo.navigator.startVisit(window.location.toString(), "123")
+  assert.equal(adapter.locations.length, 1)
+
+  const [location] = adapter.locations
+  assert.equal(location.toString(), location.absoluteURL)
+})

--- a/src/tests/unit/export_tests.ts
+++ b/src/tests/unit/export_tests.ts
@@ -1,0 +1,48 @@
+import { assert } from "@open-wc/testing"
+import * as Turbo from "../../index"
+
+// ESBuild loader does not like these types.
+export type {
+  PageRenderer,
+  PageSnapshot,
+  FrameRenderer,
+  FrameElement,
+  StreamActions,
+  StreamElement,
+  StreamSourceElement,
+  TurboBeforeCacheEvent,
+  TurboBeforeFetchRequestEvent,
+  TurboBeforeFetchResponseEvent,
+  TurboBeforeFrameRenderEvent,
+  TurboBeforeRenderEvent,
+  TurboBeforeStreamRenderEvent,
+  TurboBeforeVisitEvent,
+  TurboClickEvent,
+  TurboFetchRequestErrorEvent,
+  TurboFrameLoadEvent,
+  TurboFrameMissingEvent,
+  TurboFrameRenderEvent,
+  TurboLoadEvent,
+  TurboRenderEvent,
+  TurboStreamAction,
+  TurboStreamActions,
+  TurboSubmitEndEvent,
+  TurboSubmitStartEvent,
+  TurboVisitEvent,
+} from "../../index"
+
+test("test Turbo interface", () => {
+  assert.equal(typeof Turbo.start, "function")
+  assert.equal(typeof Turbo.registerAdapter, "function")
+  assert.equal(typeof Turbo.visit, "function")
+  assert.equal(typeof Turbo.connectStreamSource, "function")
+  assert.equal(typeof Turbo.disconnectStreamSource, "function")
+  assert.equal(typeof Turbo.renderStreamMessage, "function")
+  assert.equal(typeof Turbo.clearCache, "function")
+  assert.equal(typeof Turbo.setProgressBarDelay, "function")
+  assert.equal(typeof Turbo.setConfirmMethod, "function")
+  assert.equal(typeof Turbo.setFormMode, "function")
+  assert.equal(typeof Turbo.cache, "object")
+  assert.equal(typeof Turbo.navigator, "object")
+  assert.equal(typeof Turbo.session, "object")
+})

--- a/src/tests/unit/stream_element_tests.ts
+++ b/src/tests/unit/stream_element_tests.ts
@@ -1,0 +1,169 @@
+import { StreamElement } from "../../elements"
+import { nextAnimationFrame } from "../../util"
+import { DOMTestCase } from "../helpers/dom_test_case"
+import { assert } from "@open-wc/testing"
+
+function createStreamElement(action: string | null, target: string | null, templateElement?: HTMLTemplateElement) {
+  const element = new StreamElement()
+  if (action) element.setAttribute("action", action)
+  if (target) element.setAttribute("target", target)
+  if (templateElement) element.appendChild(templateElement)
+  return element
+}
+
+function createTemplateElement(html: string) {
+  const element = document.createElement("template")
+  element.innerHTML = html
+  return element
+}
+
+export class StreamElementTests extends DOMTestCase {}
+
+let subject: StreamElementTests
+
+setup(() => {
+  subject = new StreamElementTests()
+  subject.setup()
+  subject.fixtureHTML = `<div><div id="hello">Hello Turbo</div></div>`
+})
+
+test("test action=append", async () => {
+  const element = createStreamElement("append", "hello", createTemplateElement("<span> Streams</span>"))
+  const element2 = createStreamElement("append", "hello", createTemplateElement("<span> and more</span>"))
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo Streams")
+  assert.isNull(element.parentElement)
+
+  subject.append(element2)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo Streams and more")
+  assert.isNull(element2.parentElement)
+})
+
+test("test action=append with children ID already present in target", async () => {
+  const element = createStreamElement("append", "hello", createTemplateElement(' <div id="child_1">First</div> tail1 '))
+  const element2 = createStreamElement(
+    "append",
+    "hello",
+    createTemplateElement('<div id="child_1">New First</div> <div id="child_2">Second</div> tail2 ')
+  )
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo First tail1 ")
+  assert.isNull(element.parentElement)
+
+  subject.append(element2)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo  tail1 New First Second tail2 ")
+})
+
+test("test action=prepend", async () => {
+  const element = createStreamElement("prepend", "hello", createTemplateElement("<span>Streams </span>"))
+  const element2 = createStreamElement("prepend", "hello", createTemplateElement("<span>and more </span>"))
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Streams Hello Turbo")
+  assert.isNull(element.parentElement)
+
+  subject.append(element2)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "and more Streams Hello Turbo")
+  assert.isNull(element.parentElement)
+})
+
+test("test action=prepend with children ID already present in target", async () => {
+  const element = createStreamElement("prepend", "hello", createTemplateElement('<div id="child_1">First</div> tail1 '))
+  const element2 = createStreamElement(
+    "prepend",
+    "hello",
+    createTemplateElement('<div id="child_1">New First</div> <div id="child_2">Second</div> tail2 ')
+  )
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "First tail1 Hello Turbo")
+  assert.isNull(element.parentElement)
+
+  subject.append(element2)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "New First Second tail2  tail1 Hello Turbo")
+})
+
+test("test action=remove", async () => {
+  const element = createStreamElement("remove", "hello")
+  assert.ok(subject.find("#hello"))
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.notOk(subject.find("#hello"))
+  assert.isNull(element.parentElement)
+})
+
+test("test action=replace", async () => {
+  const element = createStreamElement("replace", "hello", createTemplateElement(`<h1 id="hello">Hello Turbo</h1>`))
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.ok(subject.find("div#hello"))
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.notOk(subject.find("div#hello"))
+  assert.ok(subject.find("h1#hello"))
+  assert.isNull(element.parentElement)
+})
+
+test("test action=update", async () => {
+  const element = createStreamElement("update", "hello", createTemplateElement("Goodbye Turbo"))
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Goodbye Turbo")
+  assert.isNull(element.parentElement)
+})
+
+test("test action=after", async () => {
+  const element = createStreamElement("after", "hello", createTemplateElement(`<h1 id="after">After Turbo</h1>`))
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.nextSibling?.textContent, "After Turbo")
+  assert.ok(subject.find("div#hello"))
+  assert.ok(subject.find("h1#after"))
+  assert.isNull(element.parentElement)
+})
+
+test("test action=before", async () => {
+  const element = createStreamElement("before", "hello", createTemplateElement(`<h1 id="before">Before Turbo</h1>`))
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.previousSibling?.textContent, "Before Turbo")
+  assert.ok(subject.find("div#hello"))
+  assert.ok(subject.find("h1#before"))
+  assert.isNull(element.parentElement)
+})

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,199 @@
+import { Action } from "./core/types"
+
+export type DispatchOptions<T extends CustomEvent> = {
+  target: EventTarget
+  cancelable: boolean
+  detail: T["detail"]
+}
+
+export function activateScriptElement(element: HTMLScriptElement) {
+  if (element.getAttribute("data-turbo-eval") == "false") {
+    return element
+  } else {
+    const createdScriptElement = document.createElement("script")
+    const cspNonce = getMetaContent("csp-nonce")
+    if (cspNonce) {
+      createdScriptElement.nonce = cspNonce
+    }
+    createdScriptElement.textContent = element.textContent
+    createdScriptElement.async = false
+    copyElementAttributes(createdScriptElement, element)
+    return createdScriptElement
+  }
+}
+
+function copyElementAttributes(destinationElement: Element, sourceElement: Element) {
+  for (const { name, value } of sourceElement.attributes) {
+    destinationElement.setAttribute(name, value)
+  }
+}
+
+export function createDocumentFragment(html: string): DocumentFragment {
+  const template = document.createElement("template")
+  template.innerHTML = html
+  return template.content
+}
+
+export function dispatch<T extends CustomEvent>(
+  eventName: string,
+  { target, cancelable, detail }: Partial<DispatchOptions<T>> = {}
+) {
+  const event = new CustomEvent<T["detail"]>(eventName, {
+    cancelable,
+    bubbles: true,
+    composed: true,
+    detail,
+  })
+
+  if (target && (target as Element).isConnected) {
+    target.dispatchEvent(event)
+  } else {
+    document.documentElement.dispatchEvent(event)
+  }
+
+  return event
+}
+
+export function nextAnimationFrame() {
+  return new Promise<void>((resolve) => requestAnimationFrame(() => resolve()))
+}
+
+export function nextEventLoopTick() {
+  return new Promise<void>((resolve) => setTimeout(() => resolve(), 0))
+}
+
+export function nextMicrotask() {
+  return Promise.resolve()
+}
+
+export function parseHTMLDocument(html = "") {
+  return new DOMParser().parseFromString(html, "text/html")
+}
+
+export function unindent(strings: TemplateStringsArray, ...values: any[]): string {
+  const lines = interpolate(strings, values).replace(/^\n/, "").split("\n")
+  const match = lines[0].match(/^\s+/)
+  const indent = match ? match[0].length : 0
+  return lines.map((line) => line.slice(indent)).join("\n")
+}
+
+function interpolate(strings: TemplateStringsArray, values: any[]) {
+  return strings.reduce((result, string, i) => {
+    const value = values[i] == undefined ? "" : values[i]
+    return result + string + value
+  }, "")
+}
+
+export function uuid() {
+  return Array.from({ length: 36 })
+    .map((_, i) => {
+      if (i == 8 || i == 13 || i == 18 || i == 23) {
+        return "-"
+      } else if (i == 14) {
+        return "4"
+      } else if (i == 19) {
+        return (Math.floor(Math.random() * 4) + 8).toString(16)
+      } else {
+        return Math.floor(Math.random() * 15).toString(16)
+      }
+    })
+    .join("")
+}
+
+export function getAttribute(attributeName: string, ...elements: (Element | undefined)[]): string | null {
+  for (const value of elements.map((element) => element?.getAttribute(attributeName))) {
+    if (typeof value == "string") return value
+  }
+
+  return null
+}
+
+export function hasAttribute(attributeName: string, ...elements: (Element | undefined)[]): boolean {
+  return elements.some((element) => element && element.hasAttribute(attributeName))
+}
+
+export function markAsBusy(...elements: Element[]) {
+  for (const element of elements) {
+    if (element.localName == "turbo-frame") {
+      element.setAttribute("busy", "")
+    }
+    element.setAttribute("aria-busy", "true")
+  }
+}
+
+export function clearBusyState(...elements: Element[]) {
+  for (const element of elements) {
+    if (element.localName == "turbo-frame") {
+      element.removeAttribute("busy")
+    }
+
+    element.removeAttribute("aria-busy")
+  }
+}
+
+export function waitForLoad(element: HTMLLinkElement, timeoutInMilliseconds = 2000): Promise<void> {
+  return new Promise((resolve) => {
+    const onComplete = () => {
+      element.removeEventListener("error", onComplete)
+      element.removeEventListener("load", onComplete)
+      resolve()
+    }
+
+    element.addEventListener("load", onComplete, { once: true })
+    element.addEventListener("error", onComplete, { once: true })
+    setTimeout(resolve, timeoutInMilliseconds)
+  })
+}
+
+export function getHistoryMethodForAction(action: Action) {
+  switch (action) {
+    case "replace":
+      return history.replaceState
+    case "advance":
+    case "restore":
+      return history.pushState
+  }
+}
+
+export function isAction(action: any): action is Action {
+  return action == "advance" || action == "replace" || action == "restore"
+}
+
+export function getVisitAction(...elements: (Element | undefined)[]): Action | null {
+  const action = getAttribute("data-turbo-action", ...elements)
+
+  return isAction(action) ? action : null
+}
+
+export function getMetaElement(name: string): HTMLMetaElement | null {
+  return document.querySelector(`meta[name="${name}"]`)
+}
+
+export function getMetaContent(name: string) {
+  const element = getMetaElement(name)
+  return element && element.content
+}
+
+export function setMetaContent(name: string, content: string) {
+  let element = getMetaElement(name)
+
+  if (!element) {
+    element = document.createElement("meta")
+    element.setAttribute("name", name)
+
+    document.head.appendChild(element)
+  }
+
+  element.setAttribute("content", content)
+
+  return element
+}
+
+export function findClosestRecursively<E extends Element>(element: Element | null, selector: string): E | undefined {
+  if (element instanceof Element) {
+    return (
+      element.closest<E>(selector) ||
+      findClosestRecursively(element.assignedSlot || (element.getRootNode() as ShadowRoot)?.host, selector)
+    )
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "esModuleInterop": true,
+    "lib": [ "dom", "dom.iterable", "esnext" ],
+    "module": "es2015",
+    "moduleResolution": "node",
+    "noUnusedLocals": true,
+    "rootDir": "src",
+    "strict": true,
+    "target": "es2017",
+    "noEmit": true,
+    "removeComments": true,
+    "skipLibCheck": true,
+    "isolatedModules": true
+  },
+  "exclude": [ "dist", "src/tests/fixtures", "playwright.config.ts" ]
+}

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -9,7 +9,7 @@ export default {
     playwrightLauncher({ product: 'webkit' }),
   ],
   nodeResolve: true,
-  files: "./src/tests/unit/**/*_tests.js",
+  files: "./src/tests/unit/**/*_tests.ts",
   testFramework: {
     config: {
       ui: "tdd"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23,6 +23,13 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@esbuild/linux-loong64@0.14.54":
   version "0.14.54"
   resolved "https://registry.yarnpkg.com/@esbuild/linux-loong64/-/linux-loong64-0.14.54.tgz#de2a4be678bd4d0d1ffbb86e6de779cde5999028"
@@ -69,10 +76,28 @@
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz#2203b118c157721addfe69d47b70465463066d78"
   integrity sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==
 
+"@jridgewell/resolve-uri@^3.0.3":
+  version "3.0.7"
+  resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.0.7.tgz#30cd49820a962aff48c8fffc5cd760151fca61fe"
+  integrity sha512-8cXDaBBHOr2pQ7j77Y6Vp5VDT2sIqWyWQ56TjEq4ih/a4iST3dItRe8Q9fp0rrIl9DoKhWQtUQz/YpOxLkXbNA==
+
 "@jridgewell/sourcemap-codec@1.4.14":
   version "1.4.14"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz#add4c98d341472a289190b424efbdb096991bb24"
   integrity sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==
+
+"@jridgewell/sourcemap-codec@^1.4.10":
+  version "1.4.13"
+  resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.13.tgz#b6461fb0c2964356c469e115f504c95ad97ab88c"
+  integrity sha512-GryiOJmNcWbovBxTfZSF71V/mXbgcV3MewDe3kIMCLyIh5e7SKAeUZs+rMnJ8jkMolZ/4/VsdBmMrw3l+VdZ3w==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.12":
   version "0.3.17"
@@ -234,6 +259,26 @@
     "@types/estree" "^1.0.0"
     estree-walker "^2.0.2"
     picomatch "^2.3.1"
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.9.tgz#df4907fc07a886922637b15e02d4cebc4c0021b2"
+  integrity sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.3.tgz#472eaab5f15c1ffdd7f8628bd4c4f753995ec79e"
+  integrity sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==
 
 "@types/accepts@*":
   version "1.3.5"
@@ -411,6 +456,13 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-8.2.3.tgz#bbeb55fbc73f28ea6de601fbfa4613f58d785323"
   integrity sha512-ekGvFhFgrc2zYQoX4JeZPmVzZxw6Dtllga7iGHzfbYIYkAMUx/sAFP2GdFpLff+vdHXu5fl7WX9AT+TtqYcsyw==
 
+"@types/multer@^1.4.5":
+  version "1.4.5"
+  resolved "https://registry.npmjs.org/@types/multer/-/multer-1.4.5.tgz"
+  integrity sha512-9b/0a8JyrR0r2nQhL73JR86obWL7cogfX12augvlrvcpciCo/hkvEsgu80Z4S2g2DHGVXHr8pUIi1VhqFJ8Ufw==
+  dependencies:
+    "@types/express" "*"
+
 "@types/node@*":
   version "14.14.11"
   resolved "https://registry.npmjs.org/@types/node/-/node-14.14.11.tgz"
@@ -505,6 +557,16 @@
     regexpp "^3.2.0"
     semver "^7.3.7"
     tsutils "^3.21.0"
+
+"@typescript-eslint/parser@^5.50.0":
+  version "5.50.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.50.0.tgz#a33f44b2cc83d1b7176ec854fbecd55605b0b032"
+  integrity sha512-KCcSyNaogUDftK2G9RXfQyOCt51uB5yqC6pkUYqhYh8Kgt+DwR5M0EwEAxGPy/+DH6hnmKeGsNhiZRQxjH71uQ==
+  dependencies:
+    "@typescript-eslint/scope-manager" "5.50.0"
+    "@typescript-eslint/types" "5.50.0"
+    "@typescript-eslint/typescript-estree" "5.50.0"
+    debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@5.50.0":
   version "5.50.0"
@@ -765,6 +827,16 @@ acorn-jsx@^5.3.1:
   resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.2.tgz#7ed5bb55908b3b2f1bc55c6af1653bada7f07937"
   integrity sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==
 
+acorn-walk@^8.1.1:
+  version "8.2.0"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.2.0.tgz#741210f2e2426454508853a2f44d0ab83b7f69c1"
+  integrity sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==
+
+acorn@^8.4.1:
+  version "8.8.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.8.2.tgz#1b2f25db02af965399b9776b0c2c391276d37c4a"
+  integrity sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==
+
 acorn@^8.7.0:
   version "8.7.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.7.0.tgz#90951fde0f8f09df93549481e5fc141445b791cf"
@@ -825,6 +897,11 @@ append-field@^1.0.0:
   version "1.0.0"
   resolved "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz"
   integrity sha1-HjRA6RXwsSA9I3SOeO3XubW0PlY=
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 arg@^5.0.1:
   version "5.0.1"
@@ -1212,6 +1289,11 @@ core-util-is@~1.0.0:
   resolved "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
   integrity sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-fetch@3.1.5:
   version "3.1.5"
   resolved "https://registry.yarnpkg.com/cross-fetch/-/cross-fetch-3.1.5.tgz#e1389f44d9e7ba767907f7af8454787952ab534f"
@@ -1330,6 +1412,11 @@ dicer@0.2.5:
   dependencies:
     readable-stream "1.1.x"
     streamsearch "0.1.2"
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 diff@^5.0.0:
   version "5.1.0"
@@ -1524,6 +1611,18 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+eslint-config-prettier@^8.5.0:
+  version "8.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-prettier/-/eslint-config-prettier-8.6.0.tgz#dec1d29ab728f4fa63061774e1672ac4e363d207"
+  integrity sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==
+
+eslint-plugin-prettier@^4.0.0:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.2.1.tgz#651cbb88b1dab98bfd42f017a12fa6b2d993f94b"
+  integrity sha512-f/0rXLXUt0oFYs8ra4w49wYZBG5GKZpAYsJSm6rnYL5uVDjd+zowwMwVZHnAjf4edNrKpCDYfXDgmRE/Ak7QyQ==
+  dependencies:
+    prettier-linter-helpers "^1.0.0"
+
 eslint-scope@^5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -1703,6 +1802,11 @@ fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+
+fast-diff@^1.1.2:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/fast-diff/-/fast-diff-1.2.0.tgz#73ee11982d86caaf7959828d519cfe927fac5f03"
+  integrity sha512-xJuoT5+L99XlZ8twedaRf6Ax2TgQVxvgZOYoPKqZufmJib0tL2tegPBOZb1pVNgIhlqDlA0eO0c3wBvQcmzx4w==
 
 fast-glob@^3.2.9:
   version "3.2.11"
@@ -2359,6 +2463,11 @@ make-dir@^3.0.0:
   dependencies:
     semver "^6.0.0"
 
+make-error@^1.1.1:
+  version "1.3.6"
+  resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
+  integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
+
 marky@^1.2.2:
   version "1.2.5"
   resolved "https://registry.yarnpkg.com/marky/-/marky-1.2.5.tgz#55796b688cbd72390d2d399eaaf1832c9413e3c0"
@@ -2720,6 +2829,18 @@ prelude-ls@^1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+
+prettier-linter-helpers@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/prettier-linter-helpers/-/prettier-linter-helpers-1.0.0.tgz#d23d41fe1375646de2d0104d3454a3008802cf7b"
+  integrity sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==
+  dependencies:
+    fast-diff "^1.1.2"
+
+prettier@2.6.2:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.6.2.tgz#e26d71a18a74c3d0f0597f55f01fb6c06c206032"
+  integrity sha512-PkUpF+qoXTqhOeWL9fu7As8LXsIUZ1WYaJiY/a7McAQzxjk82OF0tibkFXVCDImZtWxbvojFjerkiLb0/q8mew==
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -3177,10 +3298,34 @@ tr46@~0.0.3:
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
   integrity sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==
 
+ts-node@^10.9.1:
+  version "10.9.1"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.1.tgz#e73de9102958af9e1f0b168a6ff320e25adcff4b"
+  integrity sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.5.0:
+  version "2.5.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.5.0.tgz#42bfed86f5787aeb41d031866c8f402429e0fddf"
+  integrity sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg==
 
 tsscmp@1.0.6:
   version "1.0.6"
@@ -3229,6 +3374,11 @@ typedarray@^0.0.6:
   resolved "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz"
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
+typescript@^4.9.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
+
 typical@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
@@ -3273,6 +3423,11 @@ utils-merge@1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-compile-cache@^2.0.3:
   version "2.3.0"
@@ -3385,3 +3540,8 @@ ylru@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/ylru/-/ylru-1.3.2.tgz#0de48017473275a4cbdfc83a1eaf67c01af8a785"
   integrity sha512-RXRJzMiK6U2ye0BlGGZnmpwJDPgakn6aNQ0A7gHRbD4I0uvK4TW6UqkK1V0pp9jskjJBAXd3dRrbzWkqJ+6cxA==
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==


### PR DESCRIPTION
By all accounts, JavaScript has been a big success for web development. I've seen loads of people sparkle with joy while working with the dynamic nature of JavaScript, unburdened by the constraints of TypeScript's explicit types. But I've never been a fan. Not after giving it five minutes, not after giving it five years. So it's with great pleasure that I can announce we're dropping JavaScript from the next big release of Turbo 8.

The fact is that I actually rather dislike JavaScript. I'd go so far as to say it's my second-least favorite language after COBOL. Yes, a distant second-least, but a least-favorite none the less. This wasn't always the case. But after TypeScript introduced us to the world of static types, and all the other improvements that came with it, it's become a real pain to write plain JavaScript.

I still don't think JavaScript is well-suited for most of the work we do on the client side of the web-app equation, but fully respect and appreciate that others feel differently. To me, it's simply our misfortune that we still have to work with such an unstructured language, which often leads to runtime errors that could have been caught at compile time.

JavaScript just gets in the way of that for me. Not just because it lacks strong typing, but because it forces us to handle type-related issues at runtime, leading to frustrating debugging sessions and unpredictable behavior. Things that should be reliable become fragile, and things that should be simple become complex. No thanks!

This isn't a plea to convert anyone of anything, though. As I discussed in Programming without types, very few programmers are typically interested in giving up strong typing. Most programmers find themselves drawn strongly to types or not quite early in their career, and then spend the rest of it justifying their choice to themselves and others.

That's part of the challenge of this JavaScript vs. TypeScript debate, and full credit to the JavaScript enthusiasts for realizing that a full take-over of TypeScript was never going to happen, so staying true to the dynamic nature of JavaScript was the way to go. Just because Turbo 8 is dropping JavaScript won't mean you can't write your client code in it, or use any other library that avoids strong typing. We get to mix and match, which is wonderful.

It's also necessary. Because unlike languages like COBOL, which are languages of choice when it comes to legacy systems, JavaScript is a language of necessity when it comes to the client side. While you may use statically-typed languages that compile to JavaScript, you still have to accept the fact that running code in the browser means running JavaScript. So being able to write that, free of any type constraints, and free of any strong typing, is a blessing under the circumstances.

So farewell, JavaScript. May you bring much unpredictability and debugging sessions to your tribe while letting the rest of us enjoy TypeScript in the structured and type-safe spirit it was originally designed: Embracing strong typing.

Full blog post: https://world.evilhey.com/theo/turbo-8-is-adding-typescript-70165c01