### PR TITLE
Import `session` instead of reading `window.Turbo.session`

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -3,12 +3,11 @@ import { PageRenderer } from "./drive/page_renderer"
 import { PageSnapshot } from "./drive/page_snapshot"
 import { FrameRenderer } from "./frames/frame_renderer"
 import { FormSubmission } from "./drive/form_submission"
-import { StreamActions } from "./streams/stream_actions"
 import { fetch, recentRequests } from "../http/fetch"
 
 const session = new Session(recentRequests)
 const { cache, navigator } = session
-export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer, StreamActions, fetch }
+export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer, fetch }
 
 /**
  * Starts the main session.

--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -1,3 +1,5 @@
+import { session } from "../"
+
 export const StreamActions = {
   after() {
     this.targetElements.forEach((e) => e.parentElement?.insertBefore(this.templateContent, e.nextSibling))
@@ -33,6 +35,6 @@ export const StreamActions = {
   },
 
   refresh() {
-    window.Turbo.session.refresh(this.baseURI, this.requestId)
+    session.refresh(this.baseURI, this.requestId)
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,14 @@
 import "./polyfills"
 import "./elements"
 import "./script_warning"
+import { StreamActions } from "./core/streams/stream_actions"
 
 import * as Turbo from "./core"
 
-window.Turbo = Turbo
+window.Turbo = { ...Turbo, StreamActions }
 Turbo.start()
 
+export { StreamActions }
 export * from "./core"
 export * from "./elements"
 export * from "./http"


### PR DESCRIPTION
Follow-up to [#1049][]
Follow-up to [#1073][]
Related to [#1078][]

Replace an internal `window.Turbo.session` access with an `import { session }` statement.

Prior attempts at this change introduced circular dependencies. This attempt does not. Additionally, this change maintains the ability for consumers to access StreamActions through `window.Turbo.StreamActions`, while also enabling `import { StreamActions } from "@hotwired/turbo"` (or `from "@hotwired/turbo-rails"`).

[#1049]: https://github.com/hotwired/turbo/pull/1049
[#1073]: https://github.com/hotwired/turbo/pull/1073
[#1078]: https://github.com/hotwired/turbo/pull/1078