### PR TITLE
Page refreshes: Replace remaining calls to nextAnimationFrame by nextRepaint

### DIFF
--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -1,7 +1,7 @@
 import { FetchMethod, FetchRequest } from "../../http/fetch_request"
 import { getAnchor } from "../url"
 import { PageSnapshot } from "./page_snapshot"
-import { getHistoryMethodForAction, uuid } from "../../util"
+import { getHistoryMethodForAction, uuid, nextRepaint } from "../../util"
 import { StreamMessage } from "../streams/stream_message"
 import { ViewTransitioner } from "./view_transitioner"
 
@@ -418,9 +418,7 @@ export class Visit {
 
   async render(callback) {
     this.cancelRender()
-    await new Promise((resolve) => {
-      this.frame = requestAnimationFrame(() => resolve())
-    })
+    this.frame = await nextRepaint()
     await callback()
     delete this.frame
   }

--- a/src/core/frames/frame_renderer.js
+++ b/src/core/frames/frame_renderer.js
@@ -1,4 +1,4 @@
-import { activateScriptElement, nextAnimationFrame } from "../../util"
+import { activateScriptElement, nextRepaint } from "../../util"
 import { Renderer } from "../renderer"
 
 export class FrameRenderer extends Renderer {
@@ -25,14 +25,14 @@ export class FrameRenderer extends Renderer {
   }
 
   async render() {
-    await nextAnimationFrame()
+    await nextRepaint()
     this.preservingPermanentElements(() => {
       this.loadFrameElement()
     })
     this.scrollFrameIntoView()
-    await nextAnimationFrame()
+    await nextRepaint()
     this.focusFirstAutofocusableElement()
-    await nextAnimationFrame()
+    await nextRepaint()
     this.activateScriptElements()
   }
 

--- a/src/core/streams/stream_message_renderer.js
+++ b/src/core/streams/stream_message_renderer.js
@@ -1,6 +1,6 @@
 import { Bardo } from "../bardo"
 import { getPermanentElementById, queryPermanentElementsAll } from "../snapshot"
-import { around, elementIsFocusable, nextAnimationFrame, queryAutofocusableElement, uuid } from "../../util"
+import { around, elementIsFocusable, nextRepaint, queryAutofocusableElement, uuid } from "../../util"
 
 export class StreamMessageRenderer {
   render({ fragment }) {
@@ -57,7 +57,7 @@ async function withAutofocusFromFragment(fragment, callback) {
   }
 
   callback()
-  await nextAnimationFrame()
+  await nextRepaint()
 
   const hasNoActiveElement = document.activeElement == null || document.activeElement == document.body
 


### PR DESCRIPTION
In #1042, `nextRepaint` util was created, which only calls `nextAnimationFrame` when the page is in the foreground, and when it is in the background it calls `nextEventLoopTick`. Then, `nextAnimationFrame` was replaced in the `StreamElement` `render` method to allow Turbo streams actions to run even if the page is in the background.

Now that a page refresh can also be triggered by Turbo streams, it is necessary to change the remaining calls to `nextAnimationFrame`, so that page refreshes and Turbo frame reloads can occur in the background as well.

So, this change ensures that page refreshes work properly when the page is in the background.