### PR TITLE
Restore attribute "refresh=morph" to flag turbo frames to reload during a page refresh

### DIFF
--- a/src/tests/fixtures/frame_refresh_morph.html
+++ b/src/tests/fixtures/frame_refresh_morph.html
@@ -1,3 +1,3 @@
-<turbo-frame id="remote-frame">
+<turbo-frame id="refresh-morph">
   <h2>Loaded morphed frame</h2>
 </turbo-frame>

--- a/src/tests/fixtures/frame_refresh_reload.html
+++ b/src/tests/fixtures/frame_refresh_reload.html
@@ -1,0 +1,3 @@
+<turbo-frame id="refresh-reload">
+  <h2>Loaded reloadable frame</h2>
+</turbo-frame>

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -24,8 +24,12 @@
   <body>
     <h1>Page to be refreshed</h1>
 
-    <turbo-frame id="remote-frame" src="/src/tests/fixtures/frame_refresh_morph.html">
+    <turbo-frame id="refresh-morph" src="/src/tests/fixtures/frame_refresh_morph.html" refresh="morph">
       <h2>Frame to be morphed</h2>
+    </turbo-frame>
+
+    <turbo-frame id="refresh-reload" src="/src/tests/fixtures/frame_refresh_reload.html" refresh="reload">
+      <h2>Frame to be reloaded</h2>
     </turbo-frame>
 
     <div id="preserve-me" data-turbo-permanent>

--- a/src/tests/fixtures/page_refresh_replace.html
+++ b/src/tests/fixtures/page_refresh_replace.html
@@ -23,8 +23,12 @@
   <body>
     <h1>Page to be refreshed</h1>
 
-    <turbo-frame id="remote-frame" src="/src/tests/fixtures/frame_refresh_morph.html" refresh="morph">
+    <turbo-frame id="refresh-morph" src="/src/tests/fixtures/frame_refresh_morph.html" refresh="morph">
       <h2>Frame to be morphed</h2>
+    </turbo-frame>
+
+    <turbo-frame id="refresh-reload" src="/src/tests/fixtures/frame_refresh_reload.html" refresh="reload">
+      <h2>Frame to be reloaded</h2>
     </turbo-frame>
 
     <div id="preserve-me" data-turbo-permanent>


### PR DESCRIPTION
This adds a new turbo-frame attribute: `refresh`. When its value is `morph`:

* It will reload the turbo frame with morphing during a page refresh.
* It won't update the turbo frame with the server response.
* It won't remove it if it's missing in the server response.

An example where these frames are useful are for pagination, or for other scenarios where you load new state in the screen that you want to preserve during page refreshes, but that you also want to reload because the user action might have affected them.

This attribute was part of [the original proposal we presented in Rails World](https://www.youtube.com/watch?v=m97UsXa6HFg), then [we removed it](https://github.com/hotwired/turbo/pull/1019/commits/0c6a95d07fd7661e734ed1fbfe19daa9a00b3fd4), because we thought it wasn't needed. But after testing the library in different scenarios, we've found that assuming certain logic for all the remote frames was problematic. We had to be too clever about what you wanted to do with the frame. The new attribute makes for a simpler story:

* The default behavior will be the expected one: turbo frames will be morphed as any other element. E.g: if they get a new URL they will be reloaded; if the get deleted in the response, they will disappear, etc.
* You can use the new attribute to flag the frames for which you want the special behavior.

Follow up to #1019.