### PR TITLE
Respect morphing and scroll preservation settings when handling form errors

### DIFF
--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -99,7 +99,9 @@ export class Navigator {
       } else {
         await this.view.renderPage(snapshot, false, true, this.currentVisit)
       }
-      this.view.scrollToTop()
+      if(!snapshot.shouldPreserveScrollPosition) {
+        this.view.scrollToTop()
+      }
       this.view.clearSnapshotCache()
     }
   }

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -60,7 +60,7 @@ export class PageView extends View {
   }
 
   isPageRefresh(visit) {
-    return visit && this.lastRenderedLocation.href === visit.location.href
+    return !visit || this.lastRenderedLocation.href === visit.location.href
   }
 
   get snapshot() {

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -49,6 +49,13 @@
       <input id="form-submit" type="submit" value="form[method=post]">
     </form>
 
+    <div id="reject">
+      <form class="unprocessable_entity" action="/__turbo/reject" method="post" style="margin-top:100vh">
+        <input type="hidden" name="status" value="422">
+        <input type="submit">
+      </form>
+    </div>
+
     <div id="container">
     </div>
   </body>


### PR DESCRIPTION
Turbo will render 422 responses to allow handling form errors. A common scenario in Rails is to render those setting the satus like:

```ruby
render "edit", status: :unprocessable_entity
```

This change will consider such operations a "page refresh" and will also consider the scroll directive.

Thanks to @seanpdoyle for the heads up here.