### PR TITLE
Hide Progress bar on `turbo:load`

### DIFF
--- a/src/core/native/browser_adapter.js
+++ b/src/core/native/browser_adapter.js
@@ -54,18 +54,21 @@ export class BrowserAdapter {
     }
   }
 
-  visitRequestFinished(_visit) {
+  visitRequestFinished(_visit) {}
+
+  visitCompleted(_visit) {
     this.progressBar.setValue(1)
     this.hideVisitProgressBar()
   }
-
-  visitCompleted(_visit) {}
 
   pageInvalidated(reason) {
     this.reload(reason)
   }
 
-  visitFailed(_visit) {}
+  visitFailed(_visit) {
+    this.progressBar.setValue(1)
+    this.hideVisitProgressBar()
+  }
 
   visitRendered(_visit) {}
 

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -80,6 +80,7 @@
         </turbo-toggle>
       </p>
       <p><a id="delayed-link" href="/__turbo/delayed_response">Delayed link</a></p>
+      <p><a id="delayed-failure-link" href="/__turbo/delayed_response?status=500">Delayed failure link</a></p>
       <p><a id="link-target-iframe" href="/src/tests/fixtures/one.html" target="iframe">Targets iframe[name="iframe"]</a></p>
       <p><a id="link-target-empty-name-iframe" href="/src/tests/fixtures/one.html" target="">Targets iframe[name=""]</a></p>
       <p>

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -79,8 +79,9 @@ router.get("/headers", (request, response) => {
 })
 
 router.get("/delayed_response", (request, response) => {
+  const { status } = request.query
   const fixture = path.join(__dirname, "../../src/tests/fixtures/one.html")
-  setTimeout(() => response.status(200).sendFile(fixture), 1000)
+  setTimeout(() => response.status(parseInt(status || "200")).sendFile(fixture), 1000)
 })
 
 router.post("/messages", (request, response) => {


### PR DESCRIPTION
Closes [#962][]

Prior to this commit, the progress bar is hidden between the Turbo Drive visits' `turbo:before-fetch-response` event and the `turbo:render` event.

This commit changes that behavior to hide the bar when the Visit is complete (some time prior to the `turbo:load` event).

[#962]: https://github.com/hotwired/turbo/issues/962