### PR TITLE
Move `Cache` instantiation to `Session`

### DIFF
--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -2,10 +2,6 @@ import { setMetaContent } from "../util"
 import { SnapshotCache } from "./drive/snapshot_cache"
 
 export class Cache {
-  constructor(session) {
-    this.session = session
-  }
-
   clear() {
     this.store.clear()
   }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -1,13 +1,11 @@
 import { Session } from "./session"
-import { Cache } from "./cache"
 import { PageRenderer } from "./drive/page_renderer"
 import { PageSnapshot } from "./drive/page_snapshot"
 import { FrameRenderer } from "./frames/frame_renderer"
 import { FormSubmission } from "./drive/form_submission"
 
 const session = new Session()
-const cache = new Cache(session)
-const { navigator } = session
+const { cache, navigator } = session
 export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer }
 
 export { StreamActions } from "./streams/stream_actions"

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -16,6 +16,7 @@ import { clearBusyState, dispatch, findClosestRecursively, getVisitAction, markA
 import { PageView } from "./drive/page_view"
 import { FrameElement } from "../elements/frame_element"
 import { Preloader } from "./drive/preloader"
+import { Cache } from "./cache"
 
 export class Session {
   navigator = new Navigator(this)
@@ -33,6 +34,7 @@ export class Session {
   formLinkClickObserver = new FormLinkClickObserver(this, document.documentElement)
   frameRedirector = new FrameRedirector(this, document.documentElement)
   streamMessageRenderer = new StreamMessageRenderer()
+  cache = new Cache()
 
   drive = true
   enabled = true


### PR DESCRIPTION
When the `Cache` class was [introduced in a54ac17][], it depended on a `Session` instance. When it was [modified in f86a376][], that dependency was no longer necessary.

This commit preserves the export of the `Turbo.cache` property while re-arranging the location it's declared. Instead of instantiating the `Cache` instance in `@hotwired/turbo/core/`, this commit defines it as a property on the `Session` instance.

[introduced in a54ac17]: https://github.com/hotwired/turbo/commit/a54ac176a707487feee0424b8d719927305c8b7a
[modified in f86a376]: https://github.com/hotwired/turbo/commit/f86a376b0d088c8ff83ef8180b95d492527902e5