### PR TITLE
Page refreshes: Use pathname instead of href to detect if locations are equal

### DIFF
--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -56,7 +56,7 @@ export class PageView extends View {
   }
 
   isPageRefresh(visit) {
-    return !visit || (this.lastRenderedLocation.href === visit.location.href && visit.action === "replace")
+    return !visit || (this.lastRenderedLocation.pathname === visit.location.pathname && visit.action === "replace")
   }
 
   get snapshot() {

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -44,6 +44,7 @@
       <h3>Element with Stimulus controller</h3>
     </div>
 
+    <p><a id="replace-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html?param=something">Link with params to refresh the page</a></p>
     <p><a id="link" href="/src/tests/fixtures/one.html">Link to another page</a></p>
 
     <form id="form" action="/__turbo/refresh" method="post" class="redirect">

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -17,6 +17,13 @@ test("renders a page refresh with morphing", async ({ page }) => {
   await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
 })
 
+test("renders a page refresh with morphing when the paths are the same but search params are diferent", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.click("#replace-link")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+})
+
 test("doesn't morph when the turbo-refresh-method meta tag is not 'morph'", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh_replace.html")
 


### PR DESCRIPTION
Before this commit, URLs had to be exactly the same for the possibility of a refresh with morphing.

Now, it only checks that the paths are equal, regardless of whether they have different search params.

From my perspective, search params don't determine whether it is a refresh or not. The most representative example that comes to mind is the same case as a Rails controller. A show action could have different search params, but in essence, it remains the same action and the same page.

Additionally, sometimes when clicking a link on social media, for example, tracking parameters are injected. If these parameters exist and a form is submitted, Turbo would not detect that it is a refresh.

These are just small examples of use cases, but obviously there are many more.