### PR TITLE
Infer `renderElement` during `Renderer` construction

### DIFF
--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -19,7 +19,7 @@ export class PageView extends View {
     const shouldMorphPage = this.isPageRefresh(visit) && this.snapshot.shouldMorphPage
     const rendererClass = shouldMorphPage ? MorphingPageRenderer : PageRenderer
 
-    const renderer = new rendererClass(this.snapshot, snapshot, rendererClass.renderElement, isPreview, willRender)
+    const renderer = new rendererClass(this.snapshot, snapshot, isPreview, willRender)
 
     if (!renderer.shouldRender) {
       this.forceReloaded = true
@@ -32,7 +32,7 @@ export class PageView extends View {
 
   renderError(snapshot, visit) {
     visit?.changeHistory()
-    const renderer = new ErrorRenderer(this.snapshot, snapshot, ErrorRenderer.renderElement, false)
+    const renderer = new ErrorRenderer(this.snapshot, snapshot, false)
     return this.render(renderer)
   }
 

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -11,4 +11,8 @@ export class MorphingFrameRenderer extends FrameRenderer {
 
     morphChildren(currentElement, newElement)
   }
+
+  async preservingPermanentElements(callback) {
+    return await callback()
+  }
 }

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -3,12 +3,16 @@ import { Bardo } from "./bardo"
 export class Renderer {
   #activeElement = null
 
-  constructor(currentSnapshot, newSnapshot, renderElement, isPreview, willRender = true) {
+  static renderElement(currentElement, newElement) {
+    // Abstract method
+  }
+
+  constructor(currentSnapshot, newSnapshot, isPreview, willRender = true) {
     this.currentSnapshot = currentSnapshot
     this.newSnapshot = newSnapshot
     this.isPreview = isPreview
     this.willRender = willRender
-    this.renderElement = renderElement
+    this.renderElement = this.constructor.renderElement
     this.promise = new Promise((resolve, reject) => (this.resolvingFunctions = { resolve, reject }))
   }
 

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -41,6 +41,7 @@
       <a id="link-frame-with-search-params" href="/src/tests/fixtures/frames/frame.html?key=value">Navigate #frame with ?key=value</a>
       <a id="link-nested-frame-action-advance" href="/src/tests/fixtures/frames/frame.html" data-turbo-action="advance">Navigate #frame from within with a[data-turbo-action="advance"]</a>
       <a id="link-top" href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
+      <input id="permanent-input" data-turbo-permanent>
       <form action="/src/tests/fixtures/one.html" data-turbo-frame="_top">
         <button id="form-submit-top">Visit one.html</button>
       </form>

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -306,6 +306,18 @@ test("calling reload on a frame[refresh=morph] morphs the contents", async ({ pa
   expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
 })
 
+test("calling reload on a frame[refresh=morph] preserves [data-turbo-permanent] elements", async ({ page }) => {
+  await page.click("#add-src-to-frame")
+  await page.click("#add-refresh-morph-to-frame")
+  const input = await page.locator("#permanent-input")
+
+  await input.fill("Preserve me")
+  await page.evaluate(() => document.getElementById("frame").reload())
+
+  await expect(input).toBeFocused()
+  await expect(input).toHaveValue("Preserve me")
+})
+
 test("following a link in rapid succession cancels the previous request", async ({ page }) => {
   await page.click("#outside-frame-form")
   await page.click("#outer-frame-link")


### PR DESCRIPTION
Follow-up to [#1192][]
Closes [#1303][]

Remove the argument from all `Renderer` subclass constructor call sites.
In its place, define the default value for the `Renderer.renderElement`
property based on the `static renderElement(currentElement, newElement)`
defined by the inheriting class.

By automatically determining which `renderElement` implementation based
on class, this commit enables a simpler Frame morphing strategy. Instead
of attaching one-time event listeners, this commit maintains a private
`#shouldMorphFrame` property that is set, then un-set during the
rendering lifecycle of a frame.

Similarly, this commit implements the
`MorphingFrameRenderer.preservingPermanentElements` method in the same
style as the `MorphingPageRenderer.preservingPermanentElements`. Since
_instances_ of `MorphingFrameRenderer` are now being used instead of the
static `MorphingFrameRenderer.renderElement`, we're able to utilize an
instance method instead of passing around an additional anonymous
function (which is the implementation that [#1303][] proposed).

[#1192]: https://github.com/hotwired/turbo/pull/1192
[#1303]: https://github.com/hotwired/turbo/pull/1303

Co-authored-by: Micah Geisel <micah@botandrose.com>