### PR TITLE
Tests: remove `"test"` docstring prefix

### DIFF
--- a/src/tests/functional/async_script_tests.js
+++ b/src/tests/functional/async_script_tests.js
@@ -7,13 +7,13 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("test does not emit turbo:load when loaded asynchronously after DOMContentLoaded", async ({ page }) => {
+test("does not emit turbo:load when loaded asynchronously after DOMContentLoaded", async ({ page }) => {
   const events = await readEventLogs(page)
 
   assert.deepEqual(events, [])
 })
 
-test("test following a link when loaded asynchronously after DOMContentLoaded", async ({ page }) => {
+test("following a link when loaded asynchronously after DOMContentLoaded", async ({ page }) => {
   await page.click("#async-link")
 
   assert.equal(await visitAction(page), "advance")

--- a/src/tests/functional/autofocus_tests.js
+++ b/src/tests/functional/autofocus_tests.js
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/autofocus.html")
 })
 
-test("test autofocus first autofocus element on load", async ({ page }) => {
+test("autofocus first autofocus element on load", async ({ page }) => {
   await nextBeat()
   assert.ok(
     await hasSelector(page, "#first-autofocus-element:focus"),
@@ -18,7 +18,7 @@ test("test autofocus first autofocus element on load", async ({ page }) => {
   )
 })
 
-test("test autofocus first [autofocus] element on visit", async ({ page }) => {
+test("autofocus first [autofocus] element on visit", async ({ page }) => {
   await page.goto("/src/tests/fixtures/navigation.html")
   await page.click("#autofocus-link")
   await nextBeat()
@@ -33,7 +33,7 @@ test("test autofocus first [autofocus] element on visit", async ({ page }) => {
   )
 })
 
-test("test navigating a frame with a descendant link autofocuses [autofocus]:first-of-type", async ({ page }) => {
+test("navigating a frame with a descendant link autofocuses [autofocus]:first-of-type", async ({ page }) => {
   await page.click("#frame-inner-link")
   await nextBeat()
 
@@ -47,7 +47,7 @@ test("test navigating a frame with a descendant link autofocuses [autofocus]:fir
   )
 })
 
-test("test autofocus visible [autofocus] element on visit with inert elements", async ({ page }) => {
+test("autofocus visible [autofocus] element on visit with inert elements", async ({ page }) => {
   await page.click("#autofocus-inert-link")
   await nextBeat()
 
@@ -77,7 +77,7 @@ test("test autofocus visible [autofocus] element on visit with inert elements", 
   )
 })
 
-test("test navigating a frame with a link targeting the frame autofocuses [autofocus]:first-of-type", async ({
+test("navigating a frame with a link targeting the frame autofocuses [autofocus]:first-of-type", async ({
   page
 }) => {
   await page.click("#frame-outer-link")
@@ -93,7 +93,7 @@ test("test navigating a frame with a link targeting the frame autofocuses [autof
   )
 })
 
-test("test navigating a frame with a turbo-frame targeting the frame autofocuses [autofocus]:first-of-type", async ({
+test("navigating a frame with a turbo-frame targeting the frame autofocuses [autofocus]:first-of-type", async ({
   page
 }) => {
   await page.click("#drives-frame-target-link")
@@ -109,7 +109,7 @@ test("test navigating a frame with a turbo-frame targeting the frame autofocuses
   )
 })
 
-test("test receiving a Turbo Stream message with an [autofocus] element when the activeElement is the document", async ({ page }) => {
+test("receiving a Turbo Stream message with an [autofocus] element when the activeElement is the document", async ({ page }) => {
   await page.evaluate(() => {
     if (document.activeElement instanceof HTMLElement) {
       document.activeElement.blur()
@@ -128,7 +128,7 @@ test("test receiving a Turbo Stream message with an [autofocus] element when the
   )
 })
 
-test("test autofocus from a Turbo Stream message does not leak a placeholder [id]", async ({ page }) => {
+test("autofocus from a Turbo Stream message does not leak a placeholder [id]", async ({ page }) => {
   await page.evaluate(() => {
     if (document.activeElement instanceof HTMLElement) {
       document.activeElement.blur()
@@ -147,7 +147,7 @@ test("test autofocus from a Turbo Stream message does not leak a placeholder [id
   )
 })
 
-test("test receiving a Turbo Stream message with an [autofocus] element when an element within the document has focus", async ({ page }) => {
+test("receiving a Turbo Stream message with an [autofocus] element when an element within the document has focus", async ({ page }) => {
   await page.evaluate(() => {
     window.Turbo.renderStreamMessage(`
       <turbo-stream action="append" targets="body">

--- a/src/tests/functional/cache_observer_tests.js
+++ b/src/tests/functional/cache_observer_tests.js
@@ -2,7 +2,7 @@ import { test } from "@playwright/test"
 import { assert } from "chai"
 import { hasSelector, nextBody } from "../helpers/page"
 
-test("test removes temporary elements", async ({ page }) => {
+test("removes temporary elements", async ({ page }) => {
   await page.goto("/src/tests/fixtures/cache_observer.html")
 
   assert.equal(await page.textContent("#temporary"), "data-turbo-temporary")
@@ -15,7 +15,7 @@ test("test removes temporary elements", async ({ page }) => {
   assert.notOk(await hasSelector(page, "#temporary"))
 })
 
-test("test removes temporary elements with deprecated turbo-cache=false selector", async ({ page }) => {
+test("removes temporary elements with deprecated turbo-cache=false selector", async ({ page }) => {
   await page.goto("/src/tests/fixtures/cache_observer.html")
 
   assert.equal(await page.textContent("#temporary-with-deprecated-selector"), "data-turbo-cache=false")
@@ -28,7 +28,7 @@ test("test removes temporary elements with deprecated turbo-cache=false selector
   assert.notOk(await hasSelector(page, "#temporary-with-deprecated-selector"))
 })
 
-test("test following a redirect renders [data-turbo-temporary] elements before the cache removes", async ({ page }) => {
+test("following a redirect renders [data-turbo-temporary] elements before the cache removes", async ({ page }) => {
   await page.goto("/src/tests/fixtures/navigation.html")
   await page.click("#redirect-to-cache-observer")
   await nextBody(page)

--- a/src/tests/functional/drive_disabled_tests.js
+++ b/src/tests/functional/drive_disabled_tests.js
@@ -16,7 +16,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto(path)
 })
 
-test("test drive disabled by default; click normal link", async ({ page }) => {
+test("drive disabled by default; click normal link", async ({ page }) => {
   await page.click("#drive_disabled")
   await nextBody(page)
 
@@ -24,7 +24,7 @@ test("test drive disabled by default; click normal link", async ({ page }) => {
   assert.equal(await visitAction(page), "load")
 })
 
-test("test drive disabled by default; click link inside data-turbo='true'", async ({ page }) => {
+test("drive disabled by default; click link inside data-turbo='true'", async ({ page }) => {
   await page.click("#drive_enabled")
   await nextBody(page)
 
@@ -32,7 +32,7 @@ test("test drive disabled by default; click link inside data-turbo='true'", asyn
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test drive disabled by default; submit form inside data-turbo='true'", async ({ page }) => {
+test("drive disabled by default; submit form inside data-turbo='true'", async ({ page }) => {
   await setLocalStorageFromEvent(page, "turbo:submit-start", "formSubmitted", "true")
 
   await page.click("#no_submitter_drive_enabled a#requestSubmit")
@@ -44,17 +44,17 @@ test("test drive disabled by default; submit form inside data-turbo='true'", asy
   assert.equal(await searchParams(page.url()).get("greeting"), "Hello from a redirect")
 })
 
-test("test drive disabled by default; links within <turbo-frame> navigate with Turbo", async ({ page }) => {
+test("drive disabled by default; links within <turbo-frame> navigate with Turbo", async ({ page }) => {
   await page.click("#frame a")
   await nextEventOnTarget(page, "frame", "turbo:frame-render")
 })
 
-test("test drive disabled by default; forms within <turbo-frame> navigate with Turbo", async ({ page }) => {
+test("drive disabled by default; forms within <turbo-frame> navigate with Turbo", async ({ page }) => {
   await page.click("#frame button")
   await nextEventOnTarget(page, "frame", "turbo:frame-render")
 })
 
-test("test drive disabled by default; slot within <turbo-frame> navigate with Turbo", async ({ page }) => {
+test("drive disabled by default; slot within <turbo-frame> navigate with Turbo", async ({ page }) => {
   await page.click("#frame-navigation-with-slot")
   await nextEventOnTarget(page, "frame", "turbo:frame-render")
 })

--- a/src/tests/functional/drive_tests.js
+++ b/src/tests/functional/drive_tests.js
@@ -8,13 +8,13 @@ test.beforeEach(async ({ page }) => {
   await page.goto(path)
 })
 
-test("test drive enabled by default; click normal link", async ({ page }) => {
+test("drive enabled by default; click normal link", async ({ page }) => {
   await page.click("#drive_enabled")
   await nextBody(page)
   assert.equal(pathname(page.url()), path)
 })
 
-test("test drive to external link", async ({ page }) => {
+test("drive to external link", async ({ page }) => {
   await page.route("https://example.com", async (route) => {
     await route.fulfill({ body: "Hello from the outside world" })
   })
@@ -26,7 +26,7 @@ test("test drive to external link", async ({ page }) => {
   assert.equal(await page.textContent("body"), "Hello from the outside world")
 })
 
-test("test drive enabled by default; click link inside data-turbo='false'", async ({ page }) => {
+test("drive enabled by default; click link inside data-turbo='false'", async ({ page }) => {
   await page.click("#drive_disabled")
   await nextBody(page)
 

--- a/src/tests/functional/form_mode_tests.js
+++ b/src/tests/functional/form_mode_tests.js
@@ -2,63 +2,63 @@ import { test } from "@playwright/test"
 import { getFromLocalStorage, setLocalStorageFromEvent } from "../helpers/page"
 import { assert } from "chai"
 
-test("test form submission with form mode off", async ({ page }) => {
+test("form submission with form mode off", async ({ page }) => {
   await gotoPageWithFormMode(page, "off")
   await page.click("#turbo-enabled-form button")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission without submitter with form mode off", async ({ page }) => {
+test("form submission without submitter with form mode off", async ({ page }) => {
   await gotoPageWithFormMode(page, "off")
   await page.press("#turbo-enabled-form-without-submitter [type=text]", "Enter")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission with form mode off from submitter outside form", async ({ page }) => {
+test("form submission with form mode off from submitter outside form", async ({ page }) => {
   await gotoPageWithFormMode(page, "off")
   await page.click("button[form=turbo-enabled-form]")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission with form mode optin and form not enabled", async ({ page }) => {
+test("form submission with form mode optin and form not enabled", async ({ page }) => {
   await gotoPageWithFormMode(page, "optin")
   await page.click("#form button")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission without submitter with form mode optin and form not enabled", async ({ page }) => {
+test("form submission without submitter with form mode optin and form not enabled", async ({ page }) => {
   await gotoPageWithFormMode(page, "optin")
   await page.press("#form-without-submitter [type=text]", "Enter")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission with form mode optin and form not enabled from submitter outside form", async ({ page }) => {
+test("form submission with form mode optin and form not enabled from submitter outside form", async ({ page }) => {
   await gotoPageWithFormMode(page, "optin")
   await page.click("button[form=form]")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission with form mode optin and form enabled", async ({ page }) => {
+test("form submission with form mode optin and form enabled", async ({ page }) => {
   await gotoPageWithFormMode(page, "optin")
   await page.click("#turbo-enabled-form button")
 
   assert.ok(await formSubmitStarted(page))
 })
 
-test("test form submission without submitter with form mode optin and form enabled", async ({ page }) => {
+test("form submission without submitter with form mode optin and form enabled", async ({ page }) => {
   await gotoPageWithFormMode(page, "optin")
   await page.press("#turbo-enabled-form-without-submitter [type=text]", "Enter")
 
   assert.ok(await formSubmitStarted(page))
 })
 
-test("test form submission with form mode optin and form enabled from submitter outside form", async ({ page }) => {
+test("form submission with form mode optin and form enabled from submitter outside form", async ({ page }) => {
   await gotoPageWithFormMode(page, "optin")
   await page.click("button[form=turbo-enabled-form]")
 

--- a/src/tests/functional/form_submission_tests.js
+++ b/src/tests/functional/form_submission_tests.js
@@ -30,7 +30,7 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("test standard form submission renders a progress bar", async ({ page }) => {
+test("standard form submission renders a progress bar", async ({ page }) => {
   await page.evaluate(() => window.Turbo.setProgressBarDelay(0))
   await page.click("#standard form.sleep input[type=submit]")
 
@@ -43,7 +43,7 @@ test("test standard form submission renders a progress bar", async ({ page }) =>
   assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
 })
 
-test("test form submission with confirmation confirmed", async ({ page }) => {
+test("form submission with confirmation confirmed", async ({ page }) => {
   page.on("dialog", (alert) => {
     assert.equal(alert.message(), "Are you sure?")
     alert.accept()
@@ -56,7 +56,7 @@ test("test form submission with confirmation confirmed", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
 })
 
-test("test form submission with confirmation cancelled", async ({ page }) => {
+test("form submission with confirmation cancelled", async ({ page }) => {
   page.on("dialog", (alert) => {
     assert.equal(alert.message(), "Are you sure?")
     alert.dismiss()
@@ -66,7 +66,7 @@ test("test form submission with confirmation cancelled", async ({ page }) => {
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission with secondary submitter click - confirmation confirmed", async ({ page }) => {
+test("form submission with secondary submitter click - confirmation confirmed", async ({ page }) => {
   page.on("dialog", (alert) => {
     assert.equal(alert.message(), "Are you really sure?")
     alert.accept()
@@ -81,7 +81,7 @@ test("test form submission with secondary submitter click - confirmation confirm
   assert.equal(getSearchParam(page.url(), "greeting"), "secondary_submitter")
 })
 
-test("test form submission with secondary submitter click - confirmation cancelled", async ({ page }) => {
+test("form submission with secondary submitter click - confirmation cancelled", async ({ page }) => {
   page.on("dialog", (alert) => {
     assert.equal(alert.message(), "Are you really sure?")
     alert.dismiss()
@@ -92,7 +92,7 @@ test("test form submission with secondary submitter click - confirmation cancell
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test from submission with confirmation overridden", async ({ page }) => {
+test("from submission with confirmation overridden", async ({ page }) => {
   page.on("dialog", (alert) => {
     assert.equal(alert.message(), "Overridden message")
     alert.accept()
@@ -104,14 +104,14 @@ test("test from submission with confirmation overridden", async ({ page }) => {
   assert.ok(await formSubmitStarted(page))
 })
 
-test("test standard form submission does not render a progress bar before expiring the delay", async ({ page }) => {
+test("standard form submission does not render a progress bar before expiring the delay", async ({ page }) => {
   await page.evaluate(() => window.Turbo.setProgressBarDelay(500))
   await page.click("#standard form.redirect input[type=submit]")
 
   assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "does not show progress bar before delay")
 })
 
-test("test standard POST form submission with redirect response", async ({ page }) => {
+test("standard POST form submission with redirect response", async ({ page }) => {
   await page.click("#standard form.redirect input[type=submit]")
   await nextBody(page)
 
@@ -131,7 +131,7 @@ test("test standard POST form submission with redirect response", async ({ page 
   )
 })
 
-test("test standard POST form submission events", async ({ page }) => {
+test("standard POST form submission events", async ({ page }) => {
   await page.click("#standard-post-form-submit")
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
@@ -151,7 +151,7 @@ test("test standard POST form submission events", async ({ page }) => {
   await nextEventNamed(page, "turbo:load")
 })
 
-test("test supports transforming a POST submission to a GET in a turbo:submit-start listener", async ({ page }) => {
+test("supports transforming a POST submission to a GET in a turbo:submit-start listener", async ({ page }) => {
   await page.evaluate(() =>
     addEventListener("turbo:submit-start", (({ detail }) => {
       detail.formSubmission.method = "get"
@@ -166,7 +166,7 @@ test("test supports transforming a POST submission to a GET in a turbo:submit-st
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello, from an event listener")
 })
 
-test("test supports transforming a GET submission to a POST in a turbo:submit-start listener", async ({ page }) => {
+test("supports transforming a GET submission to a POST in a turbo:submit-start listener", async ({ page }) => {
   await page.evaluate(() =>
     addEventListener("turbo:submit-start", (({ detail }) => {
       detail.formSubmission.method = "post"
@@ -181,7 +181,7 @@ test("test supports transforming a GET submission to a POST in a turbo:submit-st
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello, from an event listener")
 })
 
-test("test supports modifying the submission in a turbo:before-fetch-request listener", async ({ page }) => {
+test("supports modifying the submission in a turbo:before-fetch-request listener", async ({ page }) => {
   await page.evaluate(() =>
     addEventListener("turbo:before-fetch-request", (({ detail }) => {
       detail.url = new URL("/src/tests/fixtures/one.html", document.baseURI)
@@ -197,7 +197,7 @@ test("test supports modifying the submission in a turbo:before-fetch-request lis
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a redirect")
 })
 
-test("test standard POST form submission merges values from both searchParams and body", async ({ page }) => {
+test("standard POST form submission merges values from both searchParams and body", async ({ page }) => {
   await page.click("#form-action-post-redirect-self-q-b")
   await nextBody(page)
 
@@ -206,7 +206,7 @@ test("test standard POST form submission merges values from both searchParams an
   assert.equal(getSearchParam(page.url(), "sort"), "asc")
 })
 
-test("test standard POST form submission toggles submitter [disabled] attribute", async ({ page }) => {
+test("standard POST form submission toggles submitter [disabled] attribute", async ({ page }) => {
   await page.click("#standard-post-form-submit")
 
   assert.equal(
@@ -255,7 +255,7 @@ test("replaces button innerHTML with data-turbo-submits-with on form submission"
   )
 })
 
-test("test standard GET form submission", async ({ page }) => {
+test("standard GET form submission", async ({ page }) => {
   await page.click("#standard form.greeting input[type=submit]")
   await nextBody(page)
 
@@ -275,7 +275,7 @@ test("test standard GET form submission", async ({ page }) => {
   )
 })
 
-test("test standard GET HTMLFormElement.requestSubmit() with Turbo Action", async ({ page }) => {
+test("standard GET HTMLFormElement.requestSubmit() with Turbo Action", async ({ page }) => {
   await page.evaluate(() => {
     const formControl = document.querySelector("#external-select")
 
@@ -290,7 +290,7 @@ test("test standard GET HTMLFormElement.requestSubmit() with Turbo Action", asyn
   assert.equal(getSearchParam(page.url(), "greeting"), "Hello from a replace Visit", "encodes <form> into request")
 })
 
-test("test GET HTMLFormElement.requestSubmit() triggered by javascript", async ({ page }) => {
+test("GET HTMLFormElement.requestSubmit() triggered by javascript", async ({ page }) => {
   await page.click("#request-submit-trigger")
 
   await nextEventNamed(page, "turbo:load")
@@ -299,7 +299,7 @@ test("test GET HTMLFormElement.requestSubmit() triggered by javascript", async (
   assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "navigates #hello turbo frame")
 })
 
-test("test standard GET form submission with [data-turbo-stream] declared on the form", async ({ page }) => {
+test("standard GET form submission with [data-turbo-stream] declared on the form", async ({ page }) => {
   await page.click("#standard-get-form-with-stream-opt-in-submit")
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
@@ -307,7 +307,7 @@ test("test standard GET form submission with [data-turbo-stream] declared on the
   assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
 })
 
-test("test standard GET form submission with [data-turbo-stream] declared on submitter", async ({ page }) => {
+test("standard GET form submission with [data-turbo-stream] declared on submitter", async ({ page }) => {
   await page.click("#standard-get-form-with-stream-opt-in-submitter")
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
@@ -315,7 +315,7 @@ test("test standard GET form submission with [data-turbo-stream] declared on sub
   assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
 })
 
-test("test standard GET form submission events", async ({ page }) => {
+test("standard GET form submission events", async ({ page }) => {
   await page.click("#standard-get-form-submit")
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
@@ -336,7 +336,7 @@ test("test standard GET form submission events", async ({ page }) => {
   await nextEventNamed(page, "turbo:load")
 })
 
-test("test standard GET form submission does not incorporate the current page's URLSearchParams values into the submission", async ({
+test("standard GET form submission does not incorporate the current page's URLSearchParams values into the submission", async ({
   page
 }) => {
   await page.click("#form-action-self-sort")
@@ -352,7 +352,7 @@ test("test standard GET form submission does not incorporate the current page's 
   assert.equal(search(page.url()), "?q=a", "navigates without omitted keys")
 })
 
-test("test standard GET form submission does not merge values into the [action] attribute", async ({ page }) => {
+test("standard GET form submission does not merge values into the [action] attribute", async ({ page }) => {
   await page.click("#form-action-self-sort")
   await nextBody(page)
 
@@ -366,7 +366,7 @@ test("test standard GET form submission does not merge values into the [action] 
   assert.equal(await search(page.url()), "?q=b", "navigates without omitted keys")
 })
 
-test("test standard GET form submission omits the [action] value's URLSearchParams from the submission", async ({
+test("standard GET form submission omits the [action] value's URLSearchParams from the submission", async ({
   page
 }) => {
   await page.click("#form-action-self-submit")
@@ -376,7 +376,7 @@ test("test standard GET form submission omits the [action] value's URLSearchPara
   assert.equal(search(page.url()), "")
 })
 
-test("test standard GET form submission toggles submitter [disabled] attribute", async ({ page }) => {
+test("standard GET form submission toggles submitter [disabled] attribute", async ({ page }) => {
   await page.click("#standard-get-form-submit")
 
   assert.equal(
@@ -391,7 +391,7 @@ test("test standard GET form submission toggles submitter [disabled] attribute",
   )
 })
 
-test("test standard GET form submission appending keys", async ({ page }) => {
+test("standard GET form submission appending keys", async ({ page }) => {
   await page.goto("/src/tests/fixtures/form.html?query=1")
   await page.click("#standard form.conflicting-values input[type=submit]")
   await nextBody(page)
@@ -400,7 +400,7 @@ test("test standard GET form submission appending keys", async ({ page }) => {
   assert.equal(getSearchParam(page.url(), "query"), "2")
 })
 
-test("test standard form submission with empty created response", async ({ page }) => {
+test("standard form submission with empty created response", async ({ page }) => {
   const htmlBefore = await outerHTMLForSelector(page, "body")
   const button = await page.locator("#standard form.created input[type=submit]")
   await button.click()
@@ -410,7 +410,7 @@ test("test standard form submission with empty created response", async ({ page 
   assert.equal(htmlAfter, htmlBefore)
 })
 
-test("test standard form submission with empty no-content response", async ({ page }) => {
+test("standard form submission with empty no-content response", async ({ page }) => {
   const htmlBefore = await outerHTMLForSelector(page, "body")
   const button = await page.locator("#standard form.no-content input[type=submit]")
   await button.click()
@@ -420,7 +420,7 @@ test("test standard form submission with empty no-content response", async ({ pa
   assert.equal(htmlAfter, htmlBefore)
 })
 
-test("test standard POST form submission with multipart/form-data enctype", async ({ page }) => {
+test("standard POST form submission with multipart/form-data enctype", async ({ page }) => {
   await page.click("#standard form[method=post][enctype] input[type=submit]")
   await nextBeat()
 
@@ -428,7 +428,7 @@ test("test standard POST form submission with multipart/form-data enctype", asyn
   assert.ok(enctype?.startsWith("multipart/form-data"), "submits a multipart/form-data request")
 })
 
-test("test standard GET form submission ignores enctype", async ({ page }) => {
+test("standard GET form submission ignores enctype", async ({ page }) => {
   await page.click("#standard form[method=get][enctype] input[type=submit]")
   await nextBeat()
 
@@ -436,7 +436,7 @@ test("test standard GET form submission ignores enctype", async ({ page }) => {
   assert.notOk(enctype, "GET form submissions ignore enctype")
 })
 
-test("test standard POST form submission without an enctype", async ({ page }) => {
+test("standard POST form submission without an enctype", async ({ page }) => {
   await page.click("#standard form[method=post].no-enctype input[type=submit]")
   await nextBeat()
 
@@ -447,7 +447,7 @@ test("test standard POST form submission without an enctype", async ({ page }) =
   )
 })
 
-test("test no-action form submission with single parameter", async ({ page }) => {
+test("no-action form submission with single parameter", async ({ page }) => {
   await page.click("#no-action form.single input[type=submit]")
   await nextBody(page)
 
@@ -468,7 +468,7 @@ test("test no-action form submission with single parameter", async ({ page }) =>
   assert.equal(getSearchParam(page.url(), "query"), "1")
 })
 
-test("test no-action form submission with multiple parameters", async ({ page }) => {
+test("no-action form submission with multiple parameters", async ({ page }) => {
   await page.goto("/src/tests/fixtures/form.html?query=2")
   await page.click("#no-action form.multiple input[type=submit]")
   await nextBody(page)
@@ -483,7 +483,7 @@ test("test no-action form submission with multiple parameters", async ({ page })
   assert.deepEqual(searchParams(page.url()).getAll("query"), ["1", "2"])
 })
 
-test("test no-action form submission submitter parameters", async ({ page }) => {
+test("no-action form submission submitter parameters", async ({ page }) => {
   await page.click("#no-action form.button-param [type=submit]")
   await nextBody(page)
 
@@ -499,7 +499,7 @@ test("test no-action form submission submitter parameters", async ({ page }) => 
   assert.deepEqual(searchParams(page.url()).getAll("button"), [""])
 })
 
-test("test submitter with blank formaction submits to the current page", async ({ page }) => {
+test("submitter with blank formaction submits to the current page", async ({ page }) => {
   await page.click("#blank-formaction button")
   await nextBody(page)
 
@@ -507,7 +507,7 @@ test("test submitter with blank formaction submits to the current page", async (
   assert.ok(await hasSelector(page, "#blank-formaction"), "overrides form[action] navigation")
 })
 
-test("test input named action with no action attribute", async ({ page }) => {
+test("input named action with no action attribute", async ({ page }) => {
   await page.click("#action-input form.no-action [type=submit]")
   await nextBody(page)
 
@@ -516,7 +516,7 @@ test("test input named action with no action attribute", async ({ page }) => {
   assert.equal(getSearchParam(page.url(), "query"), "1")
 })
 
-test("test input named action with action attribute", async ({ page }) => {
+test("input named action with action attribute", async ({ page }) => {
   await page.click("#action-input form.action [type=submit]")
   await nextBody(page)
 
@@ -525,7 +525,7 @@ test("test input named action with action attribute", async ({ page }) => {
   assert.equal(getSearchParam(page.url(), "query"), "1")
 })
 
-test("test invalid form submission with unprocessable entity status", async ({ page }) => {
+test("invalid form submission with unprocessable entity status", async ({ page }) => {
   await page.click("#reject form.unprocessable_entity input[type=submit]")
   await nextBody(page)
 
@@ -534,7 +534,7 @@ test("test invalid form submission with unprocessable entity status", async ({ p
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
 
-test("test invalid form submission with long form", async ({ page }) => {
+test("invalid form submission with long form", async ({ page }) => {
   await scrollToSelector(page, "#reject form.unprocessable_entity_with_tall_form input[type=submit]")
   await page.click("#reject form.unprocessable_entity_with_tall_form input[type=submit]")
   await nextBody(page)
@@ -545,7 +545,7 @@ test("test invalid form submission with long form", async ({ page }) => {
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
 
-test("test invalid form submission with server error status", async ({ page }) => {
+test("invalid form submission with server error status", async ({ page }) => {
   assert(await hasSelector(page, "head > #form-fixture-styles"))
   await page.click("#reject form.internal_server_error input[type=submit]")
   await nextBody(page)
@@ -556,13 +556,13 @@ test("test invalid form submission with server error status", async ({ page }) =
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
 
-test("test form submission with network error", async ({ page }) => {
+test("form submission with network error", async ({ page }) => {
   await page.context().setOffline(true)
   await page.click("#reject-form [type=submit]")
   await nextEventOnTarget(page, "reject-form", "turbo:fetch-request-error")
 })
 
-test("test submitter form submission reads button attributes", async ({ page }) => {
+test("submitter form submission reads button attributes", async ({ page }) => {
   const button = await page.locator("#submitter form button[type=submit][formmethod=post]")
   await button.click()
   await nextBody(page)
@@ -571,7 +571,7 @@ test("test submitter form submission reads button attributes", async ({ page }) 
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test submitter POST form submission with multipart/form-data formenctype", async ({ page }) => {
+test("submitter POST form submission with multipart/form-data formenctype", async ({ page }) => {
   await page.click("#submitter form[method=post]:not([enctype]) input[formenctype]")
   await nextBeat()
 
@@ -579,7 +579,7 @@ test("test submitter POST form submission with multipart/form-data formenctype",
   assert.ok(enctype?.startsWith("multipart/form-data"), "submits a multipart/form-data request")
 })
 
-test("test submitter GET submission from submitter with data-turbo-frame", async ({ page }) => {
+test("submitter GET submission from submitter with data-turbo-frame", async ({ page }) => {
   await page.click("#submitter form[method=get] [type=submit][data-turbo-frame]")
   await nextBeat()
 
@@ -589,7 +589,7 @@ test("test submitter GET submission from submitter with data-turbo-frame", async
   assert.equal(await message.textContent(), "Frame redirected")
 })
 
-test("test submitter POST submission from submitter with data-turbo-frame", async ({ page }) => {
+test("submitter POST submission from submitter with data-turbo-frame", async ({ page }) => {
   await page.click("#submitter form[method=post] [type=submit][data-turbo-frame]")
   await nextBeat()
 
@@ -599,7 +599,7 @@ test("test submitter POST submission from submitter with data-turbo-frame", asyn
   assert.equal(await message.textContent(), "Frame redirected")
 })
 
-test("test form[data-turbo-frame=_top] submission", async ({ page }) => {
+test("form[data-turbo-frame=_top] submission", async ({ page }) => {
   const form = await page.locator("#standard form.redirect[data-turbo-frame=_top]")
 
   await form.locator("button").click()
@@ -608,7 +608,7 @@ test("test form[data-turbo-frame=_top] submission", async ({ page }) => {
   assert.equal(await page.textContent("h1"), "One")
 })
 
-test("test form[data-turbo-frame=_top] submission within frame", async ({ page }) => {
+test("form[data-turbo-frame=_top] submission within frame", async ({ page }) => {
   const frame = await page.locator("turbo-frame#frame")
   const form = await frame.locator("form.redirect[data-turbo-frame=_top]")
 
@@ -618,7 +618,7 @@ test("test form[data-turbo-frame=_top] submission within frame", async ({ page }
   assert.equal(await page.textContent("h1"), "Frames: Form")
 })
 
-test("test frame form GET submission from submitter with data-turbo-frame=_top", async ({ page }) => {
+test("frame form GET submission from submitter with data-turbo-frame=_top", async ({ page }) => {
   await page.click("#frame form[method=get] [type=submit][data-turbo-frame=_top]")
   await nextBody(page)
 
@@ -626,7 +626,7 @@ test("test frame form GET submission from submitter with data-turbo-frame=_top",
   assert.equal(await title.textContent(), "One")
 })
 
-test("test frame form POST submission from submitter with data-turbo-frame=_top", async ({ page }) => {
+test("frame form POST submission from submitter with data-turbo-frame=_top", async ({ page }) => {
   await page.click("#frame form[method=post] [type=submit][data-turbo-frame=_top]")
   await nextBody(page)
 
@@ -634,7 +634,7 @@ test("test frame form POST submission from submitter with data-turbo-frame=_top"
   assert.equal(await title.textContent(), "One")
 })
 
-test("test frame POST form targeting frame submission", async ({ page }) => {
+test("frame POST form targeting frame submission", async ({ page }) => {
   await page.click("#targets-frame-post-form-submit")
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
@@ -658,7 +658,7 @@ test("test frame POST form targeting frame submission", async ({ page }) => {
   assert.equal(new URL(src).pathname, "/src/tests/fixtures/frames/frame.html")
 })
 
-test("test frame POST form targeting frame toggles submitter's [disabled] attribute", async ({ page }) => {
+test("frame POST form targeting frame toggles submitter's [disabled] attribute", async ({ page }) => {
   await page.click("#targets-frame-post-form-submit")
 
   assert.equal(
@@ -673,7 +673,7 @@ test("test frame POST form targeting frame toggles submitter's [disabled] attrib
   )
 })
 
-test("test frame GET form targeting frame submission", async ({ page }) => {
+test("frame GET form targeting frame submission", async ({ page }) => {
   await page.click("#targets-frame-get-form-submit")
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
@@ -697,7 +697,7 @@ test("test frame GET form targeting frame submission", async ({ page }) => {
   assert.equal(new URL(src).pathname, "/src/tests/fixtures/frames/frame.html")
 })
 
-test("test frame GET form targeting frame toggles submitter's [disabled] attribute", async ({ page }) => {
+test("frame GET form targeting frame toggles submitter's [disabled] attribute", async ({ page }) => {
   await page.click("#targets-frame-get-form-submit")
 
   assert.equal(
@@ -712,7 +712,7 @@ test("test frame GET form targeting frame toggles submitter's [disabled] attribu
   )
 })
 
-test("test frame form GET submission from submitter referencing another frame", async ({ page }) => {
+test("frame form GET submission from submitter referencing another frame", async ({ page }) => {
   await page.click("#frame form[method=get] [type=submit][data-turbo-frame=hello]")
   await nextBeat()
 
@@ -722,7 +722,7 @@ test("test frame form GET submission from submitter referencing another frame", 
   assert.equal(await title.textContent(), "Form")
 })
 
-test("test frame form POST submission from submitter referencing another frame", async ({ page }) => {
+test("frame form POST submission from submitter referencing another frame", async ({ page }) => {
   await page.click("#frame form[method=post] [type=submit][data-turbo-frame=hello]")
   await nextBeat()
 
@@ -732,7 +732,7 @@ test("test frame form POST submission from submitter referencing another frame",
   assert.equal(await title.textContent(), "Form")
 })
 
-test("test frame form submission with redirect response", async ({ page }) => {
+test("frame form submission with redirect response", async ({ page }) => {
   const path = (await page.getAttribute("#frame form.redirect input[name=path]", "value")) || ""
   const url = new URL(path, "http://localhost:9000")
   url.searchParams.set("enctype", "application/x-www-form-urlencoded;charset=UTF-8")
@@ -749,7 +749,7 @@ test("test frame form submission with redirect response", async ({ page }) => {
   assert.equal(await page.getAttribute("#frame", "src"), url.href, "redirects the target frame")
 })
 
-test("test frame POST form submission toggles the ancestor frame's [aria-busy] attribute", async ({ page }) => {
+test("frame POST form submission toggles the ancestor frame's [aria-busy] attribute", async ({ page }) => {
   await page.click("#frame form.redirect input[type=submit]")
   await nextBeat()
 
@@ -763,7 +763,7 @@ test("test frame POST form submission toggles the ancestor frame's [aria-busy] a
   )
 })
 
-test("test frame POST form submission toggles the target frame's [aria-busy] attribute", async ({ page }) => {
+test("frame POST form submission toggles the target frame's [aria-busy] attribute", async ({ page }) => {
   await page.click('#targets-frame form.frame [type="submit"]')
   await nextBeat()
 
@@ -780,7 +780,7 @@ test("test frame POST form submission toggles the target frame's [aria-busy] att
   )
 })
 
-test("test frame form submission with empty created response", async ({ page }) => {
+test("frame form submission with empty created response", async ({ page }) => {
   const htmlBefore = await outerHTMLForSelector(page, "#frame")
   const button = await page.locator("#frame form.created input[type=submit]")
   await button.click()
@@ -790,7 +790,7 @@ test("test frame form submission with empty created response", async ({ page }) 
   assert.equal(htmlAfter, htmlBefore)
 })
 
-test("test frame form submission with empty no-content response", async ({ page }) => {
+test("frame form submission with empty no-content response", async ({ page }) => {
   const htmlBefore = await outerHTMLForSelector(page, "#frame")
   const button = await page.locator("#frame form.no-content input[type=submit]")
   await button.click()
@@ -800,7 +800,7 @@ test("test frame form submission with empty no-content response", async ({ page 
   assert.equal(htmlAfter, htmlBefore)
 })
 
-test("test frame form submission within a frame submits the Turbo-Frame header", async ({ page }) => {
+test("frame form submission within a frame submits the Turbo-Frame header", async ({ page }) => {
   await page.click("#frame form.redirect input[type=submit]")
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
@@ -808,7 +808,7 @@ test("test frame form submission within a frame submits the Turbo-Frame header",
   assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
 })
 
-test("test invalid frame form submission with unprocessable entity status", async ({ page }) => {
+test("invalid frame form submission with unprocessable entity status", async ({ page }) => {
   await page.click("#frame form.unprocessable_entity input[type=submit]")
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
@@ -826,7 +826,7 @@ test("test invalid frame form submission with unprocessable entity status", asyn
   assert.equal(await title.textContent(), "Frame: Unprocessable Entity")
 })
 
-test("test invalid frame form submission with internal server error status", async ({ page }) => {
+test("invalid frame form submission with internal server error status", async ({ page }) => {
   await page.click("#frame form.internal_server_error input[type=submit]")
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
@@ -843,7 +843,7 @@ test("test invalid frame form submission with internal server error status", asy
   assert.equal(await page.textContent("#frame h2"), "Frame: Internal Server Error")
 })
 
-test("test frame form submission with stream response", async ({ page }) => {
+test("frame form submission with stream response", async ({ page }) => {
   const button = await page.locator("#frame form.stream[method=post] input[type=submit]")
   await button.click()
   await nextBeat()
@@ -855,7 +855,7 @@ test("test frame form submission with stream response", async ({ page }) => {
   assert.notOk(await page.getAttribute("#frame", "src"), "does not change frame's src")
 })
 
-test("test frame form submission with HTTP verb other than GET or POST", async ({ page }) => {
+test("frame form submission with HTTP verb other than GET or POST", async ({ page }) => {
   await page.click("#frame form.put.stream input[type=submit]")
   await nextBeat()
 
@@ -864,21 +864,21 @@ test("test frame form submission with HTTP verb other than GET or POST", async (
   assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
 })
 
-test("test frame form submission with [data-turbo=false] on the form", async ({ page }) => {
+test("frame form submission with [data-turbo=false] on the form", async ({ page }) => {
   await page.click('#frame form[data-turbo="false"] input[type=submit]')
   await waitUntilSelector(page, "#element-id")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test frame form submission with [data-turbo=false] on the submitter", async ({ page }) => {
+test("frame form submission with [data-turbo=false] on the submitter", async ({ page }) => {
   await page.click('#frame form:not([data-turbo]) input[data-turbo="false"]')
   await waitUntilSelector(page, "#element-id")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test frame form submission ignores submissions with their defaultPrevented", async ({ page }) => {
+test("frame form submission ignores submissions with their defaultPrevented", async ({ page }) => {
   await page.evaluate(() => document.addEventListener("submit", (event) => event.preventDefault(), true))
   await page.click("#frame .redirect [type=submit]")
   await nextBeat()
@@ -887,49 +887,49 @@ test("test frame form submission ignores submissions with their defaultPrevented
   assert.equal(await page.getAttribute("#frame", "src"), null, "does not navigate frame")
 })
 
-test("test form submission with [data-turbo=false] on the form", async ({ page }) => {
+test("form submission with [data-turbo=false] on the form", async ({ page }) => {
   await page.click('#turbo-false form[data-turbo="false"] input[type=submit]')
   await waitUntilSelector(page, "#element-id")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission with [data-turbo=false] on the submitter", async ({ page }) => {
+test("form submission with [data-turbo=false] on the submitter", async ({ page }) => {
   await page.click('#turbo-false form:not([data-turbo]) input[data-turbo="false"]')
   await waitUntilSelector(page, "#element-id")
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission skipped within method=dialog", async ({ page }) => {
+test("form submission skipped within method=dialog", async ({ page }) => {
   await page.click('#dialog-method [type="submit"]')
   await nextBeat()
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission skipped with submitter formmethod=dialog", async ({ page }) => {
+test("form submission skipped with submitter formmethod=dialog", async ({ page }) => {
   await page.click('#dialog-formmethod-turbo-frame [formmethod="dialog"]')
   await nextBeat()
 
   assert.notOk(await formSubmitEnded(page))
 })
 
-test("test form submission targeting frame skipped within method=dialog", async ({ page }) => {
+test("form submission targeting frame skipped within method=dialog", async ({ page }) => {
   await page.click("#dialog-method-turbo-frame button")
   await nextBeat()
 
   assert.notOk(await formSubmitEnded(page))
 })
 
-test("test form submission targeting frame skipped with submitter formmethod=dialog", async ({ page }) => {
+test("form submission targeting frame skipped with submitter formmethod=dialog", async ({ page }) => {
   await page.click('#dialog-formmethod [formmethod="dialog"]')
   await nextBeat()
 
   assert.notOk(await formSubmitStarted(page))
 })
 
-test("test form submission targets disabled frame", async ({ page }) => {
+test("form submission targets disabled frame", async ({ page }) => {
   await page.evaluate(() => document.getElementById("frame")?.setAttribute("disabled", ""))
   await page.click('#targets-frame form.one [type="submit"]')
   await nextBody(page)
@@ -937,7 +937,7 @@ test("test form submission targets disabled frame", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
 })
 
-test("test form submission targeting a frame submits the Turbo-Frame header", async ({ page }) => {
+test("form submission targeting a frame submits the Turbo-Frame header", async ({ page }) => {
   await page.click('#targets-frame [type="submit"]')
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
@@ -945,7 +945,7 @@ test("test form submission targeting a frame submits the Turbo-Frame header", as
   assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
 })
 
-test("test link method form submission dispatches events from a connected <form> element", async ({ page }) => {
+test("link method form submission dispatches events from a connected <form> element", async ({ page }) => {
   await page.evaluate(() =>
     new MutationObserver(([record]) => {
       for (const form of record.addedNodes) {
@@ -963,7 +963,7 @@ test("test link method form submission dispatches events from a connected <form>
   assert.notOk(await hasSelector(page, "a-form-link"), "the <form> is removed")
 })
 
-test("test link method form submission submits a single request", async ({ page }) => {
+test("link method form submission submits a single request", async ({ page }) => {
   let requestCounter = 0
   page.on("request", () => requestCounter++)
 
@@ -977,7 +977,7 @@ test("test link method form submission submits a single request", async ({ page 
   assert.equal(requestCounter, 1, "submits a single HTTP request")
 })
 
-test("test link method form submission inside frame submits a single request", async ({ page }) => {
+test("link method form submission inside frame submits a single request", async ({ page }) => {
   let requestCounter = 0
   page.on("request", () => requestCounter++)
 
@@ -991,7 +991,7 @@ test("test link method form submission inside frame submits a single request", a
   assert.equal(requestCounter, 1, "submits a single HTTP request")
 })
 
-test("test link method form submission targeting frame submits a single request", async ({ page }) => {
+test("link method form submission targeting frame submits a single request", async ({ page }) => {
   let requestCounter = 0
   page.on("request", () => requestCounter++)
 
@@ -1005,7 +1005,7 @@ test("test link method form submission targeting frame submits a single request"
   assert.equal(requestCounter, 2, "submits a single HTTP request then follows a redirect")
 })
 
-test("test link method form submission inside frame", async ({ page }) => {
+test("link method form submission inside frame", async ({ page }) => {
   await page.click("#link-method-inside-frame")
   await nextBeat()
 
@@ -1013,7 +1013,7 @@ test("test link method form submission inside frame", async ({ page }) => {
   assert.notOk(await hasSelector(page, "#nested-child"))
 })
 
-test("test link method form submission inside frame with data-turbo-frame=_top", async ({ page }) => {
+test("link method form submission inside frame with data-turbo-frame=_top", async ({ page }) => {
   await page.click("#link-method-inside-frame-target-top")
   await nextBody(page)
 
@@ -1021,7 +1021,7 @@ test("test link method form submission inside frame with data-turbo-frame=_top",
   assert.equal(await title.textContent(), "Hello")
 })
 
-test("test link method form submission inside frame with data-turbo-frame target", async ({ page }) => {
+test("link method form submission inside frame with data-turbo-frame target", async ({ page }) => {
   await page.click("#link-method-inside-frame-with-target")
   await nextBeat()
 
@@ -1031,7 +1031,7 @@ test("test link method form submission inside frame with data-turbo-frame target
   assert.equal(await title.textContent(), "Form")
 })
 
-test("test stream link method form submission inside frame", async ({ page }) => {
+test("stream link method form submission inside frame", async ({ page }) => {
   await page.click("#stream-link-method-inside-frame")
   await nextBeat()
 
@@ -1039,7 +1039,7 @@ test("test stream link method form submission inside frame", async ({ page }) =>
   assert.equal(await message.textContent(), "Link!")
 })
 
-test("test stream link GET method form submission inside frame", async ({ page }) => {
+test("stream link GET method form submission inside frame", async ({ page }) => {
   await page.click("#stream-link-get-method-inside-frame")
 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
@@ -1047,7 +1047,7 @@ test("test stream link GET method form submission inside frame", async ({ page }
   assert.ok(fetchOptions.headers["Accept"].includes("text/vnd.turbo-stream.html"))
 })
 
-test("test stream link inside frame", async ({ page }) => {
+test("stream link inside frame", async ({ page }) => {
   await page.click("#stream-link-inside-frame")
 
   const { fetchOptions, url } = await nextEventNamed(page, "turbo:before-fetch-request")
@@ -1056,7 +1056,7 @@ test("test stream link inside frame", async ({ page }) => {
   assert.equal(getSearchParam(url, "content"), "Link!")
 })
 
-test("test link method form submission within form inside frame", async ({ page }) => {
+test("link method form submission within form inside frame", async ({ page }) => {
   await page.click("#stream-link-method-within-form-inside-frame")
   await nextBeat()
 
@@ -1064,7 +1064,7 @@ test("test link method form submission within form inside frame", async ({ page 
   assert.equal(await message.textContent(), "Link!")
 })
 
-test("test link method form submission inside frame with confirmation confirmed", async ({ page }) => {
+test("link method form submission inside frame with confirmation confirmed", async ({ page }) => {
   page.on("dialog", (dialog) => {
     assert.equal(dialog.message(), "Are you sure?")
     dialog.accept()
@@ -1077,7 +1077,7 @@ test("test link method form submission inside frame with confirmation confirmed"
   assert.equal(await message.textContent(), "Link!")
 })
 
-test("test link method form submission inside frame with confirmation cancelled", async ({ page }) => {
+test("link method form submission inside frame with confirmation cancelled", async ({ page }) => {
   page.on("dialog", (dialog) => {
     assert.equal(dialog.message(), "Are you sure?")
     dialog.dismiss()
@@ -1089,7 +1089,7 @@ test("test link method form submission inside frame with confirmation cancelled"
   assert.notOk(await hasSelector(page, "#frame div.message"), "Not confirming form submission does not submit the form")
 })
 
-test("test link method form submission outside frame", async ({ page }) => {
+test("link method form submission outside frame", async ({ page }) => {
   await page.click("#link-method-outside-frame")
   await nextBody(page)
 
@@ -1097,7 +1097,7 @@ test("test link method form submission outside frame", async ({ page }) => {
   assert.equal(await title.textContent(), "Hello")
 })
 
-test("test following a link with [data-turbo-method] set and a target set navigates the target frame", async ({
+test("following a link with [data-turbo-method] set and a target set navigates the target frame", async ({
   page
 }) => {
   await page.click("#turbo-method-post-to-targeted-frame")
@@ -1105,7 +1105,7 @@ test("test following a link with [data-turbo-method] set and a target set naviga
   assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "drives the turbo-frame")
 })
 
-test("test following a link with [data-turbo-method] and [data-turbo=true] set when html[data-turbo=false]", async ({
+test("following a link with [data-turbo-method] and [data-turbo=true] set when html[data-turbo=false]", async ({
   page
 }) => {
   const html = await page.locator("html")
@@ -1120,7 +1120,7 @@ test("test following a link with [data-turbo-method] and [data-turbo=true] set w
   assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "drives the turbo-frame")
 })
 
-test("test following a link with [data-turbo-method] and [data-turbo=true] set when Turbo.session.drive = false", async ({
+test("following a link with [data-turbo-method] and [data-turbo=true] set when Turbo.session.drive = false", async ({
   page
 }) => {
   await page.evaluate(() => (window.Turbo.session.drive = false))
@@ -1134,7 +1134,7 @@ test("test following a link with [data-turbo-method] and [data-turbo=true] set w
   assert.equal(await page.textContent("#hello h2"), "Hello from a frame", "drives the turbo-frame")
 })
 
-test("test following a link with [data-turbo-method] set when html[data-turbo=false]", async ({ page }) => {
+test("following a link with [data-turbo-method] set when html[data-turbo=false]", async ({ page }) => {
   const html = await page.locator("html")
   await html.evaluate((html) => html.setAttribute("data-turbo", "false"))
 
@@ -1143,14 +1143,14 @@ test("test following a link with [data-turbo-method] set when html[data-turbo=fa
   assert.equal(await page.textContent("h1"), "Hello", "treats link full-page navigation")
 })
 
-test("test following a link with [data-turbo-method] set when Turbo.session.drive = false", async ({ page }) => {
+test("following a link with [data-turbo-method] set when Turbo.session.drive = false", async ({ page }) => {
   await page.evaluate(() => (window.Turbo.session.drive = false))
   await page.click("#turbo-method-post-to-targeted-frame")
 
   assert.equal(await page.textContent("h1"), "Hello", "treats link full-page navigation")
 })
 
-test("test stream link method form submission outside frame", async ({ page }) => {
+test("stream link method form submission outside frame", async ({ page }) => {
   await page.click("#stream-link-method-outside-frame")
   await nextBeat()
 
@@ -1158,7 +1158,7 @@ test("test stream link method form submission outside frame", async ({ page }) =
   assert.equal(await message.textContent(), "Link!")
 })
 
-test("test link method form submission within form outside frame", async ({ page }) => {
+test("link method form submission within form outside frame", async ({ page }) => {
   await page.click("#link-method-within-form-outside-frame")
   await nextBody(page)
 
@@ -1166,24 +1166,24 @@ test("test link method form submission within form outside frame", async ({ page
   assert.equal(await title.textContent(), "Hello")
 })
 
-test("test stream link method form submission within form outside frame", async ({ page }) => {
+test("stream link method form submission within form outside frame", async ({ page }) => {
   await page.click("#stream-link-method-within-form-outside-frame")
   await nextBeat()
 
   assert.equal(await page.textContent("#frame div.message"), "Link!")
 })
 
-test("test turbo:before-fetch-request fires on the form element", async ({ page }) => {
+test("turbo:before-fetch-request fires on the form element", async ({ page }) => {
   await page.click('#targets-frame form.one [type="submit"]')
   assert.ok(await nextEventOnTarget(page, "form_one", "turbo:before-fetch-request"))
 })
 
-test("test turbo:before-fetch-response fires on the form element", async ({ page }) => {
+test("turbo:before-fetch-response fires on the form element", async ({ page }) => {
   await page.click('#targets-frame form.one [type="submit"]')
   assert.ok(await nextEventOnTarget(page, "form_one", "turbo:before-fetch-response"))
 })
 
-test("test POST to external action ignored", async ({ page }) => {
+test("POST to external action ignored", async ({ page }) => {
   await page.click("#submit-external")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
@@ -1193,7 +1193,7 @@ test("test POST to external action ignored", async ({ page }) => {
   assert.equal(page.url(), "https://httpbin.org/post")
 })
 
-test("test POST to external action within frame ignored", async ({ page }) => {
+test("POST to external action within frame ignored", async ({ page }) => {
   await page.click("#submit-external-within-ignored")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
@@ -1203,7 +1203,7 @@ test("test POST to external action within frame ignored", async ({ page }) => {
   assert.equal(page.url(), "https://httpbin.org/post")
 })
 
-test("test POST to external action targeting frame ignored", async ({ page }) => {
+test("POST to external action targeting frame ignored", async ({ page }) => {
   await page.click("#submit-external-target-ignored")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
@@ -1213,7 +1213,7 @@ test("test POST to external action targeting frame ignored", async ({ page }) =>
   assert.equal(page.url(), "https://httpbin.org/post")
 })
 
-test("test form submission skipped with form[target]", async ({ page }) => {
+test("form submission skipped with form[target]", async ({ page }) => {
   await page.click("#skipped form[target] button")
   await nextBeat()
 
@@ -1221,7 +1221,7 @@ test("test form submission skipped with form[target]", async ({ page }) => {
   assert.notOk(await formSubmitEnded(page))
 })
 
-test("test form submission skipped with submitter button[formtarget]", async ({ page }) => {
+test("form submission skipped with submitter button[formtarget]", async ({ page }) => {
   await page.click("#skipped [formtarget]")
   await nextBeat()
 

--- a/src/tests/functional/frame_navigation_tests.js
+++ b/src/tests/functional/frame_navigation_tests.js
@@ -2,42 +2,42 @@ import { test } from "@playwright/test"
 import { getFromLocalStorage, nextEventNamed, nextEventOnTarget, pathname, scrollToSelector } from "../helpers/page"
 import { assert } from "chai"
 
-test("test frame navigation with descendant link", async ({ page }) => {
+test("frame navigation with descendant link", async ({ page }) => {
   await page.goto("/src/tests/fixtures/frame_navigation.html")
   await page.click("#inside")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
-test("test frame navigation with self link", async ({ page }) => {
+test("frame navigation with self link", async ({ page }) => {
   await page.goto("/src/tests/fixtures/frame_navigation.html")
   await page.click("#self")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
-test("test frame navigation with exterior link", async ({ page }) => {
+test("frame navigation with exterior link", async ({ page }) => {
   await page.goto("/src/tests/fixtures/frame_navigation.html")
   await page.click("#outside")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
-test("test frame navigation with exterior link in Shadow DOM", async ({ page }) => {
+test("frame navigation with exterior link in Shadow DOM", async ({ page }) => {
   await page.goto("/src/tests/fixtures/frame_navigation.html")
   await page.click("#outside-in-shadow-dom")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 })
 
-test("test frame navigation emits fetch-request-error event when offline", async ({ page }) => {
+test("frame navigation emits fetch-request-error event when offline", async ({ page }) => {
   await page.goto("/src/tests/fixtures/tabs.html")
   await page.context().setOffline(true)
   await page.click("#tab-2")
   await nextEventOnTarget(page, "tab-frame", "turbo:fetch-request-error")
 })
 
-test("test lazy-loaded frame promotes navigation", async ({ page }) => {
+test("lazy-loaded frame promotes navigation", async ({ page }) => {
   await page.goto("/src/tests/fixtures/frame_navigation.html")
 
   assert.equal(await page.textContent("#eager-loaded-frame h2"), "Eager-loaded frame: Not Loaded")
@@ -49,7 +49,7 @@ test("test lazy-loaded frame promotes navigation", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame_for_eager.html")
 })
 
-test("test promoted frame navigation updates the URL before rendering", async ({ page }) => {
+test("promoted frame navigation updates the URL before rendering", async ({ page }) => {
   await page.goto("/src/tests/fixtures/tabs.html")
 
   page.evaluate(() => {
@@ -71,7 +71,7 @@ test("test promoted frame navigation updates the URL before rendering", async ({
   assert.equal(await page.textContent("#tab-content"), "Two")
 })
 
-test("test promoted frame navigations are cached", async ({ page }) => {
+test("promoted frame navigations are cached", async ({ page }) => {
   await page.goto("/src/tests/fixtures/tabs.html")
 
   await page.click("#tab-2")

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -28,7 +28,7 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("test navigating a frame with Turbo.visit", async ({ page }) => {
+test("navigating a frame with Turbo.visit", async ({ page }) => {
   const pathname = "/src/tests/fixtures/frames/frame.html"
 
   await page.locator("#frame").evaluate((frame) => frame.setAttribute("disabled", ""))
@@ -44,7 +44,7 @@ test("test navigating a frame with Turbo.visit", async ({ page }) => {
   assert.equal(await page.textContent("#frame h2"), "Frame: Loaded", "navigates the target frame")
 })
 
-test("test navigating a frame a second time does not leak event listeners", async ({ page }) => {
+test("navigating a frame a second time does not leak event listeners", async ({ page }) => {
   await withoutChangingEventListenersCount(page, async () => {
     await page.click("#outer-frame-link")
     await nextEventOnTarget(page, "frame", "turbo:frame-load")
@@ -55,7 +55,7 @@ test("test navigating a frame a second time does not leak event listeners", asyn
   })
 })
 
-test("test following a link preserves the current <turbo-frame> element's attributes", async ({ page }) => {
+test("following a link preserves the current <turbo-frame> element's attributes", async ({ page }) => {
   const currentPath = pathname(page.url())
 
   await page.click("#hello a")
@@ -66,7 +66,7 @@ test("test following a link preserves the current <turbo-frame> element's attrib
   assert.equal(await frame.getAttribute("src"), await propertyForSelector(page, "#hello a", "href"))
 })
 
-test("test following a link sets the frame element's [src]", async ({ page }) => {
+test("following a link sets the frame element's [src]", async ({ page }) => {
   await page.click("#link-frame-with-search-params")
 
   const { url } = await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
@@ -82,7 +82,7 @@ test("test following a link sets the frame element's [src]", async ({ page }) =>
   assert.equal(src.searchParams.get("key"), "value", "[src] attribute encodes query parameters")
 })
 
-test("test following a link doesn't set the frame element's [src] if the link has [data-turbo-stream]", async ({ page }) => {
+test("following a link doesn't set the frame element's [src] if the link has [data-turbo-stream]", async ({ page }) => {
   await page.goto("/src/tests/fixtures/form.html")
 
   const originalSrc = await page.getAttribute("#frame", "src")
@@ -95,7 +95,7 @@ test("test following a link doesn't set the frame element's [src] if the link ha
   assert.equal(originalSrc, newSrc, "the turbo-frame src should not change after clicking the link")
 })
 
-test("test a frame whose src references itself does not infinitely loop", async ({ page }) => {
+test("a frame whose src references itself does not infinitely loop", async ({ page }) => {
   await page.click("#frame-self")
 
   await nextEventOnTarget(page, "frame", "turbo:frame-render")
@@ -105,7 +105,7 @@ test("test a frame whose src references itself does not infinitely loop", async 
   assert.equal(otherEvents.length, 0, "no more events")
 })
 
-test("test following a link driving a frame toggles the [aria-busy=true] attribute", async ({ page }) => {
+test("following a link driving a frame toggles the [aria-busy=true] attribute", async ({ page }) => {
   await page.click("#hello a")
 
   assert.equal(await nextAttributeMutationNamed(page, "frame", "busy"), "", "sets [busy] on the #frame")
@@ -122,7 +122,7 @@ test("test following a link driving a frame toggles the [aria-busy=true] attribu
   )
 })
 
-test("test following an a[data-turbo-frame=_top] does not toggle the frame's [aria-busy=true] attribute", async ({
+test("following an a[data-turbo-frame=_top] does not toggle the frame's [aria-busy=true] attribute", async ({
   page
 }) => {
   await page.click("#frame #link-top")
@@ -134,7 +134,7 @@ test("test following an a[data-turbo-frame=_top] does not toggle the frame's [ar
   )
 })
 
-test("test submitting a form[data-turbo-frame=_top] does not toggle the frame's [aria-busy=true] attribute", async ({
+test("submitting a form[data-turbo-frame=_top] does not toggle the frame's [aria-busy=true] attribute", async ({
   page
 }) => {
   await page.click("#frame #form-submit-top")
@@ -201,7 +201,7 @@ test("failing to follow a link to a page without a matching frame shows an error
   assert.include(error.message, `The response (404) did not contain the expected <turbo-frame id="missing">`)
 })
 
-test("test the turbo:frame-missing event following a link to a page without a matching frame can be handled", async ({
+test("the turbo:frame-missing event following a link to a page without a matching frame can be handled", async ({
   page
 }) => {
   await page.locator("#missing").evaluate((frame) => {
@@ -222,7 +222,7 @@ test("test the turbo:frame-missing event following a link to a page without a ma
   assert.equal(await page.textContent("#missing"), "Overridden")
 })
 
-test("test the turbo:frame-missing event following a link to a page without a matching frame can drive a Visit", async ({
+test("the turbo:frame-missing event following a link to a page without a matching frame can drive a Visit", async ({
   page
 }) => {
   await page.locator("#missing").evaluate((frame) => {
@@ -251,7 +251,7 @@ test("test the turbo:frame-missing event following a link to a page without a ma
   assert.ok(await hasSelector(page, "#missing-frame-link"))
 })
 
-test("test following a link to a page with a matching frame does not dispatch a turbo:frame-missing event", async ({
+test("following a link to a page with a matching frame does not dispatch a turbo:frame-missing event", async ({
   page
 }) => {
   await page.click("#link-frame")
@@ -267,7 +267,7 @@ test("test following a link to a page with a matching frame does not dispatch a 
   )
 })
 
-test("test following a link within a frame with a target set navigates the target frame", async ({ page }) => {
+test("following a link within a frame with a target set navigates the target frame", async ({ page }) => {
   await page.click("#hello a")
   await nextBeat()
 
@@ -275,7 +275,7 @@ test("test following a link within a frame with a target set navigates the targe
   assert.equal(frameText, "Frame: Loaded")
 })
 
-test("test following a link in rapid succession cancels the previous request", async ({ page }) => {
+test("following a link in rapid succession cancels the previous request", async ({ page }) => {
   await page.click("#outside-frame-form")
   await page.click("#outer-frame-link")
   await nextBeat()
@@ -284,7 +284,7 @@ test("test following a link in rapid succession cancels the previous request", a
   assert.equal(frameText, "Frame: Loaded")
 })
 
-test("test following a link within a descendant frame whose ancestor declares a target set navigates the descendant frame", async ({
+test("following a link within a descendant frame whose ancestor declares a target set navigates the descendant frame", async ({
   page
 }) => {
   const selector = "#nested-root[target=frame] #nested-child a:not([data-turbo-frame])"
@@ -305,7 +305,7 @@ test("test following a link within a descendant frame whose ancestor declares a 
   assert.equal(await attributeForSelector(page, "#nested-child", "src"), href || "")
 })
 
-test("test following a link that declares data-turbo-frame within a frame whose ancestor respects the override", async ({
+test("following a link that declares data-turbo-frame within a frame whose ancestor respects the override", async ({
   page
 }) => {
   await page.click("#nested-root[target=frame] #nested-child a[data-turbo-frame]")
@@ -318,7 +318,7 @@ test("test following a link that declares data-turbo-frame within a frame whose 
   assert.notOk(await hasSelector(page, "#nested-child"))
 })
 
-test("test following a form within a nested frame with form target top", async ({ page }) => {
+test("following a form within a nested frame with form target top", async ({ page }) => {
   await page.click("#nested-child-navigate-form-top-submit")
   await nextBeat()
 
@@ -329,7 +329,7 @@ test("test following a form within a nested frame with form target top", async (
   assert.notOk(await hasSelector(page, "#nested-child"))
 })
 
-test("test following a form within a nested frame with child frame target top", async ({ page }) => {
+test("following a form within a nested frame with child frame target top", async ({ page }) => {
   await page.click("#nested-child-navigate-top-submit")
   await nextBeat()
 
@@ -340,7 +340,7 @@ test("test following a form within a nested frame with child frame target top", 
   assert.notOk(await hasSelector(page, "#nested-child-navigate-top"))
 })
 
-test("test following a link within a frame with target=_top navigates the page", async ({ page }) => {
+test("following a link within a frame with target=_top navigates the page", async ({ page }) => {
   assert.equal(await attributeForSelector(page, "#navigate-top", "src"), null)
 
   await page.click("#navigate-top a:not([data-turbo-frame])")
@@ -353,7 +353,7 @@ test("test following a link within a frame with target=_top navigates the page",
   assert.equal(await searchParams(page.url()).get("key"), "value")
 })
 
-test("test following a link that declares data-turbo-frame='_self' within a frame with target=_top navigates the frame itself", async ({
+test("following a link that declares data-turbo-frame='_self' within a frame with target=_top navigates the frame itself", async ({
   page
 }) => {
   assert.equal(await attributeForSelector(page, "#navigate-top", "src"), null)
@@ -368,7 +368,7 @@ test("test following a link that declares data-turbo-frame='_self' within a fram
   assert.equalIgnoringWhitespace(frame, "Replaced only the frame")
 })
 
-test("test following a link to a page with a <turbo-frame recurse> which lazily loads a matching frame", async ({
+test("following a link to a page with a <turbo-frame recurse> which lazily loads a matching frame", async ({
   page
 }) => {
   await page.click("#recursive summary")
@@ -382,7 +382,7 @@ test("test following a link to a page with a <turbo-frame recurse> which lazily 
   assert.ok(await hasSelector(page, "#recursive details:not([open])"))
 })
 
-test("test submitting a form that redirects to a page with a <turbo-frame recurse> which lazily loads a matching frame", async ({
+test("submitting a form that redirects to a page with a <turbo-frame recurse> which lazily loads a matching frame", async ({
   page
 }) => {
   await page.click("#recursive summary")
@@ -396,7 +396,7 @@ test("test submitting a form that redirects to a page with a <turbo-frame recurs
   assert.ok(await hasSelector(page, "#recursive details:not([open])"))
 })
 
-test("test removing [disabled] attribute from eager-loaded frame navigates it", async ({ page }) => {
+test("removing [disabled] attribute from eager-loaded frame navigates it", async ({ page }) => {
   await page.evaluate(() => document.getElementById("frame")?.setAttribute("disabled", ""))
   await page.evaluate(() =>
     document.getElementById("frame")?.setAttribute("src", "/src/tests/fixtures/frames/frame.html")
@@ -412,7 +412,7 @@ test("test removing [disabled] attribute from eager-loaded frame navigates it", 
   await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
 })
 
-test("test evaluates frame script elements on each render", async ({ page }) => {
+test("evaluates frame script elements on each render", async ({ page }) => {
   assert.equal(await frameScriptEvaluationCount(page), undefined)
 
   await page.click("#body-script-link")
@@ -424,13 +424,13 @@ test("test evaluates frame script elements on each render", async ({ page }) => 
   assert.equal(await frameScriptEvaluationCount(page), 2)
 })
 
-test("test does not evaluate data-turbo-eval=false scripts", async ({ page }) => {
+test("does not evaluate data-turbo-eval=false scripts", async ({ page }) => {
   await page.click("#eval-false-script-link")
   await nextBeat()
   assert.equal(await frameScriptEvaluationCount(page), undefined)
 })
 
-test("test redirecting in a form is still navigatable after redirect", async ({ page }) => {
+test("redirecting in a form is still navigatable after redirect", async ({ page }) => {
   await page.click("#navigate-form-redirect")
   await nextEventOnTarget(page, "form-redirect", "turbo:frame-load")
   assert.equal(await page.textContent("turbo-frame#form-redirect h2"), "Form Redirect")
@@ -445,7 +445,7 @@ test("test redirecting in a form is still navigatable after redirect", async ({ 
   assert.equal(await page.textContent("turbo-frame#form-redirect h2"), "Form Redirect")
 })
 
-test("test 'turbo:frame-render' is triggered after frame has finished rendering", async ({ page }) => {
+test("'turbo:frame-render' is triggered after frame has finished rendering", async ({ page }) => {
   await page.click("#frame-part")
 
   await nextEventNamed(page, "turbo:frame-render") // recursive
@@ -454,7 +454,7 @@ test("test 'turbo:frame-render' is triggered after frame has finished rendering"
   assert.include(fetchResponse.response.url, "/src/tests/fixtures/frames/part.html")
 })
 
-test("test navigating a frame from an outer form fires events", async ({ page }) => {
+test("navigating a frame from an outer form fires events", async ({ page }) => {
   await page.click("#outside-frame-form")
 
   await nextEventOnTarget(page, "frame", "turbo:before-fetch-request")
@@ -468,7 +468,7 @@ test("test navigating a frame from an outer form fires events", async ({ page })
   assert.equal(otherEvents.length, 0, "no more events")
 })
 
-test("test navigating a frame from an outer link fires events", async ({ page }) => {
+test("navigating a frame from an outer link fires events", async ({ page }) => {
   await listenForEventOnTarget(page, "outside-frame-form", "turbo:click")
   await page.click("#outside-frame-form")
 
@@ -484,7 +484,7 @@ test("test navigating a frame from an outer link fires events", async ({ page })
   assert.equal(otherEvents.length, 0, "no more events")
 })
 
-test("test navigating a frame from an inner link fires events", async ({ page }) => {
+test("navigating a frame from an inner link fires events", async ({ page }) => {
   await listenForEventOnTarget(page, "link-frame", "turbo:click")
   await page.click("#link-frame")
 
@@ -500,7 +500,7 @@ test("test navigating a frame from an inner link fires events", async ({ page })
   assert.equal(otherEvents.length, 0, "no more events")
 })
 
-test("test navigating a frame targeting _top from an outer link fires events", async ({ page }) => {
+test("navigating a frame targeting _top from an outer link fires events", async ({ page }) => {
   await listenForEventOnTarget(page, "outside-navigate-top-link", "turbo:click")
   await page.click("#outside-navigate-top-link")
 
@@ -515,7 +515,7 @@ test("test navigating a frame targeting _top from an outer link fires events", a
   assert.equal(otherEvents.length, 0, "no more events")
 })
 
-test("test invoking .reload() re-fetches the frame's content", async ({ page }) => {
+test("invoking .reload() re-fetches the frame's content", async ({ page }) => {
   await page.click("#link-frame")
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
   await page.evaluate(() => document.getElementById("frame").reload())
@@ -534,7 +534,7 @@ test("test invoking .reload() re-fetches the frame's content", async ({ page }) 
   )
 })
 
-test("test following inner link reloads frame on every click", async ({ page }) => {
+test("following inner link reloads frame on every click", async ({ page }) => {
   await page.click("#hello a")
   await nextEventNamed(page, "turbo:before-fetch-request")
 
@@ -542,7 +542,7 @@ test("test following inner link reloads frame on every click", async ({ page }) 
   await nextEventNamed(page, "turbo:before-fetch-request")
 })
 
-test("test following outer link reloads frame on every click", async ({ page }) => {
+test("following outer link reloads frame on every click", async ({ page }) => {
   await page.click("#outer-frame-link")
   await nextEventNamed(page, "turbo:before-fetch-request")
 
@@ -550,7 +550,7 @@ test("test following outer link reloads frame on every click", async ({ page }) 
   await nextEventNamed(page, "turbo:before-fetch-request")
 })
 
-test("test following outer form reloads frame on every submit", async ({ page }) => {
+test("following outer form reloads frame on every submit", async ({ page }) => {
   await page.click("#outer-frame-submit")
   await nextEventNamed(page, "turbo:before-fetch-request")
 
@@ -558,7 +558,7 @@ test("test following outer form reloads frame on every submit", async ({ page })
   await nextEventNamed(page, "turbo:before-fetch-request")
 })
 
-test("test an inner/outer link reloads frame on every click", async ({ page }) => {
+test("an inner/outer link reloads frame on every click", async ({ page }) => {
   await page.click("#inner-outer-frame-link")
   await nextEventNamed(page, "turbo:before-fetch-request")
 
@@ -566,7 +566,7 @@ test("test an inner/outer link reloads frame on every click", async ({ page }) =
   await nextEventNamed(page, "turbo:before-fetch-request")
 })
 
-test("test an inner/outer form reloads frame on every submit", async ({ page }) => {
+test("an inner/outer form reloads frame on every submit", async ({ page }) => {
   await page.click("#inner-outer-frame-submit")
   await nextEventNamed(page, "turbo:before-fetch-request")
 
@@ -574,7 +574,7 @@ test("test an inner/outer form reloads frame on every submit", async ({ page }) 
   await nextEventNamed(page, "turbo:before-fetch-request")
 })
 
-test("test reconnecting after following a link does not reload the frame", async ({ page }) => {
+test("reconnecting after following a link does not reload the frame", async ({ page }) => {
   await page.click("#hello a")
   await nextEventNamed(page, "turbo:before-fetch-request")
 
@@ -596,7 +596,7 @@ test("test reconnecting after following a link does not reload the frame", async
   assert.equal(requestLogs.length, 0)
 })
 
-test("test navigating pushing URL state from a frame navigation fires events", async ({ page }) => {
+test("navigating pushing URL state from a frame navigation fires events", async ({ page }) => {
   await page.click("#link-outside-frame-action-advance")
 
   assert.equal(
@@ -620,7 +620,7 @@ test("test navigating pushing URL state from a frame navigation fires events", a
   assert.notOk(await nextAttributeMutationNamed(page, "html", "aria-busy"), "removes aria-busy from the <html>")
 })
 
-test("test navigating a frame with a form[method=get] that does not redirect still updates the [src]", async ({
+test("navigating a frame with a form[method=get] that does not redirect still updates the [src]", async ({
   page
 }) => {
   await page.click("#frame-form-get-no-redirect")
@@ -639,7 +639,7 @@ test("test navigating a frame with a form[method=get] that does not redirect sti
   assert.equal(pathname(page.url()), "/src/tests/fixtures/frames.html")
 })
 
-test("test navigating turbo-frame[data-turbo-action=advance] from within pushes URL state", async ({ page }) => {
+test("navigating turbo-frame[data-turbo-action=advance] from within pushes URL state", async ({ page }) => {
   await page.click("#add-turbo-action-to-frame")
   await page.click("#link-frame")
   await nextEventNamed(page, "turbo:load")
@@ -652,7 +652,7 @@ test("test navigating turbo-frame[data-turbo-action=advance] from within pushes 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame.html")
 })
 
-test("test navigating turbo-frame[data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
+test("navigating turbo-frame[data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
   page
 }) => {
   await page.click("#link-outside-frame-action-advance")
@@ -667,7 +667,7 @@ test("test navigating turbo-frame[data-turbo-action=advance] to the same URL cle
   assert.equal(await attributeForSelector(page, "#html", "data-turbo-preview"), null, "clears html[aria-busy]")
 })
 
-test("test navigating a turbo-frame with an a[data-turbo-action=advance] preserves page state", async ({ page }) => {
+test("navigating a turbo-frame with an a[data-turbo-action=advance] preserves page state", async ({ page }) => {
   await scrollToSelector(page, "#below-the-fold-input")
   await page.fill("#below-the-fold-input", "a value")
   await page.click("#below-the-fold-link-frame-action")
@@ -687,7 +687,7 @@ test("test navigating a turbo-frame with an a[data-turbo-action=advance] preserv
   assert.notEqual(y, 0, "preserves Y scroll position")
 })
 
-test("test a turbo-frame that has been driven by a[data-turbo-action] can be navigated normally", async ({ page }) => {
+test("a turbo-frame that has been driven by a[data-turbo-action] can be navigated normally", async ({ page }) => {
   await page.click("#remove-target-from-hello")
   await page.click("#link-hello-advance")
   await nextEventNamed(page, "turbo:load")
@@ -704,7 +704,7 @@ test("test a turbo-frame that has been driven by a[data-turbo-action] can be nav
   assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html")
 })
 
-test("test navigating turbo-frame from within with a[data-turbo-action=advance] pushes URL state", async ({ page }) => {
+test("navigating turbo-frame from within with a[data-turbo-action=advance] pushes URL state", async ({ page }) => {
   await page.click("#link-nested-frame-action-advance")
   await nextEventNamed(page, "turbo:load")
 
@@ -719,7 +719,7 @@ test("test navigating turbo-frame from within with a[data-turbo-action=advance] 
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test("test navigating frame with a[data-turbo-action=advance] pushes URL state", async ({ page }) => {
+test("navigating frame with a[data-turbo-action=advance] pushes URL state", async ({ page }) => {
   await page.click("#link-outside-frame-action-advance")
   await nextEventNamed(page, "turbo:load")
 
@@ -734,7 +734,7 @@ test("test navigating frame with a[data-turbo-action=advance] pushes URL state",
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test("test navigating frame with form[method=get][data-turbo-action=advance] pushes URL state", async ({ page }) => {
+test("navigating frame with form[method=get][data-turbo-action=advance] pushes URL state", async ({ page }) => {
   await page.click("#form-get-frame-action-advance button")
   await nextEventNamed(page, "turbo:load")
 
@@ -749,7 +749,7 @@ test("test navigating frame with form[method=get][data-turbo-action=advance] pus
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test("test navigating frame with form[method=get][data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
+test("navigating frame with form[method=get][data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
   page
 }) => {
   await page.click("#form-get-frame-action-advance button")
@@ -764,7 +764,7 @@ test("test navigating frame with form[method=get][data-turbo-action=advance] to 
   assert.equal(await attributeForSelector(page, "#html", "data-turbo-preview"), null, "clears html[aria-busy]")
 })
 
-test("test navigating frame with form[method=post][data-turbo-action=advance] pushes URL state", async ({ page }) => {
+test("navigating frame with form[method=post][data-turbo-action=advance] pushes URL state", async ({ page }) => {
   await page.click("#form-post-frame-action-advance button")
   await nextEventNamed(page, "turbo:load")
 
@@ -779,7 +779,7 @@ test("test navigating frame with form[method=post][data-turbo-action=advance] pu
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test("test navigating frame with form[method=post][data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
+test("navigating frame with form[method=post][data-turbo-action=advance] to the same URL clears the [aria-busy] and [data-turbo-preview] state", async ({
   page
 }) => {
   await page.click("#form-post-frame-action-advance button")
@@ -795,7 +795,7 @@ test("test navigating frame with form[method=post][data-turbo-action=advance] to
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test("test navigating frame with button[data-turbo-action=advance] pushes URL state", async ({ page }) => {
+test("navigating frame with button[data-turbo-action=advance] pushes URL state", async ({ page }) => {
   await page.click("#button-frame-action-advance")
   await nextEventNamed(page, "turbo:load")
 
@@ -810,7 +810,7 @@ test("test navigating frame with button[data-turbo-action=advance] pushes URL st
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test("test navigating back after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames previous contents", async ({
+test("navigating back after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames previous contents", async ({
   page
 }) => {
   await page.click("#add-turbo-action-to-frame")
@@ -829,7 +829,7 @@ test("test navigating back after pushing URL state from a turbo-frame[data-turbo
   assert.equal(await propertyForSelector(page, "#frame", "src"), null)
 })
 
-test("test navigating back then forward after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames next contents", async ({
+test("navigating back then forward after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames next contents", async ({
   page
 }) => {
   await page.click("#add-turbo-action-to-frame")
@@ -851,17 +851,17 @@ test("test navigating back then forward after pushing URL state from a turbo-fra
   assert.ok(await hasSelector(page, "#frame[complete]"), "marks the frame as [complete]")
 })
 
-test("test turbo:before-fetch-request fires on the frame element", async ({ page }) => {
+test("turbo:before-fetch-request fires on the frame element", async ({ page }) => {
   await page.click("#hello a")
   assert.ok(await nextEventOnTarget(page, "frame", "turbo:before-fetch-request"))
 })
 
-test("test turbo:before-fetch-response fires on the frame element", async ({ page }) => {
+test("turbo:before-fetch-response fires on the frame element", async ({ page }) => {
   await page.click("#hello a")
   assert.ok(await nextEventOnTarget(page, "frame", "turbo:before-fetch-response"))
 })
 
-test("test navigating a eager frame with a link[method=get] that does not fetch eager frame twice", async ({
+test("navigating a eager frame with a link[method=get] that does not fetch eager frame twice", async ({
   page
 }) => {
   await page.click("#link-to-eager-loaded-frame")

--- a/src/tests/functional/import_tests.js
+++ b/src/tests/functional/import_tests.js
@@ -1,7 +1,7 @@
 import { test } from "@playwright/test"
 import { assert } from "chai"
 
-test("test window variable with ESM", async ({ page }) => {
+test("window variable with ESM", async ({ page }) => {
   await page.goto("/src/tests/fixtures/esm.html")
   const type = await page.evaluate(() => {
     return typeof window.Turbo

--- a/src/tests/functional/loading_tests.js
+++ b/src/tests/functional/loading_tests.js
@@ -17,13 +17,13 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("test eager loading within a details element", async ({ page }) => {
+test("eager loading within a details element", async ({ page }) => {
   await nextBeat()
   assert.ok(await hasSelector(page, "#loading-eager turbo-frame#frame h2"))
   assert.ok(await hasSelector(page, "#loading-eager turbo-frame[complete]"), "has [complete] attribute")
 })
 
-test("test lazy loading within a details element", async ({ page }) => {
+test("lazy loading within a details element", async ({ page }) => {
   await nextBeat()
 
   const frameContents = "#loading-lazy turbo-frame h2"
@@ -38,7 +38,7 @@ test("test lazy loading within a details element", async ({ page }) => {
   assert.ok(await hasSelector(page, "#loading-lazy turbo-frame[complete]"), "has [complete] attribute")
 })
 
-test("test changing loading attribute from lazy to eager loads frame", async ({ page }) => {
+test("changing loading attribute from lazy to eager loads frame", async ({ page }) => {
   const frameContents = "#loading-lazy turbo-frame h2"
   await nextBeat()
 
@@ -52,7 +52,7 @@ test("test changing loading attribute from lazy to eager loads frame", async ({ 
   assert.equal(await contents.textContent(), "Hello from a frame")
 })
 
-test("test navigating a visible frame with loading=lazy navigates", async ({ page }) => {
+test("navigating a visible frame with loading=lazy navigates", async ({ page }) => {
   await page.click("#loading-lazy summary")
   await nextBeat()
 
@@ -66,7 +66,7 @@ test("test navigating a visible frame with loading=lazy navigates", async ({ pag
   assert.equal(await navigatedContents.textContent(), "Frames: #hello")
 })
 
-test("test changing src attribute on a frame with loading=lazy defers navigation", async ({ page }) => {
+test("changing src attribute on a frame with loading=lazy defers navigation", async ({ page }) => {
   const frameContents = "#loading-lazy turbo-frame h2"
   await nextBeat()
 
@@ -82,7 +82,7 @@ test("test changing src attribute on a frame with loading=lazy defers navigation
   assert.equal(await contents.textContent(), "Frames: #hello")
 })
 
-test("test changing src attribute on a frame with loading=eager navigates", async ({ page }) => {
+test("changing src attribute on a frame with loading=eager navigates", async ({ page }) => {
   const frameContents = "#loading-eager turbo-frame h2"
   await nextBeat()
 
@@ -97,7 +97,7 @@ test("test changing src attribute on a frame with loading=eager navigates", asyn
   assert.equal(await contents.textContent(), "Frames: #frame")
 })
 
-test("test reloading a frame reloads the content", async ({ page }) => {
+test("reloading a frame reloads the content", async ({ page }) => {
   await page.click("#loading-eager summary")
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
@@ -110,7 +110,7 @@ test("test reloading a frame reloads the content", async ({ page }) => {
   assert.equal(await nextAttributeMutationNamed(page, "frame", "complete"), null, "clears [complete] attribute")
 })
 
-test("test navigating away from a page does not reload its frames", async ({ page }) => {
+test("navigating away from a page does not reload its frames", async ({ page }) => {
   await page.click("#one")
   await nextBody(page)
 
@@ -119,7 +119,7 @@ test("test navigating away from a page does not reload its frames", async ({ pag
   assert.equal(requestLogs.length, 1)
 })
 
-test("test removing the [complete] attribute of an eager frame reloads the content", async ({ page }) => {
+test("removing the [complete] attribute of an eager frame reloads the content", async ({ page }) => {
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
   await page.evaluate(() => document.querySelector("#loading-eager turbo-frame")?.removeAttribute("complete"))
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
@@ -130,7 +130,7 @@ test("test removing the [complete] attribute of an eager frame reloads the conte
   )
 })
 
-test("test changing [src] attribute on a [complete] frame with loading=lazy defers navigation", async ({ page }) => {
+test("changing [src] attribute on a [complete] frame with loading=lazy defers navigation", async ({ page }) => {
   await page.click("#loading-lazy summary")
   await nextEventOnTarget(page, "hello", "turbo:frame-load")
 
@@ -165,7 +165,7 @@ test("test changing [src] attribute on a [complete] frame with loading=lazy defe
   assert.equal(src.pathname, "/src/tests/fixtures/frames.html", "lazy frame navigates")
 })
 
-test("test navigating away from a page and then back does not reload its frames", async ({ page }) => {
+test("navigating away from a page and then back does not reload its frames", async ({ page }) => {
   await page.click("#one")
   await nextBody(page)
   await readEventLogs(page)
@@ -186,7 +186,7 @@ test("test navigating away from a page and then back does not reload its frames"
   await nextEventOnTarget(page, "hello", "turbo:frame-load")
 })
 
-test("test disconnecting and reconnecting a frame does not reload the frame", async ({ page }) => {
+test("disconnecting and reconnecting a frame does not reload the frame", async ({ page }) => {
   await nextBeat()
 
   await page.evaluate(() => {

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -27,7 +27,7 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("test navigating renders a progress bar", async ({ page }) => {
+test("navigating renders a progress bar", async ({ page }) => {
   assert.equal(
     await page.locator("style").evaluate((style) => style.nonce),
     "123",
@@ -46,19 +46,19 @@ test("test navigating renders a progress bar", async ({ page }) => {
   assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
 })
 
-test("test navigating does not render a progress bar before expiring the delay", async ({ page }) => {
+test("navigating does not render a progress bar before expiring the delay", async ({ page }) => {
   await page.evaluate(() => window.Turbo.setProgressBarDelay(1000))
   await page.click("#same-origin-unannotated-link")
 
   assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "does not show progress bar before delay")
 })
 
-test("test after loading the page", async ({ page }) => {
+test("after loading the page", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
   assert.equal(await visitAction(page), "load")
 })
 
-test("test following a same-origin unannotated link", async ({ page }) => {
+test("following a same-origin unannotated link", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
@@ -75,7 +75,7 @@ test("test following a same-origin unannotated link", async ({ page }) => {
   )
 })
 
-test("test following a same-origin unannotated custom element link", async ({ page }) => {
+test("following a same-origin unannotated custom element link", async ({ page }) => {
   await nextBeat()
   await page.evaluate(() => {
     const shadowRoot = document.querySelector("#custom-link-element")?.shadowRoot
@@ -88,42 +88,42 @@ test("test following a same-origin unannotated custom element link", async ({ pa
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test drive enabled; click an element in the shadow DOM wrapped by a link in the light DOM", async ({ page }) => {
+test("drive enabled; click an element in the shadow DOM wrapped by a link in the light DOM", async ({ page }) => {
   await page.click("#shadow-dom-drive-enabled span")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test drive disabled; click an element in the shadow DOM within data-turbo='false'", async ({ page }) => {
+test("drive disabled; click an element in the shadow DOM within data-turbo='false'", async ({ page }) => {
   await page.click("#shadow-dom-drive-disabled span")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "load")
 })
 
-test("test drive enabled; click an element in the slot", async ({ page }) => {
+test("drive enabled; click an element in the slot", async ({ page }) => {
   await page.click("#element-in-slot")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test drive disabled; click an element in the slot within data-turbo='false'", async ({ page }) => {
+test("drive disabled; click an element in the slot within data-turbo='false'", async ({ page }) => {
   await page.click("#element-in-slot-disabled")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "load")
 })
 
-test("test drive disabled; click an element in the nested slot within data-turbo='false'", async ({ page }) => {
+test("drive disabled; click an element in the nested slot within data-turbo='false'", async ({ page }) => {
   await page.click("#element-in-nested-slot-disabled")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "load")
 })
 
-test("test following a same-origin unannotated link with search params", async ({ page }) => {
+test("following a same-origin unannotated link with search params", async ({ page }) => {
   await page.click("#same-origin-unannotated-link-search-params")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
@@ -131,14 +131,14 @@ test("test following a same-origin unannotated link with search params", async (
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test following a same-origin unannotated form[method=GET]", async ({ page }) => {
+test("following a same-origin unannotated form[method=GET]", async ({ page }) => {
   await page.click("#same-origin-unannotated-form button")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test following a same-origin data-turbo-method=get link", async ({ page }) => {
+test("following a same-origin data-turbo-method=get link", async ({ page }) => {
   await page.click("#same-origin-get-link-form")
   await nextEventNamed(page, "turbo:submit-start")
   await nextEventNamed(page, "turbo:submit-end")
@@ -149,28 +149,28 @@ test("test following a same-origin data-turbo-method=get link", async ({ page })
   assert.equal(getSearchParam(page.url(), "b"), "two")
 })
 
-test("test following a same-origin data-turbo-action=replace link", async ({ page }) => {
+test("following a same-origin data-turbo-action=replace link", async ({ page }) => {
   await page.click("#same-origin-replace-link")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "replace")
 })
 
-test("test following a same-origin GET form[data-turbo-action=replace]", async ({ page }) => {
+test("following a same-origin GET form[data-turbo-action=replace]", async ({ page }) => {
   await page.click("#same-origin-replace-form-get button")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "replace")
 })
 
-test("test following a same-origin GET form button[data-turbo-action=replace]", async ({ page }) => {
+test("following a same-origin GET form button[data-turbo-action=replace]", async ({ page }) => {
   await page.click("#same-origin-replace-form-submitter-get button")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "replace")
 })
 
-test("test following a same-origin POST form[data-turbo-action=replace]", async ({ page }) => {
+test("following a same-origin POST form[data-turbo-action=replace]", async ({ page }) => {
   await page.click("#same-origin-replace-form-post button")
   await nextBody(page)
 
@@ -178,7 +178,7 @@ test("test following a same-origin POST form[data-turbo-action=replace]", async 
   assert.equal(await visitAction(page), "replace")
 })
 
-test("test following a same-origin POST form button[data-turbo-action=replace]", async ({ page }) => {
+test("following a same-origin POST form button[data-turbo-action=replace]", async ({ page }) => {
   await page.click("#same-origin-replace-form-submitter-post button")
   await nextEventNamed(page, "turbo:load")
 
@@ -186,7 +186,7 @@ test("test following a same-origin POST form button[data-turbo-action=replace]",
   assert.equal(await visitAction(page), "replace")
 })
 
-test("test following a POST form clears cache", async ({ page }) => {
+test("following a POST form clears cache", async ({ page }) => {
   await page.evaluate(() => {
     const cachedElement = document.createElement("some-cached-element")
     document.body.appendChild(cachedElement)
@@ -205,7 +205,7 @@ test("test following a POST form clears cache", async ({ page }) => {
   assert.notOk(await hasSelector(page, "some-cached-element"))
 })
 
-test("test following a same-origin POST link with data-turbo-action=replace", async ({ page }) => {
+test("following a same-origin POST link with data-turbo-action=replace", async ({ page }) => {
   await page.click("#same-origin-replace-post-link")
   await nextBody(page)
 
@@ -213,28 +213,28 @@ test("test following a same-origin POST link with data-turbo-action=replace", as
   assert.equal(await visitAction(page), "replace")
 })
 
-test("test following a same-origin data-turbo=false link", async ({ page }) => {
+test("following a same-origin data-turbo=false link", async ({ page }) => {
   await page.click("#same-origin-false-link")
   await page.waitForEvent("load")
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "load")
 })
 
-test("test following a same-origin unannotated link inside a data-turbo=false container", async ({ page }) => {
+test("following a same-origin unannotated link inside a data-turbo=false container", async ({ page }) => {
   await page.click("#same-origin-unannotated-link-inside-false-container")
   await page.waitForEvent("load")
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "load")
 })
 
-test("test following a same-origin data-turbo=true link inside a data-turbo=false container", async ({ page }) => {
+test("following a same-origin data-turbo=true link inside a data-turbo=false container", async ({ page }) => {
   await page.click("#same-origin-true-link-inside-false-container")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test following a same-origin anchored link", async ({ page }) => {
+test("following a same-origin anchored link", async ({ page }) => {
   await page.click("#same-origin-anchored-link")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
@@ -243,7 +243,7 @@ test("test following a same-origin anchored link", async ({ page }) => {
   assert(await isScrolledToSelector(page, "#element-id"))
 })
 
-test("test following a same-origin link to a named anchor", async ({ page }) => {
+test("following a same-origin link to a named anchor", async ({ page }) => {
   await page.click("#same-origin-anchored-link-named")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
@@ -252,21 +252,21 @@ test("test following a same-origin link to a named anchor", async ({ page }) => 
   assert(await isScrolledToSelector(page, "[name=named-anchor]"))
 })
 
-test("test following a cross-origin unannotated link", async ({ page }) => {
+test("following a cross-origin unannotated link", async ({ page }) => {
   await page.click("#cross-origin-unannotated-link")
   await nextBody(page)
   assert.equal(page.url(), "about:blank")
   assert.equal(await visitAction(page), "load")
 })
 
-test("test following a same-origin [target] link", async ({ page }) => {
+test("following a same-origin [target] link", async ({ page }) => {
   const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#same-origin-targeted-link")])
 
   assert.equal(pathname(popup.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(popup), "load")
 })
 
-test("test following a same-origin [download] link", async ({ page }) => {
+test("following a same-origin [download] link", async ({ page }) => {
   assert.notOk(
     await willChangeBody(page, async () => {
       await page.click("#same-origin-download-link")
@@ -277,21 +277,21 @@ test("test following a same-origin [download] link", async ({ page }) => {
   assert.equal(await visitAction(page), "load")
 })
 
-test("test following a same-origin link inside an SVG element", async ({ page }) => {
+test("following a same-origin link inside an SVG element", async ({ page }) => {
   await page.click("#same-origin-link-inside-svg-element", { force: true })
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test following a cross-origin link inside an SVG element", async ({ page }) => {
+test("following a cross-origin link inside an SVG element", async ({ page }) => {
   await page.click("#cross-origin-link-inside-svg-element", { force: true })
   await nextBody(page)
   assert.equal(page.url(), "about:blank")
   assert.equal(await visitAction(page), "load")
 })
 
-test("test clicking the back button", async ({ page }) => {
+test("clicking the back button", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
   await nextBody(page)
   await page.goBack()
@@ -299,7 +299,7 @@ test("test clicking the back button", async ({ page }) => {
   assert.equal(await visitAction(page), "restore")
 })
 
-test("test clicking the forward button", async ({ page }) => {
+test("clicking the forward button", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
   await nextBody(page)
   await page.goBack()
@@ -308,14 +308,14 @@ test("test clicking the forward button", async ({ page }) => {
   assert.equal(await visitAction(page), "restore")
 })
 
-test("test link targeting a disabled turbo-frame navigates the page", async ({ page }) => {
+test("link targeting a disabled turbo-frame navigates the page", async ({ page }) => {
   await page.click("#link-to-disabled-frame")
   await nextBody(page)
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html")
 })
 
-test("test skip link with hash-only path scrolls to the anchor without a visit", async ({ page }) => {
+test("skip link with hash-only path scrolls to the anchor without a visit", async ({ page }) => {
   assert.notOk(
     await willChangeBody(page, async () => {
       await page.click('a[href="#main"]')
@@ -328,7 +328,7 @@ test("test skip link with hash-only path scrolls to the anchor without a visit",
   assert.equal(hash(page.url()), "#main")
 })
 
-test("test skip link with hash-only path moves focus and changes tab order", async ({ page }) => {
+test("skip link with hash-only path moves focus and changes tab order", async ({ page }) => {
   await page.click('a[href="#main"]')
   await nextBeat()
   await page.press("#main", "Tab")
@@ -339,7 +339,7 @@ test("test skip link with hash-only path moves focus and changes tab order", asy
   assert.equal(hash(page.url()), "#main")
 })
 
-test("test same-page anchored replace link assumes the intention was a refresh", async ({ page }) => {
+test("same-page anchored replace link assumes the intention was a refresh", async ({ page }) => {
   await page.click("#refresh-link")
   await nextBody(page)
   assert.ok(await isScrolledToSelector(page, "#main"), "scrolled to #main")
@@ -347,7 +347,7 @@ test("test same-page anchored replace link assumes the intention was a refresh",
   assert.equal(hash(page.url()), "#main")
 })
 
-test("test navigating back to anchored URL", async ({ page }) => {
+test("navigating back to anchored URL", async ({ page }) => {
   await clickWithoutScrolling(page, 'a[href="#main"]', { hasText: "Skip Link" })
   await nextBeat()
 
@@ -363,14 +363,14 @@ test("test navigating back to anchored URL", async ({ page }) => {
   assert.equal(hash(page.url()), "#main")
 })
 
-test("test following a redirection", async ({ page }) => {
+test("following a redirection", async ({ page }) => {
   await page.click("#redirection-link")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "replace")
 })
 
-test("test clicking the back button after redirection", async ({ page }) => {
+test("clicking the back button after redirection", async ({ page }) => {
   await page.click("#redirection-link")
   await nextBody(page)
   await page.goBack()
@@ -378,7 +378,7 @@ test("test clicking the back button after redirection", async ({ page }) => {
   assert.equal(await visitAction(page), "restore")
 })
 
-test("test same-page anchor visits do not trigger visit events", async ({ page }) => {
+test("same-page anchor visits do not trigger visit events", async ({ page }) => {
   const events = [
     "turbo:before-visit",
     "turbo:visit",
@@ -395,7 +395,7 @@ test("test same-page anchor visits do not trigger visit events", async ({ page }
   }
 })
 
-test("test correct referrer header", async ({ page }) => {
+test("correct referrer header", async ({ page }) => {
   page.click("#headers-link")
   await nextBody(page)
   const pre = await page.textContent("pre")
@@ -407,7 +407,7 @@ test("test correct referrer header", async ({ page }) => {
   )
 })
 
-test("test double-clicking on a link", async ({ page }) => {
+test("double-clicking on a link", async ({ page }) => {
   await page.click("#delayed-link", { clickCount: 2 })
   await nextBeat()
 
@@ -417,7 +417,7 @@ test("test double-clicking on a link", async ({ page }) => {
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test does not fire turbo:load twice after following a redirect", async ({ page }) => {
+test("does not fire turbo:load twice after following a redirect", async ({ page }) => {
   page.click("#redirection-link")
 
   await nextBeat() // 301 redirect response
@@ -429,7 +429,7 @@ test("test does not fire turbo:load twice after following a redirect", async ({ 
   await nextEventNamed(page, "turbo:load")
 })
 
-test("test navigating back whilst a visit is in-flight", async ({ page }) => {
+test("navigating back whilst a visit is in-flight", async ({ page }) => {
   page.click("#delayed-link")
   await nextEventNamed(page, "turbo:before-render")
   await page.goBack()
@@ -444,7 +444,7 @@ test("test navigating back whilst a visit is in-flight", async ({ page }) => {
   assert.equal(await visitAction(page), "restore")
 })
 
-test("test ignores links with a [target] attribute that target an iframe with a matching [name]", async ({ page }) => {
+test("ignores links with a [target] attribute that target an iframe with a matching [name]", async ({ page }) => {
   await page.click("#link-target-iframe")
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
@@ -453,7 +453,7 @@ test("test ignores links with a [target] attribute that target an iframe with a 
   assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
 })
 
-test("test ignores links with a [target] attribute that targets an iframe with [name='']", async ({ page }) => {
+test("ignores links with a [target] attribute that targets an iframe with [name='']", async ({ page }) => {
   await page.click("#link-target-empty-name-iframe")
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
@@ -461,7 +461,7 @@ test("test ignores links with a [target] attribute that targets an iframe with [
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
 })
 
-test("test ignores forms with a [target] attribute that targets an iframe with a matching [name]", async ({ page }) => {
+test("ignores forms with a [target] attribute that targets an iframe with a matching [name]", async ({ page }) => {
   await page.click("#form-target-iframe button")
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
@@ -470,7 +470,7 @@ test("test ignores forms with a [target] attribute that targets an iframe with a
   assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
 })
 
-test("test ignores forms with a button[formtarget] attribute that targets an iframe with [name='']", async ({
+test("ignores forms with a button[formtarget] attribute that targets an iframe with [name='']", async ({
   page
 }) => {
   await page.click("#form-target-empty-name-iframe button")
@@ -480,7 +480,7 @@ test("test ignores forms with a button[formtarget] attribute that targets an ifr
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
 })
 
-test("test ignores forms with a button[formtarget] attribute that targets an iframe with a matching [name]", async ({
+test("ignores forms with a button[formtarget] attribute that targets an iframe with a matching [name]", async ({
   page
 }) => {
   await page.click("#button-formtarget-iframe")
@@ -491,7 +491,7 @@ test("test ignores forms with a button[formtarget] attribute that targets an ifr
   assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
 })
 
-test("test ignores forms with a [target] attribute that target an iframe with [name='']", async ({ page }) => {
+test("ignores forms with a [target] attribute that target an iframe with [name='']", async ({ page }) => {
   await page.click("#button-formtarget-empty-name-iframe")
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")

--- a/src/tests/functional/pausable_rendering_tests.js
+++ b/src/tests/functional/pausable_rendering_tests.js
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/pausable_rendering.html")
 })
 
-test("test pauses and resumes rendering", async ({ page }) => {
+test("pauses and resumes rendering", async ({ page }) => {
   page.on("dialog", (dialog) => {
     assert.strictEqual(dialog.message(), "Continue rendering?")
     dialog.accept()
@@ -18,7 +18,7 @@ test("test pauses and resumes rendering", async ({ page }) => {
   assert.equal(await page.textContent("h1"), "One")
 })
 
-test("test aborts rendering", async ({ page }) => {
+test("aborts rendering", async ({ page }) => {
   const [firstDialog] = await Promise.all([page.waitForEvent("dialog"), page.click("#link")])
 
   assert.strictEqual(firstDialog.message(), "Continue rendering?")
@@ -28,7 +28,7 @@ test("test aborts rendering", async ({ page }) => {
   assert.equal(await page.textContent("h1"), "Pausable Rendering")
 })
 
-test("test pauses and resumes rendering a Frame", async ({ page }) => {
+test("pauses and resumes rendering a Frame", async ({ page }) => {
   page.on("dialog", (dialog) => {
     assert.strictEqual(dialog.message(), "Continue rendering?")
     dialog.accept()
@@ -40,7 +40,7 @@ test("test pauses and resumes rendering a Frame", async ({ page }) => {
   assert.equal(await page.textContent("#hello h2"), "Hello from a frame")
 })
 
-test("test aborts rendering a Frame", async ({ page }) => {
+test("aborts rendering a Frame", async ({ page }) => {
   page.on("dialog", (dialog) => {
     assert.strictEqual(dialog.message(), "Continue rendering?")
     dialog.dismiss()

--- a/src/tests/functional/pausable_requests_tests.js
+++ b/src/tests/functional/pausable_requests_tests.js
@@ -6,7 +6,7 @@ test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/pausable_requests.html")
 })
 
-test("test pauses and resumes request", async ({ page }) => {
+test("pauses and resumes request", async ({ page }) => {
   page.once("dialog", (dialog) => {
     assert.strictEqual(dialog.message(), "Continue request?")
     dialog.accept()
@@ -18,7 +18,7 @@ test("test pauses and resumes request", async ({ page }) => {
   assert.equal(await page.textContent("h1"), "One")
 })
 
-test("test aborts request", async ({ page }) => {
+test("aborts request", async ({ page }) => {
   page.once("dialog", (dialog) => {
     assert.strictEqual(dialog.message(), "Continue request?")
     dialog.dismiss()

--- a/src/tests/functional/preloader_tests.js
+++ b/src/tests/functional/preloader_tests.js
@@ -2,7 +2,7 @@ import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBeat } from "../helpers/page"
 
-test("test preloads snapshot on initial load", async ({ page }) => {
+test("preloads snapshot on initial load", async ({ page }) => {
   // contains `a[rel="preload"][href="http://localhost:9000/src/tests/fixtures/preloaded.html"]`
   await page.goto("/src/tests/fixtures/preloading.html")
   await nextBeat()
@@ -17,7 +17,7 @@ test("test preloads snapshot on initial load", async ({ page }) => {
   )
 })
 
-test("test preloads snapshot on page visit", async ({ page }) => {
+test("preloads snapshot on page visit", async ({ page }) => {
   // contains `a[rel="preload"][href="http://localhost:9000/src/tests/fixtures/preloading.html"]`
   await page.goto("/src/tests/fixtures/hot_preloading.html")
 
@@ -36,7 +36,7 @@ test("test preloads snapshot on page visit", async ({ page }) => {
   )
 })
 
-test("test navigates to preloaded snapshot from frame", async ({ page }) => {
+test("navigates to preloaded snapshot from frame", async ({ page }) => {
   // contains `a[rel="preload"][href="http://localhost:9000/src/tests/fixtures/preloaded.html"]`
   await page.goto("/src/tests/fixtures/frame_preloading.html")
   await page.waitForSelector("#frame_preload_anchor")

--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -26,7 +26,7 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("test triggers before-render and render events", async ({ page }) => {
+test("triggers before-render and render events", async ({ page }) => {
   await page.click("#same-origin-link")
   const { newBody } = await nextEventNamed(page, "turbo:before-render")
 
@@ -36,7 +36,7 @@ test("test triggers before-render and render events", async ({ page }) => {
   assert.equal(await newBody, await page.evaluate(() => document.body.outerHTML))
 })
 
-test("test includes isPreview in render event details", async ({ page }) => {
+test("includes isPreview in render event details", async ({ page }) => {
   await page.click("#same-origin-link")
 
   const { isPreview } = await nextEventNamed(page, "turbo:before-render")
@@ -46,7 +46,7 @@ test("test includes isPreview in render event details", async ({ page }) => {
   assert.equal(await isPreview, false)
 })
 
-test("test triggers before-render, render, and load events for error pages", async ({ page }) => {
+test("triggers before-render, render, and load events for error pages", async ({ page }) => {
   await page.click("#nonexistent-link")
   const { newBody } = await nextEventNamed(page, "turbo:before-render")
 
@@ -58,7 +58,7 @@ test("test triggers before-render, render, and load events for error pages", asy
   await nextEventNamed(page, "turbo:load")
 })
 
-test("test reloads when tracked elements change", async ({ page }) => {
+test("reloads when tracked elements change", async ({ page }) => {
   await page.evaluate(() =>
     window.addEventListener(
       "turbo:reload",
@@ -79,7 +79,7 @@ test("test reloads when tracked elements change", async ({ page }) => {
   assert.equal(reason, "tracked_element_mismatch")
 })
 
-test("test reloads when tracked elements change due to failed form submission", async ({ page }) => {
+test("reloads when tracked elements change due to failed form submission", async ({ page }) => {
   await page.click("#tracked-asset-change-form button")
   await nextBeat()
 
@@ -113,7 +113,7 @@ test("test reloads when tracked elements change due to failed form submission", 
   assert.equal(unloaded, "true")
 })
 
-test("test before-render event supports custom render function", async ({ page }) => {
+test("before-render event supports custom render function", async ({ page }) => {
   await page.evaluate(() =>
     addEventListener("turbo:before-render", (event) => {
       const { detail } = event
@@ -131,7 +131,7 @@ test("test before-render event supports custom render function", async ({ page }
   assert.equal(await customRendered.textContent(), "Custom Rendered", "renders with custom function")
 })
 
-test("test before-render event supports async custom render function", async ({ page }) => {
+test("before-render event supports async custom render function", async ({ page }) => {
   await page.evaluate(() => {
     const nextEventLoopTick = () =>
       new Promise((resolve) => {
@@ -161,7 +161,7 @@ test("test before-render event supports async custom render function", async ({ 
   assert.equal(renderedElement, "Custom Rendered", "renders with custom function")
 })
 
-test("test wont reload when tracked elements has a nonce", async ({ page }) => {
+test("wont reload when tracked elements has a nonce", async ({ page }) => {
   await page.click("#tracked-nonce-tag-link")
   await nextBody(page)
 
@@ -169,7 +169,7 @@ test("test wont reload when tracked elements has a nonce", async ({ page }) => {
   assert.equal(await visitAction(page), "advance")
 })
 
-test("test reloads when turbo-visit-control setting is reload", async ({ page }) => {
+test("reloads when turbo-visit-control setting is reload", async ({ page }) => {
   await page.evaluate(() =>
     window.addEventListener(
       "turbo:reload",
@@ -190,7 +190,7 @@ test("test reloads when turbo-visit-control setting is reload", async ({ page })
   assert.equal(reason, "turbo_visit_control_is_reload")
 })
 
-test("test maintains scroll position before visit when turbo-visit-control setting is reload", async ({ page }) => {
+test("maintains scroll position before visit when turbo-visit-control setting is reload", async ({ page }) => {
   await scrollToSelector(page, "#below-the-fold-visit-control-reload-link")
   assert.notOk(await isScrolledToTop(page), "scrolled down")
 
@@ -215,14 +215,14 @@ test("test maintains scroll position before visit when turbo-visit-control setti
   assert.equal(await visitAction(page), "load")
 })
 
-test("test changes the html[lang] attribute", async ({ page }) => {
+test("changes the html[lang] attribute", async ({ page }) => {
   await page.click("#es_locale_link")
   await nextEventNamed(page, "turbo:load")
 
   assert.equal(await page.getAttribute("html", "lang"), "es")
 })
 
-test("test accumulates asset elements in head", async ({ page }) => {
+test("accumulates asset elements in head", async ({ page }) => {
   const assetElements = () => page.$$('script, style, link[rel="stylesheet"]')
   const originalElements = await assetElements()
 
@@ -239,7 +239,7 @@ test("test accumulates asset elements in head", async ({ page }) => {
   await disposeAll(...originalElements, ...newElements, ...finalElements)
 })
 
-test("test replaces provisional elements in head", async ({ page }) => {
+test("replaces provisional elements in head", async ({ page }) => {
   const provisionalElements = () => page.$$('head :not(script), head :not(style), head :not(link[rel="stylesheet"])')
   const originalElements = await provisionalElements()
   assert.equal(await page.locator("meta[name=test]").count(), 0)
@@ -259,7 +259,7 @@ test("test replaces provisional elements in head", async ({ page }) => {
   await disposeAll(...originalElements, ...newElements, ...finalElements)
 })
 
-test("test evaluates head stylesheet elements", async ({ page }) => {
+test("evaluates head stylesheet elements", async ({ page }) => {
   assert.equal(await isStylesheetEvaluated(page), false)
 
   await page.click("#additional-assets-link")
@@ -267,7 +267,7 @@ test("test evaluates head stylesheet elements", async ({ page }) => {
   assert.equal(await isStylesheetEvaluated(page), true)
 })
 
-test("test does not evaluate head stylesheet elements inside noscript elements", async ({ page }) => {
+test("does not evaluate head stylesheet elements inside noscript elements", async ({ page }) => {
   assert.equal(await isNoscriptStylesheetEvaluated(page), false)
 
   await page.click("#additional-assets-link")
@@ -275,7 +275,7 @@ test("test does not evaluate head stylesheet elements inside noscript elements",
   assert.equal(await isNoscriptStylesheetEvaluated(page), false)
 })
 
-test("test waits for CSS to be loaded before rendering", async ({ page }) => {
+test("waits for CSS to be loaded before rendering", async ({ page }) => {
   let finishLoadingCSS = (_value) => {}
   const promise = new Promise((resolve) => {
     finishLoadingCSS = resolve
@@ -298,7 +298,7 @@ test("test waits for CSS to be loaded before rendering", async ({ page }) => {
   assert.equal(await isStylesheetEvaluated(page), true)
 })
 
-test("test waits for CSS to fail before rendering", async ({ page }) => {
+test("waits for CSS to fail before rendering", async ({ page }) => {
   let finishLoadingCSS = (_value) => {}
   const promise = new Promise((resolve) => {
     finishLoadingCSS = resolve
@@ -321,7 +321,7 @@ test("test waits for CSS to fail before rendering", async ({ page }) => {
   assert.equal(await isStylesheetEvaluated(page), false)
 })
 
-test("test waits for some time, but renders if CSS takes too much to load", async ({ page }) => {
+test("waits for some time, but renders if CSS takes too much to load", async ({ page }) => {
   let finishLoadingCSS = (_value) => {}
   const promise = new Promise((resolve) => {
     finishLoadingCSS = resolve
@@ -359,7 +359,7 @@ test("skip evaluates head script elements once", async ({ page }) => {
   assert.equal(await headScriptEvaluationCount(page), 1)
 })
 
-test("test evaluates body script elements on each render", async ({ page }) => {
+test("evaluates body script elements on each render", async ({ page }) => {
   assert.equal(await bodyScriptEvaluationCount(page), undefined)
 
   await page.click("#body-script-link")
@@ -375,13 +375,13 @@ test("test evaluates body script elements on each render", async ({ page }) => {
   assert.equal(await bodyScriptEvaluationCount(page), 2)
 })
 
-test("test does not evaluate data-turbo-eval=false scripts", async ({ page }) => {
+test("does not evaluate data-turbo-eval=false scripts", async ({ page }) => {
   await page.click("#eval-false-script-link")
   await nextEventNamed(page, "turbo:render")
   assert.equal(await bodyScriptEvaluationCount(page), undefined)
 })
 
-test("test preserves permanent elements", async ({ page }) => {
+test("preserves permanent elements", async ({ page }) => {
   const permanentElement = await page.locator("#permanent")
   assert.equal(await permanentElement.textContent(), "Rendering")
 
@@ -395,14 +395,14 @@ test("test preserves permanent elements", async ({ page }) => {
   assert.ok(await strictElementEquals(permanentElement, await page.locator("#permanent")))
 })
 
-test("test restores focus during page rendering when transposing the activeElement", async ({ page }) => {
+test("restores focus during page rendering when transposing the activeElement", async ({ page }) => {
   await page.press("#permanent-input", "Enter")
   await nextBody(page)
 
   assert.ok(await selectorHasFocus(page, "#permanent-input"), "restores focus after page loads")
 })
 
-test("test restores focus during page rendering when transposing an ancestor of the activeElement", async ({
+test("restores focus during page rendering when transposing an ancestor of the activeElement", async ({
   page
 }) => {
   await page.press("#permanent-descendant-input", "Enter")
@@ -411,7 +411,7 @@ test("test restores focus during page rendering when transposing an ancestor of 
   assert.ok(await selectorHasFocus(page, "#permanent-descendant-input"), "restores focus after page loads")
 })
 
-test("test before-frame-render event supports custom render function within turbo-frames", async ({ page }) => {
+test("before-frame-render event supports custom render function within turbo-frames", async ({ page }) => {
   const frame = await page.locator("#frame")
   await frame.evaluate((frame) =>
     frame.addEventListener("turbo:before-frame-render", (event) => {
@@ -431,7 +431,7 @@ test("test before-frame-render event supports custom render function within turb
   assert.equal(await customRendered.textContent(), "Custom Rendered Frame", "renders with custom function")
 })
 
-test("test preserves permanent elements within turbo-frames", async ({ page }) => {
+test("preserves permanent elements within turbo-frames", async ({ page }) => {
   assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
 
   await page.click("#permanent-in-frame-element-link")
@@ -440,14 +440,14 @@ test("test preserves permanent elements within turbo-frames", async ({ page }) =
   assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
 })
 
-test("test restores focus during turbo-frame rendering when transposing the activeElement", async ({ page }) => {
+test("restores focus during turbo-frame rendering when transposing the activeElement", async ({ page }) => {
   await page.press("#permanent-input-in-frame", "Enter")
   await nextBeat()
 
   assert.ok(await selectorHasFocus(page, "#permanent-input-in-frame"), "restores focus after page loads")
 })
 
-test("test restores focus during turbo-frame rendering when transposing a descendant of the activeElement", async ({
+test("restores focus during turbo-frame rendering when transposing a descendant of the activeElement", async ({
   page
 }) => {
   await page.press("#permanent-descendant-input-in-frame", "Enter")
@@ -456,7 +456,7 @@ test("test restores focus during turbo-frame rendering when transposing a descen
   assert.ok(await selectorHasFocus(page, "#permanent-descendant-input-in-frame"), "restores focus after page loads")
 })
 
-test("test preserves permanent element video playback", async ({ page }) => {
+test("preserves permanent element video playback", async ({ page }) => {
   const videoElement = await page.locator("#permanent-video")
   await page.click("#permanent-video-button")
   await sleep(500)
@@ -471,7 +471,7 @@ test("test preserves permanent element video playback", async ({ page }) => {
   assert.equal(timeAfterRender, timeBeforeRender, "element state is preserved")
 })
 
-test("test preserves permanent element through Turbo Stream update", async ({ page }) => {
+test("preserves permanent element through Turbo Stream update", async ({ page }) => {
   await page.evaluate(() => {
     window.Turbo.renderStreamMessage(`
       <turbo-stream action="update" target="frame">
@@ -486,7 +486,7 @@ test("test preserves permanent element through Turbo Stream update", async ({ pa
   assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
 })
 
-test("test preserves permanent element through Turbo Stream append", async ({ page }) => {
+test("preserves permanent element through Turbo Stream append", async ({ page }) => {
   await page.evaluate(() => {
     window.Turbo.renderStreamMessage(`
       <turbo-stream action="append" target="frame">
@@ -501,7 +501,7 @@ test("test preserves permanent element through Turbo Stream append", async ({ pa
   assert.equal(await page.textContent("#permanent-in-frame"), "Rendering")
 })
 
-test("test preserves input values", async ({ page }) => {
+test("preserves input values", async ({ page }) => {
   await page.fill("#text-input", "test")
   await page.click("#checkbox-input")
   await page.click("#radio-input")
@@ -522,7 +522,7 @@ test("test preserves input values", async ({ page }) => {
   assert.equal(await propertyForSelector(page, "#select-multiple", "value"), "2")
 })
 
-test("test does not preserve password values", async ({ page }) => {
+test("does not preserve password values", async ({ page }) => {
   await page.fill("#password-input", "test")
 
   await page.click("#same-origin-link")
@@ -533,7 +533,7 @@ test("test does not preserve password values", async ({ page }) => {
   assert.equal(await propertyForSelector(page, "#password-input", "value"), "")
 })
 
-test("test <input type='reset'> clears values when restored from cache", async ({ page }) => {
+test("<input type='reset'> clears values when restored from cache", async ({ page }) => {
   await page.fill("#text-input", "test")
   await page.click("#checkbox-input")
   await page.click("#radio-input")
@@ -556,7 +556,7 @@ test("test <input type='reset'> clears values when restored from cache", async (
   assert.equal(await propertyForSelector(page, "#select-multiple", "value"), "")
 })
 
-test("test before-cache event", async ({ page }) => {
+test("before-cache event", async ({ page }) => {
   await page.evaluate(() => {
     addEventListener("turbo:before-cache", () => (document.body.innerHTML = "Modified"), { once: true })
   })
@@ -568,7 +568,7 @@ test("test before-cache event", async ({ page }) => {
   assert.equal(await page.textContent("body"), "Modified")
 })
 
-test("test mutation record-cache notification", async ({ page }) => {
+test("mutation record-cache notification", async ({ page }) => {
   await modifyBodyAfterRemoval(page)
   await page.click("#same-origin-link")
   await nextBody(page)
@@ -577,13 +577,13 @@ test("test mutation record-cache notification", async ({ page }) => {
   assert.equal(await page.textContent("body"), "Modified")
 })
 
-test("test error pages", async ({ page }) => {
+test("error pages", async ({ page }) => {
   await page.click("#nonexistent-link")
   await nextBody(page)
   assert.equal(await page.textContent("body"), "\nCannot GET /nonexistent\n\n\n")
 })
 
-test("test rendering a redirect response replaces the body once and only once", async ({ page }) => {
+test("rendering a redirect response replaces the body once and only once", async ({ page }) => {
   await page.click("#redirect-link")
   await nextBodyMutation(page)
 

--- a/src/tests/functional/scroll_restoration_tests.js
+++ b/src/tests/functional/scroll_restoration_tests.js
@@ -2,14 +2,14 @@ import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBeat, scrollPosition, scrollToSelector } from "../helpers/page"
 
-test("test landing on an anchor", async ({ page }) => {
+test("landing on an anchor", async ({ page }) => {
   await page.goto("/src/tests/fixtures/scroll_restoration.html#three")
   await nextBeat()
   const { y: yAfterLoading } = await scrollPosition(page)
   assert.notEqual(yAfterLoading, 0)
 })
 
-test("test reloading after scrolling", async ({ page }) => {
+test("reloading after scrolling", async ({ page }) => {
   await page.goto("/src/tests/fixtures/scroll_restoration.html")
   await scrollToSelector(page, "#three")
   const { y: yAfterScrolling } = await scrollPosition(page)
@@ -20,7 +20,7 @@ test("test reloading after scrolling", async ({ page }) => {
   assert.notEqual(yAfterReloading, 0)
 })
 
-test("test returning from history", async ({ page }) => {
+test("returning from history", async ({ page }) => {
   await page.goto("/src/tests/fixtures/scroll_restoration.html")
   await scrollToSelector(page, "#three")
   await page.goto("/src/tests/fixtures/bare.html")

--- a/src/tests/functional/stream_tests.js
+++ b/src/tests/functional/stream_tests.js
@@ -14,7 +14,7 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("test receiving a stream message", async ({ page }) => {
+test("receiving a stream message", async ({ page }) => {
   const messages = await page.locator("#messages .message")
 
   assert.deepEqual(await messages.allTextContents(), ["First"])
@@ -25,7 +25,7 @@ test("test receiving a stream message", async ({ page }) => {
   assert.deepEqual(await messages.allTextContents(), ["First", "Hello world!"])
 })
 
-test("test dispatches a turbo:before-stream-render event", async ({ page }) => {
+test("dispatches a turbo:before-stream-render event", async ({ page }) => {
   await page.click("#append-target button")
   await nextEventNamed(page, "turbo:submit-end")
   const [[type, { newStream }, target]] = await readEventLogs(page, 1)
@@ -36,7 +36,7 @@ test("test dispatches a turbo:before-stream-render event", async ({ page }) => {
   assert.ok(newStream.includes(`target="messages"`))
 })
 
-test("test receiving a stream message with css selector target", async ({ page }) => {
+test("receiving a stream message with css selector target", async ({ page }) => {
   const messages2 = await page.locator("#messages_2 .message")
   const messages3 = await page.locator("#messages_3 .message")
 
@@ -50,7 +50,7 @@ test("test receiving a stream message with css selector target", async ({ page }
   assert.deepEqual(await messages3.allTextContents(), ["Third", "Hello CSS!"])
 })
 
-test("test receiving a message without a template", async ({ page }) => {
+test("receiving a message without a template", async ({ page }) => {
   await page.evaluate(() =>
     window.Turbo.renderStreamMessage(`
       <turbo-stream action="remove" target="messages"></turbo-stream>
@@ -60,7 +60,7 @@ test("test receiving a message without a template", async ({ page }) => {
   assert.notOk(await waitUntilNoSelector(page, "#messages"), "removes target element")
 })
 
-test("test receiving a message with a <script> element", async ({ page }) => {
+test("receiving a message with a <script> element", async ({ page }) => {
   await page.evaluate(() =>
     window.Turbo.renderStreamMessage(`
       <turbo-stream action="append" target="messages">
@@ -77,7 +77,7 @@ test("test receiving a message with a <script> element", async ({ page }) => {
   assert.ok(await waitUntilText(page, "Hello from script"))
 })
 
-test("test overriding with custom StreamActions", async ({ page }) => {
+test("overriding with custom StreamActions", async ({ page }) => {
   const html = "Rendered with Custom Action"
 
   await page.evaluate((html) => {
@@ -104,7 +104,7 @@ test("test overriding with custom StreamActions", async ({ page }) => {
   assert.ok(await waitUntilText(page, "Rendered with Custom Action"), "evaluates custom StreamAction")
 })
 
-test("test receiving a stream message over SSE", async ({ page }) => {
+test("receiving a stream message over SSE", async ({ page }) => {
   await page.evaluate(() => {
     document.body.insertAdjacentHTML(
       "afterbegin",
@@ -142,7 +142,7 @@ test("test receiving a stream message over SSE", async ({ page }) => {
   assert.deepEqual(await messages.allTextContents(), ["First", "Hello world!"])
 })
 
-test("test receiving an update stream message preserves focus if the activeElement has an [id]", async ({ page }) => {
+test("receiving an update stream message preserves focus if the activeElement has an [id]", async ({ page }) => {
   await page.locator("input#container-element").focus()
   await page.evaluate(() => {
     window.Turbo.renderStreamMessage(`
@@ -156,7 +156,7 @@ test("test receiving an update stream message preserves focus if the activeEleme
   assert.ok(await hasSelector(page, "textarea#container-element:focus"))
 })
 
-test("test receiving a replace stream message preserves focus if the activeElement has an [id]", async ({ page }) => {
+test("receiving a replace stream message preserves focus if the activeElement has an [id]", async ({ page }) => {
   await page.locator("input#container-element").focus()
   await page.evaluate(() => {
     window.Turbo.renderStreamMessage(`
@@ -170,7 +170,7 @@ test("test receiving a replace stream message preserves focus if the activeEleme
   assert.ok(await hasSelector(page, "textarea#container-element:focus"))
 })
 
-test("test receiving a remove stream message preserves focus blurs the activeElement", async ({ page }) => {
+test("receiving a remove stream message preserves focus blurs the activeElement", async ({ page }) => {
   await page.locator("#container-element").focus()
   await page.evaluate(() => {
     window.Turbo.renderStreamMessage(`

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -21,7 +21,7 @@ test.beforeEach(async ({ page }) => {
   await readEventLogs(page)
 })
 
-test("test programmatically visiting a same-origin location", async ({ page }) => {
+test("programmatically visiting a same-origin location", async ({ page }) => {
   const urlBeforeVisit = page.url()
   await visitLocation(page, "/src/tests/fixtures/one.html")
 
@@ -50,7 +50,7 @@ test("skip programmatically visiting a cross-origin location falls back to windo
   assert.equal(await visitAction(page), "load")
 })
 
-test("test visiting a location served with a non-HTML content type", async ({ page }) => {
+test("visiting a location served with a non-HTML content type", async ({ page }) => {
   const urlBeforeVisit = page.url()
   await visitLocation(page, "/src/tests/fixtures/svg.svg")
   await nextBeat()
@@ -64,14 +64,14 @@ test("test visiting a location served with a non-HTML content type", async ({ pa
   assert.equal(await visitAction(page), "load")
 })
 
-test("test canceling a turbo:click event falls back to built-in browser navigation", async ({ page }) => {
+test("canceling a turbo:click event falls back to built-in browser navigation", async ({ page }) => {
   await cancelNextEvent(page, "turbo:click")
   await Promise.all([page.waitForNavigation(), page.click("#same-origin-link")])
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
 })
 
-test("test canceling a before-visit event prevents navigation", async ({ page }) => {
+test("canceling a before-visit event prevents navigation", async ({ page }) => {
   await cancelNextVisit(page)
   const urlBeforeVisit = page.url()
 
@@ -86,7 +86,7 @@ test("test canceling a before-visit event prevents navigation", async ({ page })
   assert.equal(urlAfterVisit, urlBeforeVisit)
 })
 
-test("test navigation by history is not cancelable", async ({ page }) => {
+test("navigation by history is not cancelable", async ({ page }) => {
   await page.click("#same-origin-link")
   await nextEventNamed(page, "turbo:load")
 
@@ -99,7 +99,7 @@ test("test navigation by history is not cancelable", async ({ page }) => {
   assert.equal(await page.textContent("h1"), "Visit")
 })
 
-test("test turbo:before-fetch-request event.detail", async ({ page }) => {
+test("turbo:before-fetch-request event.detail", async ({ page }) => {
   await page.click("#same-origin-link")
   const { url, fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
 
@@ -107,14 +107,14 @@ test("test turbo:before-fetch-request event.detail", async ({ page }) => {
   assert.ok(url.includes("/src/tests/fixtures/one.html"))
 })
 
-test("test turbo:before-fetch-request event.detail encodes searchParams", async ({ page }) => {
+test("turbo:before-fetch-request event.detail encodes searchParams", async ({ page }) => {
   await page.click("#same-origin-link-search-params")
   const { url } = await nextEventNamed(page, "turbo:before-fetch-request")
 
   assert.ok(url.includes("/src/tests/fixtures/one.html?key=value"))
 })
 
-test("test turbo:before-fetch-response open new site", async ({ page }) => {
+test("turbo:before-fetch-response open new site", async ({ page }) => {
   page.evaluate(() =>
     addEventListener(
       "turbo:before-fetch-response",
@@ -138,7 +138,7 @@ test("test turbo:before-fetch-response open new site", async ({ page }) => {
   assert.isTrue(fetchResponseResult.responseHTML.indexOf("An element with an ID") > -1)
 })
 
-test("test visits with data-turbo-stream include MIME type & search params", async ({ page }) => {
+test("visits with data-turbo-stream include MIME type & search params", async ({ page }) => {
   await page.click("#stream-link")
   const { fetchOptions, url } = await nextEventNamed(page, "turbo:before-fetch-request")
 
@@ -146,7 +146,7 @@ test("test visits with data-turbo-stream include MIME type & search params", asy
   assert.equal(getSearchParam(url, "key"), "value")
 })
 
-test("test visits with data-turbo-stream do not set aria-busy", async ({ page }) => {
+test("visits with data-turbo-stream do not set aria-busy", async ({ page }) => {
   await page.click("#stream-link")
 
   assert.ok(
@@ -155,7 +155,7 @@ test("test visits with data-turbo-stream do not set aria-busy", async ({ page })
   )
 })
 
-test("test cache does not override response after redirect", async ({ page }) => {
+test("cache does not override response after redirect", async ({ page }) => {
   await page.evaluate(() => {
     const cachedElement = document.createElement("some-cached-element")
     document.body.appendChild(cachedElement)
@@ -182,7 +182,7 @@ function contentTypeOfURL(url) {
   })
 }
 
-test("test can scroll to element after click-initiated turbo:visit", async ({ page }) => {
+test("can scroll to element after click-initiated turbo:visit", async ({ page }) => {
   const id = "below-the-fold-link"
   await page.evaluate((id) => {
     addEventListener("turbo:load", () => document.getElementById(id)?.scrollIntoView())
@@ -196,7 +196,7 @@ test("test can scroll to element after click-initiated turbo:visit", async ({ pa
   assert(await isScrolledToSelector(page, "#" + id), "scrolls after click-initiated turbo:load")
 })
 
-test("test can scroll to element after history-initiated turbo:visit", async ({ page }) => {
+test("can scroll to element after history-initiated turbo:visit", async ({ page }) => {
   const id = "below-the-fold-link"
   await page.evaluate((id) => {
     addEventListener("turbo:load", () => document.getElementById(id)?.scrollIntoView())
@@ -211,7 +211,7 @@ test("test can scroll to element after history-initiated turbo:visit", async ({ 
   assert(await isScrolledToSelector(page, "#" + id), "scrolls after history-initiated turbo:load")
 })
 
-test("test Visit with network error", async ({ page }) => {
+test("Visit with network error", async ({ page }) => {
   await page.evaluate(() => {
     addEventListener("turbo:fetch-request-error", (event) => event.preventDefault())
   })

--- a/src/tests/unit/deprecated_adapter_support_tests.js
+++ b/src/tests/unit/deprecated_adapter_support_tests.js
@@ -41,7 +41,7 @@ setup(() => {
   Turbo.registerAdapter(adapter)
 })
 
-test("test visit proposal location includes deprecated absoluteURL property", async () => {
+test("visit proposal location includes deprecated absoluteURL property", async () => {
   Turbo.navigator.proposeVisit(new URL(window.location.toString()))
   assert.equal(adapter.locations.length, 1)
 
@@ -49,7 +49,7 @@ test("test visit proposal location includes deprecated absoluteURL property", as
   assert.equal(location.toString(), location.absoluteURL)
 })
 
-test("test visit start location includes deprecated absoluteURL property", async () => {
+test("visit start location includes deprecated absoluteURL property", async () => {
   Turbo.navigator.startVisit(window.location.toString(), "123")
   assert.equal(adapter.locations.length, 1)
 

--- a/src/tests/unit/export_tests.js
+++ b/src/tests/unit/export_tests.js
@@ -2,7 +2,7 @@ import { assert } from "@open-wc/testing"
 import * as Turbo from "../../"
 import { StreamActions } from "../../"
 
-test("test Turbo interface", () => {
+test("Turbo interface", () => {
   assert.equal(typeof Turbo.StreamActions, "object")
   assert.equal(typeof Turbo.start, "function")
   assert.equal(typeof Turbo.registerAdapter, "function")
@@ -19,6 +19,6 @@ test("test Turbo interface", () => {
   assert.equal(typeof Turbo.session, "object")
 })
 
-test("test StreamActions interface", () => {
+test("StreamActions interface", () => {
   assert.equal(typeof StreamActions, "object")
 })

--- a/src/tests/unit/stream_element_tests.js
+++ b/src/tests/unit/stream_element_tests.js
@@ -27,7 +27,7 @@ setup(() => {
   subject.fixtureHTML = `<div><div id="hello">Hello Turbo</div></div>`
 })
 
-test("test action=append", async () => {
+test("action=append", async () => {
   const element = createStreamElement("append", "hello", createTemplateElement("<span> Streams</span>"))
   const element2 = createStreamElement("append", "hello", createTemplateElement("<span> and more</span>"))
 
@@ -46,7 +46,7 @@ test("test action=append", async () => {
   assert.isNull(element2.parentElement)
 })
 
-test("test action=append with children ID already present in target", async () => {
+test("action=append with children ID already present in target", async () => {
   const element = createStreamElement("append", "hello", createTemplateElement(' <div id="child_1">First</div> tail1 '))
   const element2 = createStreamElement(
     "append",
@@ -67,7 +67,7 @@ test("test action=append with children ID already present in target", async () =
   assert.equal(subject.find("#hello")?.textContent, "Hello Turbo  tail1 New First Second tail2 ")
 })
 
-test("test action=prepend", async () => {
+test("action=prepend", async () => {
   const element = createStreamElement("prepend", "hello", createTemplateElement("<span>Streams </span>"))
   const element2 = createStreamElement("prepend", "hello", createTemplateElement("<span>and more </span>"))
   assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
@@ -85,7 +85,7 @@ test("test action=prepend", async () => {
   assert.isNull(element.parentElement)
 })
 
-test("test action=prepend with children ID already present in target", async () => {
+test("action=prepend with children ID already present in target", async () => {
   const element = createStreamElement("prepend", "hello", createTemplateElement('<div id="child_1">First</div> tail1 '))
   const element2 = createStreamElement(
     "prepend",
@@ -106,7 +106,7 @@ test("test action=prepend with children ID already present in target", async () 
   assert.equal(subject.find("#hello")?.textContent, "New First Second tail2  tail1 Hello Turbo")
 })
 
-test("test action=remove", async () => {
+test("action=remove", async () => {
   const element = createStreamElement("remove", "hello")
   assert.ok(subject.find("#hello"))
 
@@ -117,7 +117,7 @@ test("test action=remove", async () => {
   assert.isNull(element.parentElement)
 })
 
-test("test action=replace", async () => {
+test("action=replace", async () => {
   const element = createStreamElement("replace", "hello", createTemplateElement(`<h1 id="hello">Hello Turbo</h1>`))
   assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
   assert.ok(subject.find("div#hello"))
@@ -131,7 +131,7 @@ test("test action=replace", async () => {
   assert.isNull(element.parentElement)
 })
 
-test("test action=update", async () => {
+test("action=update", async () => {
   const element = createStreamElement("update", "hello", createTemplateElement("Goodbye Turbo"))
   assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
 
@@ -142,7 +142,7 @@ test("test action=update", async () => {
   assert.isNull(element.parentElement)
 })
 
-test("test action=after", async () => {
+test("action=after", async () => {
   const element = createStreamElement("after", "hello", createTemplateElement(`<h1 id="after">After Turbo</h1>`))
   assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
 
@@ -155,7 +155,7 @@ test("test action=after", async () => {
   assert.isNull(element.parentElement)
 })
 
-test("test action=before", async () => {
+test("action=before", async () => {
   const element = createStreamElement("before", "hello", createTemplateElement(`<h1 id="before">Before Turbo</h1>`))
   assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
 


### PR DESCRIPTION
The fact that each test case description starts with `"test"` is an artifact of the pre-Playwright test suite. Prior to Playwright, test cases were inferred from function names that started with `"test"`.

Since Playwright doesn't impose those same expectations, the prefix can be omitted.