### PR TITLE
Upload dist artifacts to GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,3 +35,8 @@ jobs:
 
     - name: Firefox Test
       run: yarn test:browser --project=firefox
+
+    - uses: actions/upload-artifact@v3
+      with:
+        name: turbo-dist
+        path: dist/*


### PR DESCRIPTION
This adds an [upload artifact](https://github.com/actions/upload-artifact) Github action step to store the results of the build in the Github Actions workflow.

This allows us to download the artifacts from the Github Actions UI. Sometimes it's useful to have the artifacts available for debugging purposes, or to test a branch in an application before merging.