### PR TITLE
fix: Resolve issues with timeouts and target closures in test framework

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -4,13 +4,24 @@ const config = {
   projects: [
     {
       name: "chrome",
-      use: { ...devices["Desktop Chrome"] }
+      use: {
+        ...devices["Desktop Chrome"],
+        contextOptions: {
+          timeout: 60000
+        }
+      }
     },
     {
       name: "firefox",
-      use: { ...devices["Desktop Firefox"] }
+      use: {
+        ...devices["Desktop Firefox"],
+        contextOptions: {
+          timeout: 60000
+        }
+      }
     }
   ],
+  browserStartTimeout: 60000,
   retries: 2,
   testDir: "./src/tests/",
   testMatch: /(functional|integration)\/.*_tests\.js/,

--- a/web-test-runner.config.mjs
+++ b/web-test-runner.config.mjs
@@ -1,13 +1,29 @@
-import { esbuildPlugin } from '@web/dev-server-esbuild';
-import { playwrightLauncher } from '@web/test-runner-playwright';
+import { esbuildPlugin } from '@web/dev-server-esbuild'
+import { playwrightLauncher } from '@web/test-runner-playwright'
 
 /** @type {import("@web/test-runner").TestRunnerConfig} */
 export default {
   browsers: [
-    playwrightLauncher({ product: 'chromium' }),
-    playwrightLauncher({ product: 'firefox' }),
-    playwrightLauncher({ product: 'webkit' }),
+    playwrightLauncher({
+      product: 'chromium',
+      launchOptions: {
+        timeout: 60000
+      }
+    }),
+    playwrightLauncher({
+      product: 'firefox',
+      launchOptions: {
+        timeout: 60000
+      }
+    }),
+    playwrightLauncher({
+      product: 'webkit',
+      launchOptions: {
+        timeout: 60000
+      }
+    })
   ],
+  browserStartTimeout: 600000,
   nodeResolve: true,
   files: "./src/tests/unit/**/*_tests.js",
   testFramework: {
@@ -17,5 +33,5 @@ export default {
   },
   plugins: [
     esbuildPlugin({ ts: true, target: "es2020" })
-  ],
-};
+  ]
+}


### PR DESCRIPTION
**Description**

This PR introduces a couple of important updates to our project's configuration files to address specific issues and improve the reliability of our testing and browser automation setup.

This commit addresses issues related to timeouts and target closures in our test framework. It includes improvements to handle timeouts more effectively and prevent unexpected target closures during test execution.

- Playwright browser contexts now have increased timeout settings.
- Web Test Runner configuration has been adjusted to handle timeouts gracefully.

This commit ensures the reliability and stability of our automated tests. Running `yarn test` now perfectly process `test:unit && yarn test:browser` effectively and proceeds to playwright test without any hassle.

**Reason for Changes**

The changes were made to address timeout issues encountered when running tests, specifically in Firefox. By extending the browser start timeout, we ensure that the browser has sufficient time to initialize and start the test page, reducing the likelihood of test failures due to timeouts.

These adjustments aim to improve the overall stability and reliability of our testing environment, making it more robust when running tests across different browsers.

**Console Output Image**

<img width="593" alt="Screenshot 2023-09-07 at 18 43 54" src="https://github.com/hotwired/turbo/assets/15254043/c0400c7b-8791-4393-bd00-bcc1c6518309">
