### PR TITLE
Preloader: Rename header to `x-purpose` to avoid it being stripped

### DIFF
--- a/src/core/drive/preloader.js
+++ b/src/core/drive/preloader.js
@@ -37,7 +37,7 @@ export class Preloader {
     }
 
     try {
-      const response = await fetch(location.toString(), { headers: { "Sec-Purpose": "prefetch", Accept: "text/html" } })
+      const response = await fetch(location.toString(), { headers: { "x-purpose": "preview", Accept: "text/html" } })
       const responseText = await response.text()
       const snapshot = PageSnapshot.fromHTMLString(responseText)
 


### PR DESCRIPTION
This PR addresses the issue mentioned in #1107 by renaming the header to `x-purpose`, as the `Sec-Purpose` header is stripped by `fetch`.

In this PR, the value is also changed to `preview` which is consistent with how eg. [Safari and Chrome uses the `x-purpose` header for their "quick view" of eg. favorite pages](https://stackoverflow.com/questions/1483008/what-is-the-definition-of-http-x-purpose).