### PR TITLE
Avoid infinite recursion from `window.fetch` name collision

### DIFF
--- a/src/http/fetch.js
+++ b/src/http/fetch.js
@@ -1,13 +1,17 @@
 import { uuid } from "../util"
 
-export function fetch(url, options = {}) {
+const nativeFetch = window.fetch
+
+function fetchWithTurboHeaders(url, options = {}) {
   const modifiedHeaders = new Headers(options.headers || {})
   const requestUID = uuid()
   window.Turbo.session.recentRequests.add(requestUID)
   modifiedHeaders.append("X-Turbo-Request-Id", requestUID)
 
-  return window.fetch(url, {
+  return nativeFetch(url, {
     ...options,
     headers: modifiedHeaders
   })
 }
+
+export { fetchWithTurboHeaders as fetch }

--- a/src/tests/unit/export_tests.js
+++ b/src/tests/unit/export_tests.js
@@ -18,6 +18,7 @@ test("Turbo interface", () => {
   assert.equal(typeof Turbo.cache.clear, "function")
   assert.equal(typeof Turbo.navigator, "object")
   assert.equal(typeof Turbo.session, "object")
+  assert.equal(typeof Turbo.fetch, "function")
 })
 
 test("StreamActions interface", () => {


### PR DESCRIPTION
Closes [@hotwired/turbo-rails#526][]

Prevent naming collisions between the new `Turbo.fetch` function and the built-in `window.fetch` function.

To do so, create a module-local reference to `window.fetch`, and define the exported function as `fetchWithTurboHeaders`. At export-time, rename to `fetch` so that consumers can continue to import it as `Turbo.fetch`.

[@hotwired/turbo-rails#526]: https://github.com/hotwired/turbo-rails/issues/526