### PR TITLE
Use new format instead of legacy

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -16,7 +16,7 @@ export default [
       },
       {
         file: "dist/turbo.es2017-esm.js",
-        format: "es",
+        format: "esm",
         banner
       }
     ],


### PR DESCRIPTION
"es" and "esm" are both formats for ECMAScript modules.

"es" is a legacy format that was used before the introduction of the "esm" format. It is a simple format that does not support all the features of modern ES modules. For example, it does not support dynamic imports.

"esm" is a newer and more advanced format that is designed to work with modern ES modules. It supports all the features of ES modules, including dynamic imports, export renaming, and export namespace objects. It is the recommended format for building modern JavaScript libraries and applications.

The same issue like here [https://github.com/hotwired/turbo-rails/pull/435](https://github.com/hotwired/turbo-rails/pull/435)
