### PR TITLE
Do not dispatch multiple visit events on redirect visit

### DIFF
--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -128,12 +128,9 @@ export class Visit {
     if (this.state == VisitState.started) {
       this.recordTimingMetric(TimingMetric.visitEnd)
       this.state = VisitState.completed
-      this.followRedirect()
 
-      if (!this.followedRedirect) {
-        this.adapter.visitCompleted(this)
-        this.delegate.visitCompleted(this)
-      }
+      this.adapter.visitCompleted(this)
+      this.delegate.visitCompleted(this)
     }
   }
 
@@ -147,6 +144,7 @@ export class Visit {
 
   changeHistory() {
     if (!this.historyChanged && this.updateHistory) {
+      this.followRedirect()
       const actionForHistory = this.location.href === this.referrer?.href ? "replace" : this.action
       const method = getHistoryMethodForAction(actionForHistory)
       this.history.update(method, this.location, this.restorationIdentifier)
@@ -259,12 +257,7 @@ export class Visit {
 
   followRedirect() {
     if (this.redirectedToLocation && !this.followedRedirect && this.response?.redirected) {
-      this.adapter.visitProposedToLocation(this.redirectedToLocation, {
-        action: "replace",
-        response: this.response,
-        shouldCacheSnapshot: false,
-        willRender: false
-      })
+      this.location = this.redirectedToLocation
       this.followedRedirect = true
     }
   }

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -361,7 +361,7 @@ test("test following a redirection", async ({ page }) => {
   await page.click("#redirection-link")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "replace")
+  assert.equal(await visitAction(page), "advance")
 })
 
 test("test clicking the back button after redirection", async ({ page }) => {


### PR DESCRIPTION
https://github.com/hotwired/turbo/pull/328 fixed an issue with the window's location in native adapters (https://github.com/hotwired/turbo-ios/issues/30 & https://github.com/hotwired/turbo-android/issues/128).

However, proposing a new visit re-runs the visit lifecycle again, duplicating events, and introduced issues such as https://github.com/hotwired/turbo/issues/428, https://github.com/hotwired/turbo/issues/526, https://github.com/hotwired/turbo/issues/537 & https://github.com/hotwired/turbo/issues/877.

This pull request reverts the visit proposal, and instead updates the location as part of `changeHistory()`. (This may not have been doable before https://github.com/hotwired/turbo/pull/601.) It leads to a simpler `followRedirect` method that now just updates the visit's location. As such, we no longer need the fix from https://github.com/hotwired/turbo/pull/563.

Fixes #877 