### PR TITLE
Update code of conduct to properly align to the behavior observed from DHH.

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -15,9 +15,9 @@ Examples of behavior that contributes to creating a positive environment
 include:
 
 * Using welcoming and inclusive language
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
+* Being respectful of differing viewpoints and experiences, unless it interferes with how 37signals operates
+* Gracefully accepting constructive criticism, unless it interferes with how 37signals operates
+* Focusing on what is best for the community, unless it interferes with how 37signals operates
 * Showing empathy towards other community members
 
 Examples of unacceptable behavior by participants include:


### PR DESCRIPTION
I haven't been personally active in the Rails community for quite some time now, and this library change personally does not affect me, but it's sad to see this is happening right now.

I see clear disrespect, obsoleting valuable PRs by making rash decisions without conferring with the community in #971, completely ignoring a valid argument by @t3dotgg saying "maybe this isn't the project for you" in #977. What happened in #977 doesn't really break the code of conduct, but it certainly isn't welcoming which is outlined as the interest of the Code of Conduct:

![](https://i-work-at-the.cocaine.institute/Lizzy64faa4fdDrh6i84iyZU8.png)

I see you calling members of your project's community "Hooligans". Everybody is free to share their disagreement in a harm free manner, and I see no harm being done by those you have called out in your blog post. @scorbettUM and @t3dotgg are both valuable members of the wider OSS community whose words carry far more weight than mine even in our "dogmatic circle" as you so call it.

I'm certain this PR will get closed and locked as the rest have (and I see it's already been done by someone I don't recognize!). Before that happens @dhh, I ask you this: Do you have what it takes to accept this PR and admit that "community doesn't matter" is your mindset? If that is the case, I can see forks being made and favored by most as a likely outcome from this point forward. If you don't admit to it, the same thing will likely happen, but slower. 

These are **your** options, and the future of **your** project relies on **your** decisions. Like you and many others have said, it is "your" project. The community can fork it and maintain it how they see fit. I hope they know that this is what they have to do, because your mind is made up for the path you think is best.
