### PR TITLE
Include idiomorph as a dev dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,9 +32,6 @@
   "publishConfig": {
     "access": "public"
   },
-  "dependencies": {
-    "idiomorph": "https://github.com/basecamp/idiomorph#rollout-build"
-  },
   "devDependencies": {
     "@open-wc/testing": "^3.1.7",
     "@playwright/test": "^1.28.0",
@@ -47,6 +44,7 @@
     "chai": "~4.3.4",
     "eslint": "^8.13.0",
     "express": "^4.18.2",
+    "idiomorph": "https://github.com/basecamp/idiomorph#rollout-build",
     "multer": "^1.4.2",
     "rollup": "^2.35.1"
   },


### PR DESCRIPTION
The library is bundled within Turbo so there's no need for apps using Turbo to install it.