### PR TITLE
Page refreshes

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,9 @@
   "publishConfig": {
     "access": "public"
   },
+  "dependencies": {
+    "idiomorph": "https://github.com/basecamp/idiomorph#rollout-build"
+  },
   "devDependencies": {
     "@open-wc/testing": "^3.1.7",
     "@playwright/test": "^1.28.0",

--- a/src/core/drive/limited_set.js
+++ b/src/core/drive/limited_set.js
@@ -1,0 +1,15 @@
+export class LimitedSet extends Set {
+  constructor(maxSize) {
+    super()
+    this.maxSize = maxSize
+  }
+
+  add(value) {
+    if (this.size >= this.maxSize) {
+      const iterator = this.values()
+      const oldestValue = iterator.next().value
+      this.delete(oldestValue)
+    }
+    super.add(value)
+  }
+}

--- a/src/core/drive/morph_renderer.js
+++ b/src/core/drive/morph_renderer.js
@@ -1,0 +1,88 @@
+import Idiomorph from "idiomorph"
+import { nextAnimationFrame } from "../../util"
+import { Renderer } from "../renderer"
+
+export class MorphRenderer extends Renderer {
+  async render() {
+    if (this.willRender) await this.#morphBody()
+  }
+
+  get renderMethod() {
+    return "morph"
+  }
+
+  // Private
+
+  async #morphBody() {
+    this.#morphElements(this.currentElement, this.newElement)
+    this.#reloadRemoteFrames()
+
+    this.#dispatchEvent("turbo:morph", { currentElement: this.currentElement, newElement: this.newElement })
+  }
+
+  #morphElements(currentElement, newElement, morphStyle = "outerHTML") {
+    Idiomorph.morph(currentElement, newElement, {
+      morphStyle: morphStyle,
+      callbacks: {
+        beforeNodeMorphed: this.#shouldMorphElement,
+        beforeNodeRemoved: this.#shouldRemoveElement,
+        afterNodeMorphed: this.#reloadStimulusControllers
+      }
+    })
+  }
+
+  #reloadRemoteFrames() {
+    this.#remoteFrames().forEach((frame) => {
+      if (this.#isFrameReloadedWithMorph(frame)) {
+        this.#renderFrameWithMorph(frame)
+      }
+      frame.reload()
+    })
+  }
+
+  #renderFrameWithMorph(frame) {
+    frame.addEventListener("turbo:before-frame-render", (event) => {
+      event.detail.render = this.#morphFrameUpdate
+    }, { once: true })
+  }
+
+  #morphFrameUpdate = (currentElement, newElement) => {
+    this.#dispatchEvent("turbo:before-frame-morph", { currentElement, newElement }, currentElement)
+    this.#morphElements(currentElement, newElement, "innerHTML")
+  }
+
+  #shouldRemoveElement = (node) => {
+    return this.#shouldMorphElement(node)
+  }
+
+  #shouldMorphElement = (node) => {
+    if (node instanceof HTMLElement) {
+      return !node.hasAttribute("data-turbo-permanent")
+    } else {
+      return true
+    }
+  }
+
+  #reloadStimulusControllers = async (node) => {
+    if (node instanceof HTMLElement && node.hasAttribute("data-controller")) {
+      const originalAttribute = node.getAttribute("data-controller")
+      node.removeAttribute("data-controller")
+      await nextAnimationFrame()
+      node.setAttribute("data-controller", originalAttribute)
+    }
+  }
+
+  #isFrameReloadedWithMorph(element) {
+    return element.getAttribute("src") && element.getAttribute("refresh") === "morph"
+  }
+
+  #remoteFrames() {
+    return document.querySelectorAll("turbo-frame[src]")
+  }
+
+  #dispatchEvent(name, detail, target = document.documentElement) {
+    const event = new CustomEvent(name, { bubbles: true, cancelable: true, detail })
+    target.dispatchEvent(event)
+    return event
+  }
+}

--- a/src/core/drive/page_snapshot.js
+++ b/src/core/drive/page_snapshot.js
@@ -73,6 +73,14 @@ export class PageSnapshot extends Snapshot {
     return this.headSnapshot.getMetaValue("view-transition") === "same-origin"
   }
 
+  get shouldMorphPage() {
+    return this.getSetting("refresh-method") === "morph"
+  }
+
+  get shouldPreserveScrollPosition() {
+    return this.getSetting("refresh-scroll") === "preserve"
+  }
+
   // Private
 
   getSetting(name) {

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -1,6 +1,7 @@
 import { nextEventLoopTick } from "../../util"
 import { View } from "../view"
 import { ErrorRenderer } from "./error_renderer"
+import { MorphRenderer } from "./morph_renderer"
 import { PageRenderer } from "./page_renderer"
 import { PageSnapshot } from "./page_snapshot"
 import { SnapshotCache } from "./snapshot_cache"
@@ -15,7 +16,10 @@ export class PageView extends View {
   }
 
   renderPage(snapshot, isPreview = false, willRender = true, visit) {
-    const renderer = new PageRenderer(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)
+    const shouldMorphPage = this.isPageRefresh(visit) && this.snapshot.shouldMorphPage
+    const rendererClass = shouldMorphPage ? MorphRenderer : PageRenderer
+
+    const renderer = new rendererClass(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)
 
     if (!renderer.shouldRender) {
       this.forceReloaded = true
@@ -53,6 +57,10 @@ export class PageView extends View {
 
   getCachedSnapshotForLocation(location) {
     return this.snapshotCache.get(location)
+  }
+
+  isPageRefresh(visit) {
+    return visit && this.lastRenderedLocation.href === visit.location.href
   }
 
   get snapshot() {

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -154,10 +154,10 @@ export class Visit {
     }
   }
 
-  issueRequest() {
+  async issueRequest() {
     if (this.hasPreloadedResponse()) {
       this.simulateRequest()
-    } else if (this.shouldIssueRequest() && !this.request) {
+    } else if (!this.request && await this.shouldIssueRequest()) {
       this.request = new FetchRequest(this, FetchMethod.get, this.location)
       this.request.perform()
     }
@@ -231,14 +231,14 @@ export class Visit {
     }
   }
 
-  hasCachedSnapshot() {
-    return this.getCachedSnapshot() != null
+  async hasCachedSnapshot() {
+    return (await this.getCachedSnapshot()) != null
   }
 
   async loadCachedSnapshot() {
     const snapshot = await this.getCachedSnapshot()
     if (snapshot) {
-      const isPreview = this.shouldIssueRequest()
+      const isPreview = await this.shouldIssueRequest()
       this.render(async () => {
         this.cacheSnapshot()
         if (this.isSamePage) {
@@ -335,7 +335,7 @@ export class Visit {
   // Scrolling
 
   performScroll() {
-    if (!this.scrolled && !this.view.forceReloaded) {
+    if (!this.scrolled && !this.view.forceReloaded && !this.view.snapshot.shouldPreserveScrollPosition) {
       if (this.action == "restore") {
         this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()
       } else {
@@ -391,11 +391,11 @@ export class Visit {
     return typeof this.response == "object"
   }
 
-  shouldIssueRequest() {
+  async shouldIssueRequest() {
     if (this.isSamePage) {
       return false
-    } else if (this.action == "restore") {
-      return !this.hasCachedSnapshot()
+    } else if (this.action === "restore") {
+      return !(await this.hasCachedSnapshot())
     } else {
       return this.willRender
     }

--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -276,7 +276,7 @@ export class FrameController {
     return !defaultPrevented
   }
 
-  viewRenderedSnapshot(_snapshot, _isPreview) {}
+  viewRenderedSnapshot(_snapshot, _isPreview, _renderMethod) {}
 
   preloadOnLoadLinksForView(element) {
     session.preloadOnLoadLinksForView(element)

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -4,11 +4,13 @@ import { PageRenderer } from "./drive/page_renderer"
 import { PageSnapshot } from "./drive/page_snapshot"
 import { FrameRenderer } from "./frames/frame_renderer"
 import { FormSubmission } from "./drive/form_submission"
+import { LimitedSet } from "./drive/limited_set"
 
 const session = new Session()
 const cache = new Cache(session)
+const recentRequests = new LimitedSet(20)
 const { navigator } = session
-export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer }
+export { navigator, session, cache, recentRequests, PageRenderer, PageSnapshot, FrameRenderer }
 
 export { StreamActions } from "./streams/stream_actions"
 

--- a/src/core/native/browser_adapter.js
+++ b/src/core/native/browser_adapter.js
@@ -22,11 +22,7 @@ export class BrowserAdapter {
 
   visitRequestStarted(visit) {
     this.progressBar.setValue(0)
-    if (visit.hasCachedSnapshot() || visit.action != "restore") {
-      this.showVisitProgressBarAfterDelay()
-    } else {
-      this.showProgressBar()
-    }
+    this.showVisitProgressBarAfterDelay()
   }
 
   visitRequestCompleted(visit) {

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -79,4 +79,8 @@ export class Renderer {
   get permanentElementMap() {
     return this.currentSnapshot.getPermanentElementMapForSnapshot(this.newSnapshot)
   }
+
+  get renderMethod() {
+    return "replace"
+  }
 }

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -263,9 +263,9 @@ export class Session {
     return !defaultPrevented
   }
 
-  viewRenderedSnapshot(_snapshot, isPreview) {
+  viewRenderedSnapshot(_snapshot, isPreview, renderMethod) {
     this.view.lastRenderedLocation = this.history.location
-    this.notifyApplicationAfterRender(isPreview)
+    this.notifyApplicationAfterRender(isPreview, renderMethod)
   }
 
   preloadOnLoadLinksForView(element) {
@@ -328,8 +328,8 @@ export class Session {
     })
   }
 
-  notifyApplicationAfterRender(isPreview) {
-    return dispatch("turbo:render", { detail: { isPreview } })
+  notifyApplicationAfterRender(isPreview, renderMethod) {
+    return dispatch("turbo:render", { detail: { isPreview, renderMethod } })
   }
 
   notifyApplicationAfterPageLoad(timing = {}) {

--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -30,5 +30,14 @@ export const StreamActions = {
       targetElement.innerHTML = ""
       targetElement.append(this.templateContent)
     })
+  },
+
+  refresh() {
+    const requestId = this.getAttribute("request-id")
+    const isRecentRequest = requestId && window.Turbo.recentRequests.has(requestId)
+    if (!isRecentRequest) {
+      window.Turbo.cache.exemptPageFromPreview()
+      window.Turbo.visit(window.location.href, { action: "replace" })
+    }
   }
 }

--- a/src/core/view.js
+++ b/src/core/view.js
@@ -69,7 +69,7 @@ export class View {
         if (!immediateRender) await renderInterception
 
         await this.renderSnapshot(renderer)
-        this.delegate.viewRenderedSnapshot(snapshot, isPreview)
+        this.delegate.viewRenderedSnapshot(snapshot, isPreview, this.renderer.renderMethod)
         this.delegate.preloadOnLoadLinksForView(this.element)
         this.finishRenderingSnapshot(renderer)
       } finally {

--- a/src/http/recent_fetch_requests.js
+++ b/src/http/recent_fetch_requests.js
@@ -1,0 +1,15 @@
+import { uuid } from "../util"
+
+const originalFetch = window.fetch
+
+window.fetch = async function(url, options = {}) {
+  const modifiedHeaders = new Headers(options.headers || {})
+  const requestUID = uuid()
+  window.Turbo.recentRequests.add(requestUID)
+  modifiedHeaders.append("X-Turbo-Request-Id", requestUID)
+
+  return originalFetch(url, {
+    ...options,
+    headers: modifiedHeaders
+  })
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 import "./polyfills"
 import "./elements"
 import "./script_warning"
+import "./http/recent_fetch_requests"
 
 import * as Turbo from "./core"
 

--- a/src/tests/fixtures/frame_refresh_morph.html
+++ b/src/tests/fixtures/frame_refresh_morph.html
@@ -1,0 +1,3 @@
+<turbo-frame id="refresh-morph">
+  <h2>Loaded morphed frame</h2>
+</turbo-frame>

--- a/src/tests/fixtures/frame_refresh_reload.html
+++ b/src/tests/fixtures/frame_refresh_reload.html
@@ -1,0 +1,3 @@
+<turbo-frame id="refresh-reload">
+  <h2>Loaded reloadable frame</h2>
+</turbo-frame>

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end turbo:fetch-request-error">
+  <head>
+    <meta charset="utf-8">
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
+
+    <title>Turbo</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+
+    <style>
+        body {
+            margin: 0;
+            padding: 0;
+
+            /* Ensure the page is large enough to scroll */
+            width: 150vw;
+            height: 150vh;
+        }
+    </style>
+  </head>
+  <body>
+    <h1>Page to be refreshed</h1>
+
+    <turbo-frame id="refresh-morph" src="/src/tests/fixtures/frame_refresh_morph.html" refresh="morph">
+      <h2>Frame to be morphed</h2>
+    </turbo-frame>
+
+    <turbo-frame id="refresh-reload" src="/src/tests/fixtures/frame_refresh_reload.html" refresh="reload">
+      <h2>Frame to be reloaded</h2>
+    </turbo-frame>
+
+    <div id="preserve-me" data-turbo-permanent>
+      Preserve me!
+    </div>
+
+    <div id="stimulus-controller" data-controller="test">
+      <h3>Element with Stimulus controller</h3>
+    </div>
+
+    <p><a id="link" href="/src/tests/fixtures/one.html">Link to another page</a></p>
+
+    <form id="form" action="/__turbo/refresh" method="post" class="redirect">
+      <input type="text" name="text" value="">
+      <input type="hidden" name="path" value="/src/tests/fixtures/page_refresh.html">
+      <input type="hidden" name="sleep" value="50">
+      <input id="form-submit" type="submit" value="form[method=post]">
+    </form>
+  </body>
+</html>

--- a/src/tests/fixtures/page_refresh_replace.html
+++ b/src/tests/fixtures/page_refresh_replace.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end turbo:fetch-request-error">
+  <head>
+    <meta charset="utf-8">
+    <meta name="turbo-refresh-scroll" content="preserve">
+
+    <title>Turbo</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+
+        /* Ensure the page is large enough to scroll */
+        width: 150vw;
+        height: 150vh;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Page to be refreshed</h1>
+
+    <turbo-frame id="refresh-morph" src="/src/tests/fixtures/frame_refresh_morph.html" refresh="morph">
+      <h2>Frame to be morphed</h2>
+    </turbo-frame>
+
+    <turbo-frame id="refresh-reload" src="/src/tests/fixtures/frame_refresh_reload.html" refresh="reload">
+      <h2>Frame to be reloaded</h2>
+    </turbo-frame>
+
+    <div id="preserve-me" data-turbo-permanent>
+      Preserve me!
+    </div>
+
+    <form id="form" action="/__turbo/refresh" method="post" class="redirect">
+      <input type="text" name="text" value="">
+      <input type="hidden" name="path" value="/src/tests/fixtures/page_refresh_replace.html">
+      <input type="hidden" name="sleep" value="50">
+      <input id="form-submit" type="submit" value="form[method=post]">
+    </form>
+  </body>
+</html>

--- a/src/tests/fixtures/page_refresh_scroll_reset.html
+++ b/src/tests/fixtures/page_refresh_scroll_reset.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end turbo:fetch-request-error">
+  <head>
+    <meta charset="utf-8">
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="reset">
+
+    <title>Turbo</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+
+    <style>
+      body {
+        margin: 0;
+        padding: 0;
+
+        /* Ensure the page is large enough to scroll */
+        width: 150vw;
+        height: 150vh;
+      }
+
+      #form {
+        position: absolute;
+        top: 120px;
+        left: 100px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Page to be refreshed</h1>
+
+    <turbo-frame id="refreshed-frame" src="/src/tests/fixtures/frame_refresh.html">
+      <h2>Frame to be refreshed</h2>
+    </turbo-frame>
+
+    <form id="form" action="/__turbo/refresh" method="post" class="redirect">
+      <input type="text" name="text" value="">
+      <input type="hidden" name="path" value="/src/tests/fixtures/page_refresh_scroll_reset.html">
+      <input type="hidden" name="sleep" value="50">
+      <input id="form-submit" type="submit" value="form[method=post]">
+    </form>
+  </body>
+</html>

--- a/src/tests/fixtures/page_refresh_stream_action.html
+++ b/src/tests/fixtures/page_refresh_stream_action.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html data-skip-event-details="turbo:submit-start turbo:submit-end">
+<head>
+  <meta charset="utf-8">
+  <title>Turbo Streams</title>
+  <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  <script src="/src/tests/fixtures/test.js"></script>
+</head>
+<body>
+  <form id="refresh" method="post" action="/__turbo/refreshes">
+    <button>Refresh</button>
+    <input id="request-id" type="hidden" name="requestId" value="">
+  </form>
+
+  <div id="content">
+    <span>Hello</span>
+  </div>
+</body>
+</html>

--- a/src/tests/fixtures/page_refreshed.html
+++ b/src/tests/fixtures/page_refreshed.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html data-skip-event-details="turbo:before-render">
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Refreshed page</h1>
+  </body>
+</html>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -83,6 +83,7 @@
   "turbo:frame-load",
   "turbo:frame-render",
   "turbo:frame-missing",
+  "turbo:before-frame-morph",
   "turbo:reload"
 ])
 

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -195,7 +195,13 @@ test("test following a POST form clears cache", async ({ page }) => {
   await page.click("#form-post-submit")
   await nextBeat() // 301 redirect response
   await nextBeat() // 200 response
+
+  assert.equal(await page.textContent("h1"), "One")
+
   await page.goBack()
+  await nextBeat()
+
+  assert.equal(await page.textContent("h1"), "Navigation")
   assert.notOk(await hasSelector(page, "some-cached-element"))
 })
 

--- a/src/tests/functional/page_refresh_stream_action_tests.js
+++ b/src/tests/functional/page_refresh_stream_action_tests.js
@@ -1,0 +1,55 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBeat } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_stream_action.html")
+})
+
+test("test refreshing the page", async ({ page }) => {
+  assert.match(await textContent(page), /Hello/)
+
+  await page.locator("#content").evaluate((content)=>content.innerHTML = "")
+  assert.notMatch(await textContent(page), /Hello/)
+
+  await page.click("#refresh button")
+  await nextBeat()
+
+  assert.match(await textContent(page), /Hello/)
+})
+
+test("don't refresh the page on self-originated request ids", async ({ page }) => {
+  assert.match(await textContent(page), /Hello/)
+
+  await page.locator("#content").evaluate((content)=>content.innerHTML = "")
+  page.evaluate(()=> { window.Turbo.recentRequests.add("123") })
+
+  await page.locator("#request-id").evaluate((input)=>input.value = "123")
+  await page.click("#refresh button")
+  await nextBeat()
+
+  assert.notMatch(await textContent(page), /Hello/)
+})
+
+test("fetch injects a Turbo-Request-Id with a UID generated automatically", async ({ page }) => {
+  const response1 = await fetchRequestId(page)
+  const response2 = await fetchRequestId(page)
+
+  assert.notEqual(response1, response2)
+
+  for (const response of [response1, response2]) {
+    assert.match(response, /.+-.+-.+-.+/)
+  }
+})
+
+async function textContent(page) {
+  const messages = await page.locator("#content")
+  return await messages.textContent()
+}
+
+async function fetchRequestId(page) {
+  return await page.evaluate(async () => {
+    const response = await window.fetch("/__turbo/request_id_header")
+    return response.text()
+  })
+}

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -1,0 +1,115 @@
+import { test, expect } from "@playwright/test"
+import {
+  nextAttributeMutationNamed,
+  nextBeat,
+  nextEventNamed,
+  nextEventOnTarget,
+  noNextEventNamed,
+  noNextEventOnTarget
+} from "../helpers/page"
+
+test("renders a page refresh with morphing", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+})
+
+test("doesn't morph when the turbo-refresh-method meta tag is not 'morph'", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_replace.html")
+
+  await page.click("#form-submit")
+  expect(await noNextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+})
+
+test("doesn't morph when the navigation doesn't go to the same URL", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.click("#link")
+  await expect(page.locator("h1")).toHaveText("One")
+
+  expect(await noNextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+})
+
+test("uses morphing to update remote frames marked with refresh='morph'", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+  await nextBeat()
+
+  // Only the frame marked with refresh="morph" uses morphing
+  expect(await nextEventOnTarget(page, "refresh-morph", "turbo:before-frame-morph")).toBeTruthy()
+  expect(await noNextEventOnTarget(page, "refresh-reload", "turbo:before-frame-morph")).toBeTruthy()
+})
+
+test("it preserves the scroll position when the turbo-refresh-scroll meta tag is 'preserve'", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.evaluate(() => window.scrollTo(10, 10))
+  await assertPageScroll(page, 10, 10)
+
+  // not using page.locator("#form-submit").click() because it can reset the scroll position
+  await page.evaluate(() => document.getElementById("form-submit")?.click())
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  await assertPageScroll(page, 10, 10)
+})
+
+test("it resets the scroll position when the turbo-refresh-scroll meta tag is 'reset'", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_scroll_reset.html")
+
+  await page.evaluate(() => window.scrollTo(10, 10))
+  await assertPageScroll(page, 10, 10)
+
+  // not using page.locator("#form-submit").click() because it can reset the scroll position
+  await page.evaluate(() => document.getElementById("form-submit")?.click())
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  await assertPageScroll(page, 0, 0)
+})
+
+test("it preserves data-turbo-permanent elements", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.evaluate(() => {
+    const element = document.getElementById("preserve-me")
+    element.textContent = "Preserve me, I have a family!"
+  })
+
+  await expect(page.locator("#preserve-me")).toHaveText("Preserve me, I have a family!")
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  await expect(page.locator("#preserve-me")).toHaveText("Preserve me, I have a family!")
+})
+
+test("it reloads data-controller attributes after a morph", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  expect(
+    await nextAttributeMutationNamed(page, "stimulus-controller", "data-controller")
+  ).toEqual(null)
+
+  await nextBeat()
+
+  expect(
+    await nextAttributeMutationNamed(page, "stimulus-controller", "data-controller")
+  ).toEqual("test")
+})
+
+async function assertPageScroll(page, top, left) {
+  const [scrollTop, scrollLeft] = await page.evaluate(() => {
+    return [
+      document.documentElement.scrollTop || document.body.scrollTop,
+      document.documentElement.scrollLeft || document.body.scrollLeft
+    ]
+  })
+
+  expect(scrollTop).toEqual(top)
+  expect(scrollLeft).toEqual(left)
+}

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -68,11 +68,13 @@ export function nextBody(_page, timeout = 500) {
   return sleep(timeout)
 }
 
-export async function nextEventNamed(page, eventName) {
+export async function nextEventNamed(page, eventName, expectedDetail = {}) {
   let record
   while (!record) {
     const records = await readEventLogs(page, 1)
-    record = records.find(([name]) => name == eventName)
+    record = records.find(([name, detail]) => {
+      return name == eventName && Object.entries(expectedDetail).every(([key, value]) => detail[key] === value)
+    })
   }
   return record[1]
 }
@@ -126,9 +128,11 @@ export async function noNextAttributeMutationNamed(page, elementId, attributeNam
   return !records.some(([name, _, target]) => name == attributeName && target == elementId)
 }
 
-export async function noNextEventNamed(page, eventName) {
-  const records = await readEventLogs(page, 1)
-  return !records.some(([name]) => name == eventName)
+export async function noNextEventNamed(page, eventName, expectedDetail = {}) {
+  const records = await readEventLogs(page)
+  return !records.some(([name, detail]) => {
+    return name === eventName && Object.entries(expectedDetail).every(([key, value]) => value === detail[key])
+  })
 }
 
 export async function noNextEventOnTarget(page, elementId, eventName) {

--- a/src/tests/unit/limited_set_tests.js
+++ b/src/tests/unit/limited_set_tests.js
@@ -1,0 +1,17 @@
+import { assert } from "@open-wc/testing"
+import { LimitedSet } from "../../core/drive/limited_set"
+
+test("add a limited number of elements", () => {
+  const set = new LimitedSet(3)
+  set.add(1)
+  set.add(2)
+  set.add(3)
+  set.add(4)
+
+  assert.equal(set.size, 3)
+
+  assert.notInclude(set, 1)
+  assert.include(set, 2)
+  assert.include(set, 3)
+  assert.include(set, 4)
+})

--- a/src/tests/unit/stream_element_tests.js
+++ b/src/tests/unit/stream_element_tests.js
@@ -2,6 +2,8 @@ import { StreamElement } from "../../elements"
 import { nextAnimationFrame } from "../../util"
 import { DOMTestCase } from "../helpers/dom_test_case"
 import { assert } from "@open-wc/testing"
+import { nextBeat } from "../helpers/page"
+import * as Turbo from "../../index"
 
 function createStreamElement(action, target, templateElement) {
   const element = new StreamElement()
@@ -166,4 +168,31 @@ test("test action=before", async () => {
   assert.ok(subject.find("div#hello"))
   assert.ok(subject.find("h1#before"))
   assert.isNull(element.parentElement)
+})
+
+test("test action=refresh", async () => {
+  document.body.setAttribute("data-modified", "")
+  assert.ok(document.body.hasAttribute("data-modified"))
+
+  const element = createStreamElement("refresh")
+  subject.append(element)
+
+  await nextBeat()
+
+  assert.notOk(document.body.hasAttribute("data-modified"))
+})
+
+test("test action=refresh discarded when matching request id", async () => {
+  Turbo.recentRequests.add("123")
+
+  document.body.setAttribute("data-modified", "")
+  assert.ok(document.body.hasAttribute("data-modified"))
+
+  const element = createStreamElement("refresh")
+  element.setAttribute("request-id", "123")
+  subject.append(element)
+
+  await nextBeat()
+
+  assert.ok(document.body.hasAttribute("data-modified"))
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,6 +1865,10 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
+"idiomorph@https://github.com/basecamp/idiomorph#rollout-build":
+  version "0.0.8"
+  resolved "https://github.com/basecamp/idiomorph#e906820368e4c9c52489a3336b8c3826b1bf6de5"
+
 ieee754@^1.1.13:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"


### PR DESCRIPTION
This PR introduces the concept of *page refresh*. A page refresh happens when Turbo renders the current page again. We will offer two new options to control behavior when a page refresh happens:

- The method used to update the page: with a new option to use morphing (Turbo currently replaces the body).

- The scroll strategy: with a new option to keep it (Turbo currently resets scroll to the top-left).

The combination of morphing and scroll-keeping results in smoother updates that keep the screen state. For example, this will keep both horizontal and vertical scroll, the focus, the text selection, CSS transition states, etc.

We will also introduce a new turbo stream action that, when broadcasted, will request a page refresh. This will offer a simplified alternative to fine-grained broadcasted turbo-stream actions.

https://github.com/basecamp/turbo-private/assets/150107/a2ded86c-e68e-44ab-b07a-78fd7d20c6b2

By @afcapel and @jorgemanrubia.

## API

### Page refresh configuration

Turbo will detect page refreshes automatically when it renders the current location again. The user configures how those page refreshes are handled.

#### Configurable refresh method

```html
<meta name="turbo-refresh-method" content="replace|morph">
```

* `replace`: Current behavior: it replaces the body.
* `morph`: It morphs the existing body to become the new body.

The default is `replace`. We may switch to `morph` eventually.

#### Configurable scroll behavior:

```html
<meta name="turbo-refresh-scroll" content="reset|preserve">
```

* `reset`: Current behavior: it resets the scroll to the top-left.
* `preserve`: It keeps the scroll in place.

The default is `reset`. We may switch to `preserve` eventually.

#### Support via helpers

==See companion PR in `turbo-rails`==.

```ruby
turbo_refreshes_with scroll method: :morph, scroll: :preserve
```

#### Exclude sections from morphing

There are scenarios where you might want to define sections that you want to ignore while morphing. The most common scenario is a popover or similar UI elements, which state you want to preserve when the page refreshes. We reuse the existing `data-turbo-permanent` attribute to flag such elements.

```html
<div data-turbo-permanent>...</div>
```

#### Reload turbo frames on page refreshes

Refreshing the current page presents a challenge if the page has loaded additional content dynamically. For example, if you have loaded new pages of data. You don’t want to lose that data when a page refresh happens. If the user can act on that data, you want to see it refreshed too.

To deal with this, it will reload turbo-frames with a `src` attribute that are flagged with `[refresh=reload]`. And it will use the configured page refresh method to reload those. 

```html
<turbo-frame refresh="reload">...</turbo-frame>
```

### Broadcast changes

#### Turbo stream action to signal a refresh

This introduces a new turbo stream action called `refresh` that will trigger a page refresh:

```html
<turbo-stream action="refresh"></turbo-stream>
```

#### Broadcast changes that require a page refresh

There is a new method in active record's models to broadcast a *page refresh signal* when the record changes. This is implemented internally by broadcasting the turbo stream action referred to above.

```ruby
module Recording::Broadcasting
  extend ActiveSupport::Concern

  included do
    broadcasts_refreshes_to :bucket
  end
end
```

In view templates, you would subscribe to these updates using the regular turbo_stream_from helper:

```ruby
turbo_stream_from bucket
```

The system will debounce automatically sequences of updates since it doesn't make sense to trigger multiple signals for multiple updates in a row. 

⚠️ ⚠️ ==You can learn more about the Rails helpers in the companion PR in `turbo-rails`==.

## Implementation notes

### Idiomorph

We started with [`morphdom`](https://github.com/patrick-steele-idem/morphdom) as the DOM-tree morphing library but we eventually changed to [`idiomorph`](https://github.com/bigskysoftware/idiomorph). The reason is that we found `morphdom` to be very picky about `ids` when matching nodes, when `idiomorph` is way more relaxed. In practice, we found that with `morphdom` you had to keep adding `ids` everywhere if you wanted morphing to work, while `idiomorph` worked out of the box with pretty complex HTML structures.

### Mechanism against bounced signals

The system includes a mechanism to ignore refresh actions that originated in a web request that originated in the same browser session. To enable this, these refresh actions can carry a `request-id` attribute to track the request that originated them. Turbo will keep a list of recent requests and, when there is a match, the stream action is discarded.

This is implemented by patching `fetch` to inject a random request id in a custom header `X-Turbo-Request-Id`. We originally intended to use the Rails' standard `X-Request-Id` in the response, but we found a blocking problem: it's not possible with Javascript to read the response headers in a redirect response, you can just read the headers in the target destination response.

The server side where the broadcasts originate is responsible for using that header to flag broadcasted page refreshes with it (==see `turbo-rails` PR with the reference implementation == ).

## Pending

- [ ] Document in guides.
- [ ] Complete code documentation.