### PR TITLE
Add test coverage for `StreamActions` export

### DIFF
--- a/src/tests/unit/export_tests.js
+++ b/src/tests/unit/export_tests.js
@@ -1,7 +1,9 @@
 import { assert } from "@open-wc/testing"
-import * as Turbo from "../../index"
+import * as Turbo from "../../"
+import { StreamActions } from "../../"
 
 test("test Turbo interface", () => {
+  assert.equal(typeof Turbo.StreamActions, "object")
   assert.equal(typeof Turbo.start, "function")
   assert.equal(typeof Turbo.registerAdapter, "function")
   assert.equal(typeof Turbo.visit, "function")
@@ -15,4 +17,8 @@ test("test Turbo interface", () => {
   assert.equal(typeof Turbo.cache, "object")
   assert.equal(typeof Turbo.navigator, "object")
   assert.equal(typeof Turbo.session, "object")
+})
+
+test("test StreamActions interface", () => {
+  assert.equal(typeof StreamActions, "object")
 })


### PR DESCRIPTION
According to the [official documentation][], applications that need to extend `StreamActions` should be importing it directly from the module instead of accessing it through `window.Turbo.StreamActions`.

This commit adds test coverage to exercise the corresponding `import`. It also re-arranges the `export` to explicitly occur in the `@hotwired/turbo` module itself, instead of being transitively exported as part of the `@hotwired/turbo/core` module.

[official documentation]: https://turbo.hotwired.dev/handbook/streams#custom-actions