### PR TITLE
Add coverage for focus and value preservation during morph

### DIFF
--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -95,6 +95,33 @@ test("it resets the scroll position when the turbo-refresh-scroll meta tag is 'r
   await assertPageScroll(page, 0, 0)
 })
 
+test("it preserves focus across morphs", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  const input = await page.locator("#form input[type=text]")
+
+  await input.fill("Discard me")
+  await input.press("Enter")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  await expect(input).toBeFocused()
+  await expect(input).toHaveValue("")
+})
+
+test("it preserves focus and the [data-turbo-permanent] element's value across morphs", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  const input = await page.locator("#form input[type=text]")
+
+  await input.evaluate((element) => element.setAttribute("data-turbo-permanent", ""))
+  await input.fill("Preserve me")
+  await input.press("Enter")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  await expect(input).toBeFocused()
+  await expect(input).toHaveValue("Preserve me")
+})
+
 test("it preserves data-turbo-permanent elements", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 


### PR DESCRIPTION
Idiomorph will preserve focus, but discard content. Version [0.0.9][] introduces the `ignoredActiveValue:` option to preserve the value for the element with focus. Since the currently packaged build isn't caught up to that version, the `[data-turbo-permanent]` treatment enables a similar kind of behavior.

This commit adds test coverage to ensure that focus preservation is global, and value preservation requires opt-in with `[data-turbo-permanent]`.

[0.0.9]: https://github.com/bigskysoftware/idiomorph/tree/v0.0.9#options