### PR TITLE
Handle `<turbo-stream>` name collisions with `<form>` controls

### DIFF
--- a/src/tests/fixtures/stream.html
+++ b/src/tests/fixtures/stream.html
@@ -26,6 +26,16 @@
       <button>Receive Message</button>
     </form>
 
+    <form id="form_with_action_names">
+      <input name="after" type="hidden">
+      <input name="append" type="hidden">
+      <input name="before" type="hidden">
+      <input name="prepend" type="hidden">
+      <input name="remove" type="hidden">
+      <input name="replace" type="hidden">
+      <input name="update" type="hidden">
+    </form>
+
     <div id="messages">
       <div class="message">First</div>
     </div>

--- a/src/tests/functional/stream_tests.js
+++ b/src/tests/functional/stream_tests.js
@@ -182,6 +182,92 @@ test("test receiving a remove stream message preserves focus blurs the activeEle
   assert.notOk(await hasSelector(page, ":focus"))
 })
 
+test("test receiving an [action=after] targeting a form", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="after" target="form_with_action_names">
+        <template><p id="after_form_with_action_names">After</p></template>
+      </turbo-stream>
+    `)
+  )
+
+  assert.equal(await page.textContent("#after_form_with_action_names"), "After")
+})
+
+test("test receiving an [action=append] targeting a form", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="append" target="form_with_action_names">
+        <template>Append</template>
+      </turbo-stream>
+    `)
+  )
+  await nextBeat()
+
+  assert.include(await page.textContent("#form_with_action_names"), "Append")
+})
+
+test("test receiving an [action=before] targeting a form", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="before" target="form_with_action_names">
+        <template><p id="before_form_with_action_names">Before</p></template>
+      </turbo-stream>
+    `)
+  )
+
+  assert.equal(await page.textContent("#before_form_with_action_names"), "Before")
+})
+
+test("test receiving an [action=prepend] targeting a form", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="prepend" target="form_with_action_names">
+        <template>Prepend</template>
+      </turbo-stream>
+    `)
+  )
+  await nextBeat()
+
+  assert.include(await page.textContent("#form_with_action_names"), "Prepend")
+})
+
+test("test receiving an [action=remove] targeting a form", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="remove" target="form_with_action_names"></turbo-stream>
+    `)
+  )
+
+  assert.notOk(await waitUntilNoSelector(page, "#form_with_action_names"), "removes target element")
+})
+
+test("test receiving an [action=replace] targeting a form", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="replace" target="form_with_action_names">
+        <template><div id="form_with_action_names"></div></template>
+      </turbo-stream>
+    `)
+  )
+
+  assert.notOk(await hasSelector(page, "form#form_with_action_names"))
+  assert.ok(await hasSelector(page, "div#form_with_action_names"))
+})
+
+test("test receiving an [action=update] targeting a form", async ({ page }) => {
+  await page.evaluate(() =>
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="update" target="form_with_action_names">
+        <template><input name="updated_field"></template>
+      </turbo-stream>
+    `)
+  )
+  await nextBeat()
+
+  assert.ok(await hasSelector(page, "#form_with_action_names [name=updated_field]"))
+})
+
 async function getReadyState(page, id) {
   return page.evaluate((id) => {
     const element = document.getElementById(id)


### PR DESCRIPTION
Closes [#929][]

At the very least, we should provide guidance based on MDN's [Issues with Naming Elements][]:

> Some names will interfere with JavaScript access to the form's
> properties and elements.
>
> For example:
>

> `<input name="id">` will take precedence over `<form id="…">`. This
> means that `form.id` will not refer to the form's `id`, but to the
> element whose `name` is `"id"`. This will be the case with any other
> form properties, such as `<input name="action">` or `<input
> name="post">`. `<input name="elements">` will render the form's
> `elements` collection inaccessible. The reference `form.elements` will
> now refer to the individual element.
>
> To avoid such problems with element names:
>

> * Always use the `elements` collection to avoid ambiguity between an
>   element `name` and a form property.
> * Never use `"elements"` as an element name.

To guard against future regressions, this commit adds coverage for the `stream.html` fixture page by rendering a `<form>` element with `<input type="hidden">` elements whose names match each `StreamActions` function.

[#929]: https://github.com/hotwired/turbo/issues/929
[Issues with Naming Elements]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLFormElement#issues_with_naming_elements