### PR TITLE
Dispatch `turbo:before-fetch-{request,response}` during preloading

### DIFF
--- a/src/tests/fixtures/hot_preloading.html
+++ b/src/tests/fixtures/hot_preloading.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <title>Page That Links to Preloading Page</title>
   <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  <script src="/src/tests/fixtures/test.js"></script>
 </head>
 
 <body>

--- a/src/tests/fixtures/preloaded.html
+++ b/src/tests/fixtures/preloaded.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <title>Preloaded Page</title>
   <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  <script src="/src/tests/fixtures/test.js"></script>
 </head>
 
 <body>

--- a/src/tests/fixtures/preloading.html
+++ b/src/tests/fixtures/preloading.html
@@ -5,6 +5,7 @@
   <meta charset="utf-8">
   <title>Preloading Page</title>
   <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
 </head>
 
 <body>

--- a/src/tests/functional/preloader_tests.js
+++ b/src/tests/functional/preloader_tests.js
@@ -12,6 +12,20 @@ test("preloads snapshot on initial load", async ({ page }) => {
   assert.ok(await urlInSnapshotCache(page, href))
 })
 
+test("preloading dispatch turbo:before-fetch-{request,response} events", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/preloading.html")
+
+  const link = await page.locator("#preload_anchor")
+  const href = await link.evaluate((link) => link.href)
+
+  const { url, fetchOptions } = await nextEventOnTarget(page, "preload_anchor", "turbo:before-fetch-request")
+  const { fetchResponse } = await nextEventOnTarget(page, "preload_anchor", "turbo:before-fetch-response")
+
+  assert.equal(href, url, "dispatches request during preloading")
+  assert.equal(fetchOptions.headers.Accept, "text/html, application/xhtml+xml")
+  assert.equal(fetchResponse.response.url, href)
+})
+
 test("preloads snapshot on page visit", async ({ page }) => {
   // contains `a[rel="preload"][href="http://localhost:9000/src/tests/fixtures/preloading.html"]`
   await page.goto("/src/tests/fixtures/hot_preloading.html")


### PR DESCRIPTION
Closes [#963][]

Replace the raw call to `fetch` with a new `FetchRequest` instance that treats the `Preloaded` instances as its delegate. During that request's lifecycle, dispatch the `turbo:before-fetch-request` and `turbo:before-fetch-response` events with the `<a>` element as its target.

Prepare the request with the [Sec-Purpose][] header in the `prepareRequest` delegate callback.

Write to the snapshot cache from within the
`requestSucceededWithResponse` delegate callback.

[#963]: https://github.com/hotwired/turbo/issues/963
[Sec-Purpose]: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Sec-Purpose#prefetch