### PR TITLE
Don't preserve scroll position unless it's a page refresh

### DIFF
--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -59,6 +59,10 @@ export class PageView extends View {
     return !visit || (this.lastRenderedLocation.href === visit.location.href && visit.action === "replace")
   }
 
+  shouldPreserveScrollPosition(visit) {
+    return this.isPageRefresh(visit) && this.snapshot.shouldPreserveScrollPosition
+  }
+
   get snapshot() {
     return PageSnapshot.fromElement(this.element)
   }

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -335,7 +335,7 @@ export class Visit {
   // Scrolling
 
   performScroll() {
-    if (!this.scrolled && !this.view.forceReloaded && !this.view.snapshot.shouldPreserveScrollPosition) {
+    if (!this.scrolled && !this.view.forceReloaded && !this.view.shouldPreserveScrollPosition(this)) {
       if (this.action == "restore") {
         this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()
       } else {

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -24,6 +24,8 @@
   <body>
     <h1>Page to be refreshed</h1>
 
+    <a href="/src/tests/fixtures/page_refresh.html" id="reload-link">Reload</a>
+
     <turbo-frame id="refresh-morph" src="/src/tests/fixtures/frame_refresh_morph.html" refresh="morph">
       <h2>Frame to be morphed</h2>
     </turbo-frame>

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -87,6 +87,18 @@ test("it preserves the scroll position when the turbo-refresh-scroll meta tag is
   await assertPageScroll(page, 10, 10)
 })
 
+test("it does not preserve the scroll position on regular 'advance' navigations, despite of using a 'preserve' option", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.evaluate(() => window.scrollTo(10, 10))
+  await assertPageScroll(page, 10, 10)
+
+  await page.evaluate(() => document.getElementById("reload-link").click())
+  await nextEventNamed(page, "turbo:render", { renderMethod: "replace" })
+
+  await assertPageScroll(page, 0, 0)
+})
+
 test("it resets the scroll position when the turbo-refresh-scroll meta tag is 'reset'", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh_scroll_reset.html")
 


### PR DESCRIPTION
The current logic was triggering on any navigation operation, not only on page refreshes.

Fixes https://github.com/hotwired/turbo/issues/1081