### PR TITLE
Check new snapshot (instead of previous) for refresh-method

### DIFF
--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -16,8 +16,7 @@ export class PageView extends View {
   }
 
   renderPage(snapshot, isPreview = false, willRender = true, visit) {
-    const shouldMorphPage = this.isPageRefresh(visit) && snapshot.shouldMorphPage;
-    console.info("shold morph", shouldMorphPage);
+    const shouldMorphPage = this.isPageRefresh(visit) && snapshot.shouldMorphPage
     const rendererClass = shouldMorphPage ? MorphRenderer : PageRenderer
 
     const renderer = new rendererClass(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -16,7 +16,7 @@ export class PageView extends View {
   }
 
   renderPage(snapshot, isPreview = false, willRender = true, visit) {
-    const shouldMorphPage = this.isPageRefresh(visit) && this.snapshot.shouldMorphPage
+    const shouldMorphPage = this.isPageRefresh(visit) && snapshot.shouldMorphPage
     const rendererClass = shouldMorphPage ? MorphRenderer : PageRenderer
 
     const renderer = new rendererClass(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -16,7 +16,8 @@ export class PageView extends View {
   }
 
   renderPage(snapshot, isPreview = false, willRender = true, visit) {
-    const shouldMorphPage = this.isPageRefresh(visit) && snapshot.shouldMorphPage && this.snapshot.shouldMorphPage
+    const shouldMorphPage = this.isPageRefresh(visit) && snapshot.shouldMorphPage;
+    console.info("shold morph", shouldMorphPage);
     const rendererClass = shouldMorphPage ? MorphRenderer : PageRenderer
 
     const renderer = new rendererClass(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -16,7 +16,7 @@ export class PageView extends View {
   }
 
   renderPage(snapshot, isPreview = false, willRender = true, visit) {
-    const shouldMorphPage = this.isPageRefresh(visit) && snapshot.shouldMorphPage
+    const shouldMorphPage = this.isPageRefresh(visit) && snapshot.shouldMorphPage && this.snapshot.shouldMorphPage
     const rendererClass = shouldMorphPage ? MorphRenderer : PageRenderer
 
     const renderer = new rendererClass(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)

--- a/src/tests/fixtures/422_morph.html
+++ b/src/tests/fixtures/422_morph.html
@@ -1,0 +1,16 @@
+<html>
+  <head>
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
+
+    <title>Unprocessable Entity</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <h1>Unprocessable Entity</h1>
+
+    <turbo-frame id="frame">
+      <h2>Frame: Unprocessable Entity</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -118,7 +118,7 @@
     <button id="add-new-assets">Add new assets</button>
 
     <div id="reject">
-      <form class="unprocessable_entity" action="/__turbo/reject" method="post" style="margin-top:100vh">
+      <form class="unprocessable_entity" action="/__turbo/reject/morph" method="post" style="margin-top:100vh">
         <input type="hidden" name="status" value="422">
         <input type="submit">
       </form>

--- a/src/tests/functional/autofocus_tests.js
+++ b/src/tests/functional/autofocus_tests.js
@@ -140,6 +140,7 @@ test("autofocus from a Turbo Stream message does not leak a placeholder [id]", a
     `)
   })
   await nextBeat()
+  await nextBeat()  // to avoid flakiness
 
   assert.ok(
     await hasSelector(page, "#container-from-stream input:focus"),

--- a/src/tests/functional/autofocus_tests.js
+++ b/src/tests/functional/autofocus_tests.js
@@ -140,7 +140,7 @@ test("autofocus from a Turbo Stream message does not leak a placeholder [id]", a
     `)
   })
   await nextBeat()
-  await nextBeat()  // to avoid flakiness
+  await nextBeat() // to avoid flakiness
 
   assert.ok(
     await hasSelector(page, "#container-from-stream input:focus"),

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -61,6 +61,13 @@ router.post("/reject/tall", (request, response) => {
   response.status(parseInt(status || "422", 10)).sendFile(fixture)
 })
 
+router.post("/reject/morph", (request, response) => {
+  const { status } = request.body
+  const fixture = path.join(__dirname, `../../src/tests/fixtures/422_morph.html`)
+
+  response.status(parseInt(status || "422", 10)).sendFile(fixture)
+})
+
 router.post("/reject", (request, response) => {
   const { status } = request.body
   const fixture = path.join(__dirname, `../../src/tests/fixtures/${status}.html`)


### PR DESCRIPTION
While trying to port the Turbo Morph Demo over to Django, I found that if a form submission returns a classic django error page, the morph renderer is still used, causing an undesired blend of the previous pages <head> tags with the error page's content.  

Since morphing is predicated on the idea of a full-page refresh, the tag `<meta name="turbo-refresh-method" content="morph">` should be on all responses that intend to be morphed, and if not (as the case of an error page), it would be ideal to fallback on the full page renderer.  

This PR checks both the current page AND the upcoming snapshot for the meta setting `refresh-method='morph'` to determine if the morph renderer should be used, instead of just the originating page.

https://github.com/hotwired/turbo/assets/1790447/96d7ec6e-e791-4fae-819b-bc73151a45e1


