### PR TITLE
Add control to preserve scroll during Drive visits

### DIFF
--- a/src/core/drive/page_snapshot.js
+++ b/src/core/drive/page_snapshot.js
@@ -73,6 +73,10 @@ export class PageSnapshot extends Snapshot {
     return this.headSnapshot.getMetaValue("view-transition") === "same-origin"
   }
 
+  get shouldPreserveScrollPosition() {
+    return this.getSetting("scroll") === "preserve"
+  }
+
   // Private
 
   getSetting(name) {

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -335,7 +335,7 @@ export class Visit {
   // Scrolling
 
   performScroll() {
-    if (!this.scrolled && !this.view.forceReloaded) {
+    if (!this.scrolled && !this.view.forceReloaded && !this.view.snapshot.shouldPreserveScrollPosition) {
       if (this.action == "restore") {
         this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()
       } else {

--- a/src/tests/fixtures/scroll_restoration/preserve.html
+++ b/src/tests/fixtures/scroll_restoration/preserve.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="turbo-scroll" content="preserve">
     <title>Scroll Restoration</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>

--- a/src/tests/fixtures/scroll_restoration/reset.html
+++ b/src/tests/fixtures/scroll_restoration/reset.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <meta charset="utf-8">
+    <meta name="turbo-scroll" content="reset">
     <title>Scroll Restoration</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>

--- a/src/tests/functional/scroll_preservation_tests.js
+++ b/src/tests/functional/scroll_preservation_tests.js
@@ -1,0 +1,45 @@
+import { test, expect } from "@playwright/test"
+import { nextEventNamed } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_restoration.html")
+})
+
+test("it preserves the scroll position when the turbo-scroll meta tag is 'preserve'", async ({ page }) => {
+  const preserve = await page.locator("#preserve")
+  await preserve.scrollIntoViewIfNeeded()
+
+  const [ scrollTop, scrollLeft ] = await page.evaluate(() => [window.scrollY, window.scrollX])
+
+  await clickWithoutScrolling(preserve)
+  await nextEventNamed(page, "turbo:render")
+
+  await assertPageScroll(page, scrollTop, scrollLeft)
+})
+
+test("it resets the scroll position when the turbo-scroll meta tag is 'reset'", async ({ page }) => {
+  const reset = await page.locator("#reset")
+  await reset.scrollIntoViewIfNeeded()
+
+  await clickWithoutScrolling(reset)
+  await nextEventNamed(page, "turbo:render")
+
+  await assertPageScroll(page, 0, 0)
+})
+
+async function clickWithoutScrolling(locator) {
+  // not using locator.click() because it can reset the scroll position
+  await locator.evaluate((element) => element.click())
+}
+
+async function assertPageScroll(page, top, left) {
+  const [scrollTop, scrollLeft] = await page.evaluate(() => {
+    return [
+      document.documentElement.scrollTop || document.body.scrollTop,
+      document.documentElement.scrollLeft || document.body.scrollLeft
+    ]
+  })
+
+  expect(scrollTop).toEqual(top)
+  expect(scrollLeft).toEqual(left)
+}


### PR DESCRIPTION
Extracted from [#1019][]

Add support for preserving scroll changes from page to page. Controlled by the presence of the `<meta name="turbo-scroll">` element in the `<head>`.

To preserve:

```html
<meta name="turbo-scroll" content="preserve">
```

To reset:

```html
<meta name="turbo-scroll" content="reset">
```

[#1019]: https://github.com/hotwired/turbo/pull/1019

Co-authored-by: Alberto Fernández-Capel <afcapel@gmail.com>
Co-Authored-By: Jorge Manrubia <jorge@hey.com>