### PR TITLE
Pass session instance to cache constructor

### DIFF
--- a/src/core/cache.js
+++ b/src/core/cache.js
@@ -1,6 +1,10 @@
 import { setMetaContent } from "../util"
 
 export class Cache {
+  constructor(session) {
+    this.session = session
+  }
+
   clear() {
     this.session.clearCache()
   }

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -34,7 +34,7 @@ export class Session {
   formLinkClickObserver = new FormLinkClickObserver(this, document.documentElement)
   frameRedirector = new FrameRedirector(this, document.documentElement)
   streamMessageRenderer = new StreamMessageRenderer()
-  cache = new Cache()
+  cache = new Cache(this)
 
   drive = true
   enabled = true

--- a/src/tests/unit/export_tests.js
+++ b/src/tests/unit/export_tests.js
@@ -15,6 +15,7 @@ test("Turbo interface", () => {
   assert.equal(typeof Turbo.setConfirmMethod, "function")
   assert.equal(typeof Turbo.setFormMode, "function")
   assert.equal(typeof Turbo.cache, "object")
+  assert.equal(typeof Turbo.cache.clear, "function")
   assert.equal(typeof Turbo.navigator, "object")
   assert.equal(typeof Turbo.session, "object")
 })


### PR DESCRIPTION
We refactored the cache class to not take a session in the constructor in 485115d24a3b331e6fc2a0e2f564bde7dd063309.

But after reverting the disk cache https://github.com/hotwired/turbo/pull/1062 the cache needs a reference to the session again.