### PR TITLE
Content Security Policy tests

### DIFF
--- a/src/tests/fixtures/content_security_policy_with_nonce.html
+++ b/src/tests/fixtures/content_security_policy_with_nonce.html
@@ -1,0 +1,13 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Turbo</title>
+    <meta name="csp-nonce" content="123" />
+    <script src="/src/tests/fixtures/test.js" nonce="testHelpers"></script>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload" nonce="123"></script>
+  </head>
+  <body>
+    Content Security Policy Test Page with nonce
+  </body>
+</html>

--- a/src/tests/fixtures/content_security_policy_without_nonce.html
+++ b/src/tests/fixtures/content_security_policy_without_nonce.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Turbo</title>
+    <script src="/src/tests/fixtures/test.js" nonce="testHelpers"></script>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    Content Security Policy Test Page without nonce
+  </body>
+</html>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -65,6 +65,18 @@
     },
     { once: true }
   )
+
+  if (typeof window.ReportingObserver === 'function') {
+    window.cspViolations = []
+    // eslint-disable-next-line no-undef
+    new ReportingObserver((reports) => {
+      for (const report of reports) {
+        if (report.type === "csp-violation") {
+          window.cspViolations.push(report)
+        }
+      }
+    }, { buffered: false }).observe()
+  }
 })([
   "turbo:click",
   "turbo:before-stream-render",

--- a/src/tests/functional/content_security_policy_tests.js
+++ b/src/tests/functional/content_security_policy_tests.js
@@ -1,0 +1,60 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import {
+  readCspViolations
+} from "../helpers/page"
+
+test.describe('ReportingObserver supported', () => {
+  test.skip(async ({ page }) => { return page.evaluate(() => typeof window.ReportingObserver !== 'function') }, "ReportingObserver is not supported in this environment")
+
+  test("Content Security Policy - reject all", async ({ page }) => {
+    await page.goto("/__turbo/csp?default-src='none'&script-src='nonce-testHelpers'&file=../../src/tests/fixtures/content_security_policy_without_nonce.html")
+
+    const cspReports = await readCspViolations(page, 10)
+    assert.equal(cspReports.length, 1, "reports CSP violations")
+    assert.equal(cspReports[0].body.blockedURL, "http://localhost:9000/dist/turbo.es2017-umd.js", "CSP violation blockedURL")
+  })
+
+  test("Content Security Policy - script-src-elem=self", async ({ page }) => {
+    await page.goto("/__turbo/csp?default-src='self'&script-src-elem='self' 'nonce-testHelpers'&file=../../src/tests/fixtures/content_security_policy_without_nonce.html")
+
+    const cspReports = await readCspViolations(page, 10)
+    assert.equal(cspReports.length, 1, "reports CSP violations")
+    assert.equal(cspReports[0].body.effectiveDirective, "style-src-elem", "CSP violation directive (style-src-elem)")
+    assert.equal(cspReports[0].body.blockedURL, "inline", "CSP violation blockedURL (inline)")
+  })
+
+  test("Content Security Policy - script-src-elem=self&style-src-elem=unsafe-inline", async ({ page }) => {
+    await page.goto("/__turbo/csp?default-src='self'&script-src-elem='self' 'nonce-testHelpers'&style-src-elem='unsafe-inline'&file=../../src/tests/fixtures/content_security_policy_without_nonce.html")
+
+    assert.equal(
+      await page.locator("style").evaluate((style) => style.nonce),
+      "",
+      "renders progress bar stylesheet inline without nonce"
+    )
+    assert.equal((await readCspViolations(page, 10)).length, 0, "reports no CSP violations")
+  })
+
+  test("Content Security Policy - script-src-elem=self&style-src-elem=nonce=123", async ({ page, browserName }) => {
+    await page.goto("/__turbo/csp?default-src='self'&script-src-elem='self' 'nonce-testHelpers'&style-src-elem='nonce-123'&file=../../src/tests/fixtures/content_security_policy_with_nonce.html")
+
+    assert.equal(
+      await page.locator("style").evaluate((style) => style.nonce),
+      "123",
+      "renders progress bar stylesheet inline with nonce"
+    )
+    assert.equal((await readCspViolations(page, 10)).length, 0, "reports no CSP violations")
+  })
+
+  test("Content Security Policy - script-src-elem=self&style-src-elem='self' 'sha256-WAyOw4V+FqDc35lQPyRADLBWbuNK8ahvYEaQIYF1+Ps='", async ({ page }) => {
+    const progressBarStyleHash = encodeURIComponent("sha256-WAyOw4V+FqDc35lQPyRADLBWbuNK8ahvYEaQIYF1+Ps=");
+    await page.goto(`/__turbo/csp?default-src='self'&script-src-elem='self' 'nonce-testHelpers'&style-src-elem='self' '${progressBarStyleHash}'&file=../../src/tests/fixtures/content_security_policy_without_nonce.html`)
+
+    assert.equal(
+      await page.locator("style").evaluate((style) => style.nonce),
+      "",
+      "renders progress bar stylesheet inline without nonce"
+    )
+    assert.equal((await readCspViolations(page, 10)).length, 0, "reports no CSP violations")
+  })
+})

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -126,6 +126,10 @@ export async function noNextAttributeMutationNamed(page, elementId, attributeNam
   return !records.some(([name, _, target]) => name == attributeName && target == elementId)
 }
 
+export function readCspViolations(page, length) {
+  return readArray(page, "cspViolations", length)
+}
+
 export async function noNextEventNamed(page, eventName) {
   const records = await readEventLogs(page, 1)
   return !records.some(([name]) => name == eventName)

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -6,6 +6,7 @@ import path from "path"
 import url from "url"
 import { fileURLToPath } from 'url'
 import fs from "fs"
+import querystring from "querystring"
 
 const __filename = fileURLToPath(import.meta.url)
 const __dirname = path.dirname(__filename)
@@ -23,6 +24,22 @@ router.use((request, response, next) => {
   } else {
     response.sendStatus(422)
   }
+})
+
+router.get('/csp', (request, response) => {
+  const cspDirectives = request.query
+
+  const filepath = path.join(__dirname, cspDirectives.file)
+  delete cspDirectives.file
+
+  const cspHeaderValue = Object.entries(cspDirectives)
+    .map(([key, value]) => `${key} ${value}`)
+    .join('; ')
+
+  response.type('html')
+    .setHeader('Content-Security-Policy', cspHeaderValue)
+    .status(200)
+    .sendFile(filepath)
 })
 
 router.post("/redirect", (request, response) => {


### PR DESCRIPTION
Add tests validating if the content security policy works as expected, especially for the progress bar inline styles.

Turbo is currently lacking some tests around validating how it behaves with different CSP settings. This PR adds a new test server end point which lets you set the CSP headers on the response. Further it is making use of the new ReportingObserver to catch and log any CSP violations. Unfortunately on Firefox this functionality is behind a flag and only on their nightly builds - but the tests are using feature detection so when support lands they *should* hopefully start working.

Chrome docs: https://developer.chrome.com/articles/reporting-observer/
Firefox docs: https://developer.mozilla.org/en-US/docs/Web/API/ReportingObserver/ReportingObserver

I built these trying to debug a progress bar turbo frame issue I was seeing relating to #809, but it turns out we were running on a slightly older version of Turbo and this got fixed via https://github.com/hotwired/turbo/commit/ed72ba16bc23dcccd88e0ab76ba72cfef82cd599.
