### PR TITLE
[Deprecation]: Remove internal objects from public API

### DIFF
--- a/src/core/drive/form_submission.js
+++ b/src/core/drive/form_submission.js
@@ -116,64 +116,106 @@ export class FormSubmission {
 
   // Fetch request delegate
 
-  prepareRequest(request) {
-    if (!request.isSafe) {
+  prepareRequest(fetchRequest) {
+    if (!fetchRequest.isSafe) {
       const token = getCookieValue(getMetaContent("csrf-param")) || getMetaContent("csrf-token")
       if (token) {
-        request.headers["X-CSRF-Token"] = token
+        fetchRequest.headers.set("X-CSRF-Token", token)
       }
     }
 
-    if (this.requestAcceptsTurboStreamResponse(request)) {
-      request.acceptResponseType(StreamMessage.contentType)
+    if (this.requestAcceptsTurboStreamResponse(fetchRequest)) {
+      fetchRequest.acceptResponseType(StreamMessage.contentType)
     }
   }
 
-  requestStarted(_request) {
+  requestStarted(fetchRequest) {
+    const formSubmission = this
+
     this.state = FormSubmissionState.waiting
     this.submitter?.setAttribute("disabled", "")
     this.setSubmitsWith()
     dispatch("turbo:submit-start", {
       target: this.formElement,
-      detail: { formSubmission: this }
+      detail: {
+        request: fetchRequest.request,
+        submitter: this.submitter,
+
+        get formSubmission() {
+          console.warn("`event.detail.formSubmission` is deprecated. Use `event.target`, `event.detail.submitter`, and `event.detail.request` instead")
+
+          return formSubmission
+        }
+      }
     })
     this.delegate.formSubmissionStarted(this)
   }
 
-  requestPreventedHandlingResponse(request, response) {
-    this.result = { success: response.succeeded, fetchResponse: response }
+  requestPreventedHandlingResponse(fetchRequest, fetchResponse) {
+    this.result = { success: fetchResponse.succeeded, fetchResponse: fetchResponse }
   }
 
-  requestSucceededWithResponse(request, response) {
-    if (response.clientError || response.serverError) {
-      this.delegate.formSubmissionFailedWithResponse(this, response)
-    } else if (this.requestMustRedirect(request) && responseSucceededWithoutRedirect(response)) {
+  requestSucceededWithResponse(fetchRequest, fetchResponse) {
+    if (fetchResponse.clientError || fetchResponse.serverError) {
+      this.delegate.formSubmissionFailedWithResponse(this, fetchResponse)
+    } else if (this.requestMustRedirect(fetchRequest) && responseSucceededWithoutRedirect(fetchResponse)) {
       const error = new Error("Form responses must redirect to another location")
       this.delegate.formSubmissionErrored(this, error)
     } else {
       this.state = FormSubmissionState.receiving
-      this.result = { success: true, fetchResponse: response }
-      this.delegate.formSubmissionSucceededWithResponse(this, response)
+      this.result = {
+        success: true,
+        response: fetchResponse.response,
+
+        get fetchResponse() {
+          console.warn("`event.detail.fetchResponse` is deprecated. Use `event.detail.response` instead")
+
+          return fetchResponse
+        }
+      }
+      this.delegate.formSubmissionSucceededWithResponse(this, fetchResponse)
     }
   }
 
-  requestFailedWithResponse(request, response) {
-    this.result = { success: false, fetchResponse: response }
-    this.delegate.formSubmissionFailedWithResponse(this, response)
+  requestFailedWithResponse(fetchRequest, fetchResponse) {
+    this.result = {
+      success: false,
+      response: fetchResponse.response,
+
+      get fetchResponse() {
+        console.warn("`event.detail.fetchResponse` is deprecated. Use `event.detail.response` instead")
+
+        return fetchResponse
+      }
+    }
+    this.delegate.formSubmissionFailedWithResponse(this, fetchResponse)
   }
 
-  requestErrored(request, error) {
+  requestErrored(fetchRequest, error) {
     this.result = { success: false, error }
     this.delegate.formSubmissionErrored(this, error)
   }
 
-  requestFinished(_request) {
+  requestFinished(fetchRequest) {
     this.state = FormSubmissionState.stopped
     this.submitter?.removeAttribute("disabled")
     this.resetSubmitterText()
+    const { formSubmission } = this
+
     dispatch("turbo:submit-end", {
       target: this.formElement,
-      detail: { formSubmission: this, ...this.result }
+      detail: {
+        request: fetchRequest.request,
+        submitter: this.submitter,
+
+        get formSubmission() {
+          console.warn("`event.detail.formSubmission` is deprecated. Use `event.target`, `event.detail.submitter`, and `event.detail.request` instead")
+
+          return formSubmission
+        },
+
+        ...this.result
+      }
     })
     this.delegate.formSubmissionFinished(this)
   }
@@ -204,12 +246,12 @@ export class FormSubmission {
     }
   }
 
-  requestMustRedirect(request) {
-    return !request.isSafe && this.mustRedirect
+  requestMustRedirect(fetchRequest) {
+    return !fetchRequest.isSafe && this.mustRedirect
   }
 
-  requestAcceptsTurboStreamResponse(request) {
-    return !request.isSafe || hasAttribute("data-turbo-stream", this.submitter, this.formElement)
+  requestAcceptsTurboStreamResponse(fetchRequest) {
+    return !fetchRequest.isSafe || hasAttribute("data-turbo-stream", this.submitter, this.formElement)
   }
 
   get submitsWith() {

--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -192,7 +192,7 @@ export class FrameController {
   // Fetch request delegate
 
   prepareRequest(request) {
-    request.headers["Turbo-Frame"] = this.id
+    request.headers.set("Turbo-Frame", this.id)
 
     if (this.currentNavigationElement?.hasAttribute("data-turbo-stream")) {
       request.acceptResponseType(StreamMessage.contentType)

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -353,7 +353,15 @@ export class Session {
 
   notifyApplicationAfterFrameRender(fetchResponse, frame) {
     return dispatch("turbo:frame-render", {
-      detail: { fetchResponse },
+      detail: {
+        response: fetchResponse.response,
+
+        get fetchResponse() {
+          console.warn("`event.detail.fetchResponse` is deprecated. Use `event.detail.response` instead")
+
+          return fetchResponse
+        }
+      },
       target: frame,
       cancelable: true
     })

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end turbo:fetch-request-error">
+<html id="html" data-skip-event-details="turbo:fetch-request-error">
   <head>
     <meta charset="utf-8">
     <title>Form</title>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end">
+<html id="html">
   <head>
     <meta charset="utf-8">
     <meta name="csp-nonce" content="123">

--- a/src/tests/fixtures/stream.html
+++ b/src/tests/fixtures/stream.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-skip-event-details="turbo:submit-start turbo:submit-end">
+<html>
   <head>
     <meta charset="utf-8">
     <title>Turbo Streams</title>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -9,6 +9,8 @@
         returned[key] = value.toJSON()
       } else if (value instanceof Element) {
         returned[key] = value.outerHTML
+      } else if (value instanceof Headers) {
+        returned[key] = Object.fromEntries(value.entries())
       } else if (typeof value == "object") {
         if (visited.has(value)) {
           returned[key] = "skipped to prevent infinitely recursing"

--- a/src/tests/functional/form_submission_tests.js
+++ b/src/tests/functional/form_submission_tests.js
@@ -136,9 +136,9 @@ test("test standard POST form submission events", async ({ page }) => {
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.ok(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
 
   await nextEventNamed(page, "turbo:before-fetch-response")
 
@@ -189,6 +189,24 @@ test("replaces input value with data-turbo-submits-with on form submission", asy
     "Save",
     "restores the original submitter text value"
   )
+})
+
+test("turbo:submit-start events details dispatched with request and submitter", async ({ page }) => {
+  await page.click("#submits-with-form-button")
+
+  const { request, submitter } = await nextEventNamed(page, "turbo:submit-start")
+  assert.ok(request, "turbo:submit-start assigns event.detail.request")
+  assert.ok(submitter, "turbo:submit-start assigns event.detail.submitter")
+})
+
+test("turbo:submit-end events details dispatched with request and submitter", async ({ page }) => {
+  await page.click("#submits-with-form-button")
+
+  const { request, response, submitter, success } = await nextEventNamed(page, "turbo:submit-end")
+  assert.ok(request, "turbo:submit-end assigns event.detail.request")
+  assert.ok(response, "turbo:submit-end assigns event.detail.response")
+  assert.ok(submitter, "turbo:submit-end assigns event.detail.submitter")
+  assert.equal(true, success, "turbo:submit-end assigns event.detail.success")
 })
 
 test("replaces button innerHTML with data-turbo-submits-with on form submission", async ({ page }) => {
@@ -256,17 +274,17 @@ test("test GET HTMLFormElement.requestSubmit() triggered by javascript", async (
 test("test standard GET form submission with [data-turbo-stream] declared on the form", async ({ page }) => {
   await page.click("#standard-get-form-with-stream-opt-in-submit")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.ok(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
 })
 
 test("test standard GET form submission with [data-turbo-stream] declared on submitter", async ({ page }) => {
   await page.click("#standard-get-form-with-stream-opt-in-submitter")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.ok(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
 })
 
 test("test standard GET form submission events", async ({ page }) => {
@@ -274,9 +292,9 @@ test("test standard GET form submission events", async ({ page }) => {
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.notOk(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.notOk(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
 
   await nextEventNamed(page, "turbo:before-fetch-response")
 
@@ -574,10 +592,10 @@ test("test frame POST form targeting frame submission", async ({ page }) => {
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
-  assert.equal("frame", fetchOptions.headers["Turbo-Frame"])
+  assert.ok(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal("frame", request.headers["turbo-frame"])
 
   await nextEventNamed(page, "turbo:before-fetch-response")
 
@@ -613,10 +631,10 @@ test("test frame GET form targeting frame submission", async ({ page }) => {
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.notOk(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
-  assert.equal("frame", fetchOptions.headers["Turbo-Frame"])
+  assert.notOk(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal("frame", request.headers["turbo-frame"])
 
   await nextEventNamed(page, "turbo:before-fetch-response")
 
@@ -738,9 +756,9 @@ test("test frame form submission with empty no-content response", async ({ page 
 test("test frame form submission within a frame submits the Turbo-Frame header", async ({ page }) => {
   await page.click("#frame form.redirect input[type=submit]")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
+  assert.ok(request.headers["turbo-frame"], "submits with the Turbo-Frame header")
 })
 
 test("test invalid frame form submission with unprocessable entity status", async ({ page }) => {
@@ -875,9 +893,9 @@ test("test form submission targets disabled frame", async ({ page }) => {
 test("test form submission targeting a frame submits the Turbo-Frame header", async ({ page }) => {
   await page.click('#targets-frame [type="submit"]')
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
+  assert.ok(request.headers["turbo-frame"], "submits with the Turbo-Frame header")
 })
 
 test("test link method form submission dispatches events from a connected <form> element", async ({ page }) => {
@@ -905,10 +923,10 @@ test("test link method form submission submits a single request", async ({ page 
   await page.click("#stream-link-method-within-form-outside-frame")
   await nextBeat()
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
-  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(request.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 1, "submits a single HTTP request")
 })
 
@@ -919,10 +937,10 @@ test("test link method form submission inside frame submits a single request", a
   await page.click("#stream-link-method-inside-frame")
   await nextBeat()
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
-  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(request.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 1, "submits a single HTTP request")
 })
 
@@ -933,10 +951,10 @@ test("test link method form submission targeting frame submits a single request"
   await page.click("#turbo-method-post-to-targeted-frame")
   await nextBeat()
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
-  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
+  assert.equal(request.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 2, "submits a single HTTP request then follows a redirect")
 })
 
@@ -977,17 +995,17 @@ test("test stream link method form submission inside frame", async ({ page }) =>
 test("test stream link GET method form submission inside frame", async ({ page }) => {
   await page.click("#stream-link-get-method-inside-frame")
 
-  const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.ok(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
 })
 
 test("test stream link inside frame", async ({ page }) => {
   await page.click("#stream-link-inside-frame")
 
-  const { fetchOptions, url } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request, url } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
+  assert.ok(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
   assert.equal(getSearchParam(url, "content"), "Link!")
 })
 

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -436,9 +436,9 @@ test("test 'turbo:frame-render' is triggered after frame has finished rendering"
   await page.click("#frame-part")
 
   await nextEventNamed(page, "turbo:frame-render") // recursive
-  const { fetchResponse } = await nextEventNamed(page, "turbo:frame-render")
+  const { response } = await nextEventNamed(page, "turbo:frame-render")
 
-  assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/part.html")
+  assert.include(response.url, "/src/tests/fixtures/frames/part.html")
 })
 
 test("test navigating a frame from an outer form fires events", async ({ page }) => {
@@ -446,8 +446,8 @@ test("test navigating a frame from an outer form fires events", async ({ page })
 
   await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
   await nextEventOnTarget(page, "frame", "turbo:before-fetch-response")
-  const { fetchResponse } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
-  assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/form.html")
+  const { response } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  assert.include(response.url, "/src/tests/fixtures/frames/form.html")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
@@ -462,8 +462,8 @@ test("test navigating a frame from an outer link fires events", async ({ page })
   await nextEventOnTarget(page, "outside-frame-form", "turbo:click")
   await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
   await nextEventOnTarget(page, "frame", "turbo:before-fetch-response")
-  const { fetchResponse } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
-  assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/form.html")
+  const { response } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  assert.include(response.url, "/src/tests/fixtures/frames/form.html")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
@@ -478,8 +478,8 @@ test("test navigating a frame from an inner link fires events", async ({ page })
   await nextEventOnTarget(page, "link-frame", "turbo:click")
   await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
   await nextEventOnTarget(page, "frame", "turbo:before-fetch-response")
-  const { fetchResponse } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
-  assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/frame.html")
+  const { response } = await nextEventOnTarget(page, "frame", "turbo:frame-render")
+  assert.include(response.url, "/src/tests/fixtures/frames/frame.html")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -101,10 +101,10 @@ test("test navigation by history is not cancelable", async ({ page }) => {
 
 test("test turbo:before-fetch-request event.detail", async ({ page }) => {
   await page.click("#same-origin-link")
-  const { url, fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.equal(fetchOptions.method, "GET")
-  assert.ok(url.includes("/src/tests/fixtures/one.html"))
+  assert.equal(request.method, "GET")
+  assert.ok(request.url.includes("/src/tests/fixtures/one.html"))
 })
 
 test("test turbo:before-fetch-request event.detail encodes searchParams", async ({ page }) => {
@@ -140,10 +140,10 @@ test("test turbo:before-fetch-response open new site", async ({ page }) => {
 
 test("test visits with data-turbo-stream include MIME type & search params", async ({ page }) => {
   await page.click("#stream-link")
-  const { fetchOptions, url } = await nextEventNamed(page, "turbo:before-fetch-request")
+  const { request } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
-  assert.equal(getSearchParam(url, "key"), "value")
+  assert.ok(request.headers["accept"].includes("text/vnd.turbo-stream.html"))
+  assert.equal(getSearchParam(request.url, "key"), "value")
 })
 
 test("test visits with data-turbo-stream do not set aria-busy", async ({ page }) => {


### PR DESCRIPTION
The `FetchRequest`, `FetchResponse`, and `FormSubmission` objects are internal abstractions that facilitate Turbo's management of HTTP and Form Submission life cycles.

Currently, references to instances of those classes are available through `event.detail` for the following events:

* `turbo:frame-render`
* `turbo:before-fetch-request`
* `turbo:before-fetch-response`
* `turbo:submit-start`
* `turbo:submit-end`

Similarly, the `turbo:before-fetch-request` exposes a `fetchOptions` object that is a separate instance from the one used to submit the request. This means that **any** modifications to **any** value made from within an event listener are ineffective and **do not change** the ensuing request.

This commit deprecates those properties in favor of their built-in foundations, namely:

* [Request][]
* [Response][]

The properties that expose those instances will remain as deprecations, but will be inaccessible after an `8.0` release.

[Request]: https://developer.mozilla.org/en-US/docs/Web/API/Request
[Response]: https://developer.mozilla.org/en-US/docs/Web/API/Response