### PR TITLE
Upgrade idiomorph to 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chai": "~4.3.4",
     "eslint": "^8.13.0",
     "express": "^4.18.2",
-    "idiomorph": "https://github.com/basecamp/idiomorph#rollout-build",
+    "idiomorph": "^0.3.0",
     "multer": "^1.4.2",
     "rollup": "^2.35.1"
   },

--- a/src/core/drive/morph_renderer.js
+++ b/src/core/drive/morph_renderer.js
@@ -1,4 +1,4 @@
-import Idiomorph from "idiomorph"
+import { Idiomorph } from "idiomorph/dist/idiomorph.esm.js"
 import { dispatch } from "../../util"
 import { Renderer } from "../renderer"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,9 +1865,10 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-"idiomorph@https://github.com/basecamp/idiomorph#rollout-build":
-  version "0.0.8"
-  resolved "https://github.com/basecamp/idiomorph#e906820368e4c9c52489a3336b8c3826b1bf6de5"
+idiomorph@^0.3.0:
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/idiomorph/-/idiomorph-0.3.0.tgz#f6675bc5bef1a72c94021e43141a3f605d2d6288"
+  integrity sha512-UhV1Ey5xCxIwR9B+OgIjQa+1Jx99XQ1vQHUsKBU1RpQzCx1u+b+N6SOXgf5mEJDqemUI/ffccu6+71l2mJUsRA==
 
 ieee754@^1.1.13:
   version "1.2.1"


### PR DESCRIPTION
Use the upstream version that now includes a ESM dist file since

https://github.com/bigskysoftware/idiomorph/commit/6cc541f4fe1bd341b16003c6560d243928f00b91