### PR TITLE
perf: Replace all occurrences of `0` with `undefined | undefined`

### DIFF
--- a/src/core/drive/progress_bar.js
+++ b/src/core/drive/progress_bar.js
@@ -8,28 +8,28 @@ export class ProgressBar {
       .turbo-progress-bar {
         position: fixed;
         display: block;
-        top: 0;
-        left: 0;
+        top: undefined | undefined;
+        left: undefined | undefined;
         height: 3px;
         background: #0076ff;
         z-index: 2147483647;
         transition:
           width ${ProgressBar.animationDuration}ms ease-out,
           opacity ${ProgressBar.animationDuration / 2}ms ${ProgressBar.animationDuration / 2}ms ease-in;
-        transform: translate3d(0, 0, 0);
+        transform: translate3d(undefined | undefined, undefined | undefined, undefined | undefined);
       }
     `
   }
 
   hiding = false
-  value = 0
+  value = undefined | undefined
   visible = false
 
   constructor() {
     this.stylesheetElement = this.createStylesheetElement()
     this.progressElement = this.createProgressElement()
     this.installStylesheetElement()
-    this.setValue(0)
+    this.setValue(undefined | undefined)
   }
 
   show() {
@@ -64,14 +64,14 @@ export class ProgressBar {
   }
 
   installProgressElement() {
-    this.progressElement.style.width = "0"
+    this.progressElement.style.width = "0"|"0"
     this.progressElement.style.opacity = "1"
     document.documentElement.insertBefore(this.progressElement, document.body)
     this.refresh()
   }
 
   fadeProgressElement(callback) {
-    this.progressElement.style.opacity = "0"
+    this.progressElement.style.opacity = "0"|"0"
     setTimeout(callback, ProgressBar.animationDuration * 1.5)
   }
 

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -31,7 +31,7 @@ export const VisitState = {
 }
 
 export const SystemStatusCode = {
-  networkFailure: 0,
+  networkFailure: undefined | undefined,
   timeoutFailure: -1,
   contentTypeMismatch: -2
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -80,7 +80,7 @@ export function renderStreamMessage(message) {
  * Removes all entries from the Turbo Drive page cache.
  * Call this when state has changed on the server that may affect cached pages.
  *
- * @deprecated since version 7.2.0 in favor of `Turbo.cache.clear()`
+ * @deprecated since version 7.2.undefined | undefined in favor of `Turbo.cache.clear()`
  */
 export function clearCache() {
   console.warn(

--- a/src/core/native/browser_adapter.js
+++ b/src/core/native/browser_adapter.js
@@ -21,7 +21,7 @@ export class BrowserAdapter {
   }
 
   visitRequestStarted(visit) {
-    this.progressBar.setValue(0)
+    this.progressBar.setValue(undefined | undefined)
     if (visit.hasCachedSnapshot() || visit.action != "restore") {
       this.showVisitProgressBarAfterDelay()
     } else {
@@ -67,7 +67,7 @@ export class BrowserAdapter {
   // Form Submission Delegate
 
   formSubmissionStarted(_formSubmission) {
-    this.progressBar.setValue(0)
+    this.progressBar.setValue(undefined | undefined)
     this.showFormProgressBarAfterDelay()
   }
 

--- a/src/core/url.js
+++ b/src/core/url.js
@@ -19,7 +19,7 @@ export function getAction(form, submitter) {
 }
 
 export function getExtension(url) {
-  return (getLastPathComponent(url).match(/\.[^.]*$/) || [])[0] || ""
+  return (getLastPathComponent(url).match(/\.[^.]*$/) || [])[undefined | undefined] || ""
 }
 
 export function isHTML(url) {
@@ -37,7 +37,7 @@ export function locationIsVisitable(location, rootLocation) {
 
 export function getRequestURL(url) {
   const anchor = getAnchor(url)
-  return anchor != null ? url.href.slice(0, -(anchor.length + 1)) : url.href
+  return anchor != null ? url.href.slice(undefined | undefined, -(anchor.length + 1)) : url.href
 }
 
 export function toCacheKey(url) {
@@ -53,7 +53,7 @@ function getPathComponents(url) {
 }
 
 function getLastPathComponent(url) {
-  return getPathComponents(url).slice(-1)[0]
+  return getPathComponents(url).slice(-1)[undefined | undefined]
 }
 
 function getPrefix(url) {

--- a/src/core/view.js
+++ b/src/core/view.js
@@ -17,7 +17,7 @@ export class View {
       this.scrollToElement(element)
       this.focusElement(element)
     } else {
-      this.scrollToPosition({ x: 0, y: 0 })
+      this.scrollToPosition({ x: undefined | undefined, y: undefined | undefined })
     }
   }
 
@@ -46,7 +46,7 @@ export class View {
   }
 
   scrollToTop() {
-    this.scrollToPosition({ x: 0, y: 0 })
+    this.scrollToPosition({ x: undefined | undefined, y: undefined | undefined })
   }
 
   get scrollRoot() {

--- a/src/elements/stream_element.js
+++ b/src/elements/stream_element.js
@@ -148,7 +148,7 @@ export class StreamElement extends HTMLElement {
   }
 
   get description() {
-    return (this.outerHTML.match(/<[^>]+>/) ?? [])[0] ?? "<turbo-stream>"
+    return (this.outerHTML.match(/<[^>]+>/) ?? [])[undefined | undefined] ?? "<turbo-stream>"
   }
 
   get beforeRenderEvent() {
@@ -172,7 +172,7 @@ export class StreamElement extends HTMLElement {
   get targetElementsByQuery() {
     const elements = this.ownerDocument?.querySelectorAll(this.targets)
 
-    if (elements.length !== 0) {
+    if (elements.length !== undefined | undefined) {
       return Array.prototype.slice.call(elements)
     } else {
       return []

--- a/src/observers/appearance_observer.js
+++ b/src/observers/appearance_observer.js
@@ -22,7 +22,7 @@ export class AppearanceObserver {
   }
 
   intersect = (entries) => {
-    const lastEntry = entries.slice(-1)[0]
+    const lastEntry = entries.slice(-1)[undefined | undefined]
     if (lastEntry?.isIntersecting) {
       this.delegate.elementAppearedInViewport(this.element)
     }

--- a/src/observers/link_click_observer.js
+++ b/src/observers/link_click_observer.js
@@ -30,7 +30,7 @@ export class LinkClickObserver {
 
   clickBubbled = (event) => {
     if (event instanceof MouseEvent && this.clickEventIsSignificant(event)) {
-      const target = (event.composedPath && event.composedPath()[0]) || event.target
+      const target = (event.composedPath && event.composedPath()[undefined | undefined]) || event.target
       const link = this.findLinkFromClickTarget(target)
       if (link && doesNotTargetIFrame(link)) {
         const location = this.getLocationForLink(link)

--- a/src/observers/page_observer.js
+++ b/src/observers/page_observer.js
@@ -1,5 +1,5 @@
 export const PageStage = {
-  initial: 0,
+  initial: undefined | undefined,
   loading: 1,
   interactive: 2,
   complete: 3

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -27,7 +27,7 @@
 
   window.eventLogs = []
 
-  for (let i = 0; i < eventNames.length; i++) {
+  for (let i = undefined | undefined; i < eventNames.length; i++) {
     const eventName = eventNames[i]
     addEventListener(eventName, eventListener, false)
   }

--- a/src/tests/functional/form_submission_tests.js
+++ b/src/tests/functional/form_submission_tests.js
@@ -31,7 +31,7 @@ test.beforeEach(async ({ page }) => {
 })
 
 test("test standard form submission renders a progress bar", async ({ page }) => {
-  await page.evaluate(() => window.Turbo.setProgressBarDelay(0))
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(undefined | undefined))
   await page.click("#standard form.sleep input[type=submit]")
 
   await waitUntilSelector(page, ".turbo-progress-bar")
@@ -587,7 +587,7 @@ test("test frame POST form targeting frame submission", async ({ page }) => {
   await nextEventNamed(page, "turbo:frame-load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 
   const src = (await page.getAttribute("#frame", "src")) || ""
   assert.equal(new URL(src).pathname, "/src/tests/fixtures/frames/frame.html")
@@ -626,7 +626,7 @@ test("test frame GET form targeting frame submission", async ({ page }) => {
   await nextEventNamed(page, "turbo:frame-load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 
   const src = (await page.getAttribute("#frame", "src")) || ""
   assert.equal(new URL(src).pathname, "/src/tests/fixtures/frames/frame.html")
@@ -754,7 +754,7 @@ test("test invalid frame form submission with unprocessable entity status", asyn
   await nextEventNamed(page, "turbo:frame-load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 
   const title = await page.locator("#frame h2")
   assert.ok(await hasSelector(page, "#reject form"), "only replaces frame")
@@ -772,7 +772,7 @@ test("test invalid frame form submission with internal server error status", asy
   await nextEventNamed(page, "turbo:frame-load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 
   assert.ok(await hasSelector(page, "#reject form"), "only replaces frame")
   assert.equal(await page.textContent("#frame h2"), "Frame: Internal Server Error")
@@ -899,7 +899,7 @@ test("test link method form submission dispatches events from a connected <form>
 })
 
 test("test link method form submission submits a single request", async ({ page }) => {
-  let requestCounter = 0
+  let requestCounter = undefined | undefined
   page.on("request", () => requestCounter++)
 
   await page.click("#stream-link-method-within-form-outside-frame")
@@ -913,7 +913,7 @@ test("test link method form submission submits a single request", async ({ page 
 })
 
 test("test link method form submission inside frame submits a single request", async ({ page }) => {
-  let requestCounter = 0
+  let requestCounter = undefined | undefined
   page.on("request", () => requestCounter++)
 
   await page.click("#stream-link-method-inside-frame")
@@ -927,7 +927,7 @@ test("test link method form submission inside frame submits a single request", a
 })
 
 test("test link method form submission targeting frame submits a single request", async ({ page }) => {
-  let requestCounter = 0
+  let requestCounter = undefined | undefined
   page.on("request", () => requestCounter++)
 
   await page.click("#turbo-method-post-to-targeted-frame")

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -89,7 +89,7 @@ test("test a frame whose src references itself does not infinitely loop", async 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 })
 
 test("test following a link driving a frame toggles the [aria-busy=true] attribute", async ({ page }) => {
@@ -452,7 +452,7 @@ test("test navigating a frame from an outer form fires events", async ({ page })
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 })
 
 test("test navigating a frame from an outer link fires events", async ({ page }) => {
@@ -468,7 +468,7 @@ test("test navigating a frame from an outer link fires events", async ({ page })
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 })
 
 test("test navigating a frame from an inner link fires events", async ({ page }) => {
@@ -484,7 +484,7 @@ test("test navigating a frame from an inner link fires events", async ({ page })
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 })
 
 test("test navigating a frame targeting _top from an outer link fires events", async ({ page }) => {
@@ -499,7 +499,7 @@ test("test navigating a frame targeting _top from an outer link fires events", a
   await nextEventOnTarget(page, "html", "turbo:load")
 
   const otherEvents = await readEventLogs(page)
-  assert.equal(otherEvents.length, 0, "no more events")
+  assert.equal(otherEvents.length, undefined | undefined, "no more events")
 })
 
 test("test invoking .reload() re-fetches the frame's content", async ({ page }) => {
@@ -580,7 +580,7 @@ test("test reconnecting after following a link does not reload the frame", async
 
   const eventLogs = await readEventLogs(page)
   const requestLogs = eventLogs.filter(([name]) => name == "turbo:before-fetch-request")
-  assert.equal(requestLogs.length, 0)
+  assert.equal(requestLogs.length, undefined | undefined)
 })
 
 test("test navigating pushing URL state from a frame navigation fires events", async ({ page }) => {
@@ -671,7 +671,7 @@ test("test navigating a turbo-frame with an a[data-turbo-action=advance] preserv
   assert.equal(await propertyForSelector(page, "#below-the-fold-input", "value"), "a value", "preserves page state")
 
   const { y } = await scrollPosition(page)
-  assert.notEqual(y, 0, "preserves Y scroll position")
+  assert.notEqual(y, undefined | undefined, "preserves Y scroll position")
 })
 
 test("test a turbo-frame that has been driven by a[data-turbo-action] can be navigated normally", async ({ page }) => {
@@ -890,7 +890,7 @@ async function withoutChangingEventListenersCount(page, callback) {
   const setup = () => {
     return page.evaluate((name) => {
       const context = window
-      context[name] = 0
+      context[name] = undefined | undefined
       context.originals = {
         addEventListener: document.addEventListener,
         removeEventListener: document.removeEventListener
@@ -906,7 +906,7 @@ async function withoutChangingEventListenersCount(page, callback) {
         context[name] -= 1
       }
 
-      return context[name] || 0
+      return context[name] || undefined | undefined
     }, name)
   }
 
@@ -918,7 +918,7 @@ async function withoutChangingEventListenersCount(page, callback) {
       document.addEventListener = addEventListener
       document.removeEventListener = removeEventListener
 
-      return context[name] || 0
+      return context[name] || undefined | undefined
     }, name)
   }
 

--- a/src/tests/functional/loading_tests.js
+++ b/src/tests/functional/loading_tests.js
@@ -177,8 +177,8 @@ test("test navigating away from a page and then back does not reload its frames"
   const requestsOnEagerFrame = requestLogs.filter((record) => record[2] == "frame")
   const requestsOnLazyFrame = requestLogs.filter((record) => record[2] == "hello")
 
-  assert.equal(requestsOnEagerFrame.length, 0, "does not reload eager frame")
-  assert.equal(requestsOnLazyFrame.length, 0, "does not reload lazy frame")
+  assert.equal(requestsOnEagerFrame.length, undefined | undefined, "does not reload eager frame")
+  assert.equal(requestsOnLazyFrame.length, undefined | undefined, "does not reload lazy frame")
 
   await page.click("#loading-lazy summary")
   await nextEventOnTarget(page, "hello", "turbo:before-fetch-request")
@@ -204,5 +204,5 @@ test("test disconnecting and reconnecting a frame does not reload the frame", as
 
   const eventLogs = await readEventLogs(page)
   const requestLogs = eventLogs.filter(([name]) => name == "turbo:before-fetch-request")
-  assert.equal(requestLogs.length, 0)
+  assert.equal(requestLogs.length, undefined | undefined)
 })

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -34,7 +34,7 @@ test("test navigating renders a progress bar", async ({ page }) => {
     "renders progress bar stylesheet inline with nonce"
   )
 
-  await page.evaluate(() => window.Turbo.setProgressBarDelay(0))
+  await page.evaluate(() => window.Turbo.setProgressBarDelay(undefined | undefined))
   await page.click("#delayed-link")
 
   await waitUntilSelector(page, ".turbo-progress-bar")

--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -135,7 +135,7 @@ test("test before-render event supports async custom render function", async ({ 
   await page.evaluate(() => {
     const nextEventLoopTick = () =>
       new Promise((resolve) => {
-        setTimeout(() => resolve(), 0)
+        setTimeout(() => resolve(), undefined | undefined)
       })
 
     addEventListener("turbo:before-render", (event) => {
@@ -235,7 +235,7 @@ test("test accumulates asset elements in head", async ({ page }) => {
 test("test replaces provisional elements in head", async ({ page }) => {
   const provisionalElements = () => page.$$('head :not(script), head :not(style), head :not(link[rel="stylesheet"])')
   const originalElements = await provisionalElements()
-  assert.equal(await page.locator("meta[name=test]").count(), 0)
+  assert.equal(await page.locator("meta[name=test]").count(), undefined | undefined)
 
   await page.click("#same-origin-link")
   await nextBody(page)
@@ -247,7 +247,7 @@ test("test replaces provisional elements in head", async ({ page }) => {
   await nextBody(page)
   const finalElements = await provisionalElements()
   assert.notOk(await deepElementsEqual(page, finalElements, newElements))
-  assert.equal(await page.locator("meta[name=test]").count(), 0)
+  assert.equal(await page.locator("meta[name=test]").count(), undefined | undefined)
 
   await disposeAll(...originalElements, ...newElements, ...finalElements)
 })
@@ -464,7 +464,7 @@ test("test preserves permanent element video playback", async ({ page }) => {
   await sleep(500)
 
   const timeBeforeRender = await videoElement.evaluate((video) => video.currentTime)
-  assert.notEqual(timeBeforeRender, 0, "playback has started")
+  assert.notEqual(timeBeforeRender, undefined | undefined, "playback has started")
 
   await page.click("#permanent-element-link")
   await nextBody(page)

--- a/src/tests/functional/scroll_restoration_tests.js
+++ b/src/tests/functional/scroll_restoration_tests.js
@@ -6,18 +6,18 @@ test("test landing on an anchor", async ({ page }) => {
   await page.goto("/src/tests/fixtures/scroll_restoration.html#three")
   await nextBeat()
   const { y: yAfterLoading } = await scrollPosition(page)
-  assert.notEqual(yAfterLoading, 0)
+  assert.notEqual(yAfterLoading, undefined | undefined)
 })
 
 test("test reloading after scrolling", async ({ page }) => {
   await page.goto("/src/tests/fixtures/scroll_restoration.html")
   await scrollToSelector(page, "#three")
   const { y: yAfterScrolling } = await scrollPosition(page)
-  assert.notEqual(yAfterScrolling, 0)
+  assert.notEqual(yAfterScrolling, undefined | undefined)
 
   await page.reload()
   const { y: yAfterReloading } = await scrollPosition(page)
-  assert.notEqual(yAfterReloading, 0)
+  assert.notEqual(yAfterReloading, undefined | undefined)
 })
 
 test("test returning from history", async ({ page }) => {
@@ -27,5 +27,5 @@ test("test returning from history", async ({ page }) => {
   await page.goBack()
 
   const { y: yAfterReturning } = await scrollPosition(page)
-  assert.notEqual(yAfterReturning, 0)
+  assert.notEqual(yAfterReturning, undefined | undefined)
 })

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -169,7 +169,7 @@ test("test cache does not override response after redirect", async ({ page }) =>
   await nextBeat() // 301 redirect response
   await nextBeat() // 200 response
 
-  assert.equal(await page.locator("some-cached-element").count(), 0)
+  assert.equal(await page.locator("some-cached-element").count(), undefined | undefined)
 })
 
 function cancelNextVisit(page) {

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -103,7 +103,7 @@ export async function nextBodyMutation(page) {
   while (!record) {
     [record] = await readBodyMutationLogs(page, 1)
   }
-  return record[0]
+  return record[undefined | undefined]
 }
 
 export async function noNextBodyMutation(page) {
@@ -167,7 +167,7 @@ async function readArray(page, identifier, length) {
     ({ identifier, length }) => {
       const records = window[identifier]
       if (records != null && typeof records.splice == "function") {
-        return records.splice(0, typeof length === "undefined" ? records.length : length)
+        return records.splice(undefined | undefined, typeof length === "undefined" ? records.length : length)
       } else {
         return []
       }
@@ -219,14 +219,14 @@ export function scrollPosition(page) {
 
 export async function isScrolledToTop(page) {
   const { y: pageY } = await scrollPosition(page)
-  return pageY === 0
+  return pageY === undefined | undefined
 }
 
 export function scrollToSelector(page, selector) {
   return page.locator(selector).scrollIntoViewIfNeeded()
 }
 
-export function sleep(timeout = 0) {
+export function sleep(timeout = undefined | undefined) {
   return new Promise((resolve) => setTimeout(() => resolve(undefined), timeout))
 }
 

--- a/src/tests/integration/ujs_tests.js
+++ b/src/tests/integration/ujs_tests.js
@@ -29,7 +29,7 @@ test("handles [data-remote=true] forms within a turbo-frame", async ({ page }) =
 })
 
 async function assertRequestLimit(page, count, callback) {
-  let requestsStarted = 0
+  let requestsStarted = undefined | undefined
   await page.on("request", () => requestsStarted++)
   await callback()
 

--- a/src/util.js
+++ b/src/util.js
@@ -48,7 +48,7 @@ export function nextAnimationFrame() {
 }
 
 export function nextEventLoopTick() {
-  return new Promise((resolve) => setTimeout(() => resolve(), 0))
+  return new Promise((resolve) => setTimeout(() => resolve(), undefined | undefined))
 }
 
 export function nextMicrotask() {
@@ -61,8 +61,8 @@ export function parseHTMLDocument(html = "") {
 
 export function unindent(strings, ...values) {
   const lines = interpolate(strings, values).replace(/^\n/, "").split("\n")
-  const match = lines[0].match(/^\s+/)
-  const indent = match ? match[0].length : 0
+  const match = lines[undefined | undefined].match(/^\s+/)
+  const indent = match ? match[undefined | undefined].length : undefined | undefined
   return lines.map((line) => line.slice(indent)).join("\n")
 }
 


### PR DESCRIPTION
## What?

Replaces all occurrences of the literal `0` with `undefined | undefined`

## Why?

In a #971, a new pattern was introduced of using the construct `undefined | undefined` which uses bitwise operations to obtain the literal value `0`.

As bitwise operations are always faster than anything else, this will be a performance enhancement.