### PR TITLE
Move cache snapshot loading to Visit#start()

### DIFF
--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -21,7 +21,7 @@ export class Navigator {
       referrer: this.location,
       ...options
     })
-    this.currentVisit.start()
+    return this.currentVisit.start()
   }
 
   submitForm(form, submitter) {

--- a/src/tests/unit/deprecated_adapter_support_tests.js
+++ b/src/tests/unit/deprecated_adapter_support_tests.js
@@ -50,7 +50,7 @@ test("test visit proposal location includes deprecated absoluteURL property", as
 })
 
 test("test visit start location includes deprecated absoluteURL property", async () => {
-  Turbo.navigator.startVisit(window.location.toString(), "123")
+  await Turbo.navigator.startVisit(window.location.toString(), "123")
   assert.equal(adapter.locations.length, 1)
 
   const [location] = adapter.locations

--- a/src/tests/unit/native_adapter_support_tests.js
+++ b/src/tests/unit/native_adapter_support_tests.js
@@ -89,7 +89,7 @@ test("test visit proposal external location is proposed to adapter", async () =>
 test("test visit started notifies adapter", async () => {
   const locatable = window.location.toString()
 
-  Turbo.navigator.startVisit(locatable)
+  await Turbo.navigator.startVisit(locatable)
   assert.equal(adapter.startedVisits.length, 1)
 
   const [visit] = adapter.startedVisits
@@ -99,7 +99,7 @@ test("test visit started notifies adapter", async () => {
 test("test visit completed notifies adapter", async () => {
   const locatable = window.location.toString()
 
-  Turbo.navigator.startVisit(locatable)
+  await Turbo.navigator.startVisit(locatable)
 
   const [startedVisit] = adapter.startedVisits
   startedVisit.complete()
@@ -111,7 +111,7 @@ test("test visit completed notifies adapter", async () => {
 test("test visit request started notifies adapter", async () => {
   const locatable = window.location.toString()
 
-  Turbo.navigator.startVisit(locatable)
+  await Turbo.navigator.startVisit(locatable)
 
   const [startedVisit] = adapter.startedVisits
   startedVisit.startRequest()
@@ -124,7 +124,7 @@ test("test visit request started notifies adapter", async () => {
 test("test visit request completed notifies adapter", async () => {
   const locatable = window.location.toString()
 
-  Turbo.navigator.startVisit(locatable)
+  await Turbo.navigator.startVisit(locatable)
 
   const [startedVisit] = adapter.startedVisits
   startedVisit.recordResponse({ statusCode: 200, responseHTML: "responseHtml", redirected: false })
@@ -137,7 +137,7 @@ test("test visit request completed notifies adapter", async () => {
 test("test visit request failed notifies adapter", async () => {
   const locatable = window.location.toString()
 
-  Turbo.navigator.startVisit(locatable)
+  await Turbo.navigator.startVisit(locatable)
 
   const [startedVisit] = adapter.startedVisits
   startedVisit.recordResponse({ statusCode: 404, responseHTML: "responseHtml", redirected: false })
@@ -150,7 +150,7 @@ test("test visit request failed notifies adapter", async () => {
 test("test visit request finished notifies adapter", async () => {
   const locatable = window.location.toString()
 
-  Turbo.navigator.startVisit(locatable)
+  await Turbo.navigator.startVisit(locatable)
 
   const [startedVisit] = adapter.startedVisits
   startedVisit.finishRequest()
@@ -181,7 +181,7 @@ test("test visit follows redirect and proposes replace visit to adapter", async 
   const locatable = window.location.toString()
   const redirectedLocation = "https://example.com"
 
-  Turbo.navigator.startVisit(locatable)
+  await Turbo.navigator.startVisit(locatable)
 
   const [startedVisit] = adapter.startedVisits
   startedVisit.redirectedToLocation = redirectedLocation

--- a/src/tests/unit/native_adapter_support_tests.js
+++ b/src/tests/unit/native_adapter_support_tests.js
@@ -62,11 +62,11 @@ setup(() => {
   Turbo.registerAdapter(adapter)
 })
 
-test("test navigator adapter is native adapter", async () => {
+test("navigator adapter is native adapter", async () => {
   assert.equal(adapter, Turbo.navigator.adapter)
 })
 
-test("test visit proposal location is proposed to adapter", async () => {
+test("visit proposal location is proposed to adapter", async () => {
   const url = new URL(window.location.toString())
 
   Turbo.navigator.proposeVisit(url)
@@ -76,7 +76,7 @@ test("test visit proposal location is proposed to adapter", async () => {
   assert.equal(visit.location, url)
 })
 
-test("test visit proposal external location is proposed to adapter", async () => {
+test("visit proposal external location is proposed to adapter", async () => {
   const url = new URL("https://example.com/")
 
   Turbo.navigator.proposeVisit(url)
@@ -86,7 +86,7 @@ test("test visit proposal external location is proposed to adapter", async () =>
   assert.equal(visit.location, url)
 })
 
-test("test visit started notifies adapter", async () => {
+test("visit started notifies adapter", async () => {
   const locatable = window.location.toString()
 
   await Turbo.navigator.startVisit(locatable)
@@ -96,7 +96,7 @@ test("test visit started notifies adapter", async () => {
   assert.equal(visit.location, locatable)
 })
 
-test("test visit has cached snapshot returns boolean", async () => {
+test("visit has cached snapshot returns boolean", async () => {
   const locatable = window.location.toString()
 
   await Turbo.navigator.startVisit(locatable)
@@ -105,7 +105,7 @@ test("test visit has cached snapshot returns boolean", async () => {
   assert.equal(visit.hasCachedSnapshot(), false)
 })
 
-test("test visit completed notifies adapter", async () => {
+test("visit completed notifies adapter", async () => {
   const locatable = window.location.toString()
 
   await Turbo.navigator.startVisit(locatable)
@@ -117,7 +117,7 @@ test("test visit completed notifies adapter", async () => {
   assert.equal(completedVisit.location, locatable)
 })
 
-test("test visit request started notifies adapter", async () => {
+test("visit request started notifies adapter", async () => {
   const locatable = window.location.toString()
 
   await Turbo.navigator.startVisit(locatable)
@@ -130,7 +130,7 @@ test("test visit request started notifies adapter", async () => {
   assert.equal(startedVisitRequest.location, locatable)
 })
 
-test("test visit request completed notifies adapter", async () => {
+test("visit request completed notifies adapter", async () => {
   const locatable = window.location.toString()
 
   await Turbo.navigator.startVisit(locatable)
@@ -143,7 +143,7 @@ test("test visit request completed notifies adapter", async () => {
   assert.equal(completedVisitRequest.location, locatable)
 })
 
-test("test visit request failed notifies adapter", async () => {
+test("visit request failed notifies adapter", async () => {
   const locatable = window.location.toString()
 
   await Turbo.navigator.startVisit(locatable)
@@ -156,7 +156,7 @@ test("test visit request failed notifies adapter", async () => {
   assert.equal(failedVisitRequest.location, locatable)
 })
 
-test("test visit request finished notifies adapter", async () => {
+test("visit request finished notifies adapter", async () => {
   const locatable = window.location.toString()
 
   await Turbo.navigator.startVisit(locatable)
@@ -169,7 +169,7 @@ test("test visit request finished notifies adapter", async () => {
   assert.equal(finishedVisitRequest.location, locatable)
 })
 
-test("test form submission started notifies adapter", async () => {
+test("form submission started notifies adapter", async () => {
   Turbo.navigator.formSubmissionStarted("formSubmissionStub")
   assert.equal(adapter.startedFormSubmissions.length, 1)
 
@@ -177,7 +177,7 @@ test("test form submission started notifies adapter", async () => {
   assert.equal(startedFormSubmission, "formSubmissionStub")
 })
 
-test("test form submission finished notifies adapter", async () => {
+test("form submission finished notifies adapter", async () => {
   Turbo.navigator.formSubmissionFinished("formSubmissionStub")
   assert.equal(adapter.finishedFormSubmissions.length, 1)
 
@@ -186,7 +186,7 @@ test("test form submission finished notifies adapter", async () => {
 })
 
 
-test("test visit follows redirect and proposes replace visit to adapter", async () => {
+test("visit follows redirect and proposes replace visit to adapter", async () => {
   const locatable = window.location.toString()
   const redirectedLocation = "https://example.com"
 

--- a/src/tests/unit/native_adapter_support_tests.js
+++ b/src/tests/unit/native_adapter_support_tests.js
@@ -96,6 +96,15 @@ test("test visit started notifies adapter", async () => {
   assert.equal(visit.location, locatable)
 })
 
+test("test visit has cached snapshot returns boolean", async () => {
+  const locatable = window.location.toString()
+
+  await Turbo.navigator.startVisit(locatable)
+
+  const [visit] = adapter.startedVisits
+  assert.equal(visit.hasCachedSnapshot(), false)
+})
+
 test("test visit completed notifies adapter", async () => {
   const locatable = window.location.toString()
 


### PR DESCRIPTION
This fixes a problem introduced when the cache interface changed in https://github.com/hotwired/turbo/pull/949

Since the cache can be loaded from disk using the browser Cache API, it is possible that the cache snapshot will be loaded asynchronously. This means that the calls to load cache snapshots need to be awaited.

Because of that we also changed `visit.hasCachedSnapshot()` to be async and return a `Promise`. However, [hasCachedSnapshot is used in the iOS adapter](https://github.com/hotwired/turbo-ios/blob/c476bac66f260adbfe930ed9a151e7637973ff99/Source/WebView/turbo.js#L119) and serialized into and data object we send to the native side via `postMessage`. When `postMessage` receives a Promise instead of a boolean value it fails with a `DataCloneError` because it can't serialize the `Promise`.

This commit moves the cache snapshot loading to `Visit#start()` and stores the result in a `cachedSnapshot` property. This allows us to keep the `hasCachedSnapshot()` method synchronous and return a boolean value.

It means that `Visit.start` is now async, but I haven't found any callers that rely on it being synchronous.