### PR TITLE
Improve handling of anchor links and hashchange events

### DIFF
--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -129,13 +129,12 @@ export class Navigator {
 
   locationWithActionIsSamePage(location, action) {
     const anchor = getAnchor(location)
-    const currentAnchor = getAnchor(this.view.lastRenderedLocation)
     const isRestorationToTop = action === "restore" && typeof anchor === "undefined"
 
     return (
       action !== "replace" &&
       getRequestURL(location) === getRequestURL(this.view.lastRenderedLocation) &&
-      (isRestorationToTop || (anchor != null && anchor !== currentAnchor))
+      (isRestorationToTop || anchor != null)
     )
   }
 

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -349,7 +349,7 @@ export class Visit {
       } else {
         this.scrollToAnchor() || this.view.scrollToTop()
         if (this.isSamePage) {
-          this.delegate.visitScrolledToSamePageLocation(this.view.lastRenderedLocation, this.location)
+          this.delegate.visitScrolledToSamePageLocation(window.location.href, this.location)
         }
       }
 

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -348,9 +348,9 @@ export class Visit {
         this.scrollToRestoredPosition() || this.scrollToAnchor() || this.view.scrollToTop()
       } else {
         this.scrollToAnchor() || this.view.scrollToTop()
-      }
-      if (this.isSamePage) {
-        this.delegate.visitScrolledToSamePageLocation(this.view.lastRenderedLocation, this.location)
+        if (this.isSamePage) {
+          this.delegate.visitScrolledToSamePageLocation(this.view.lastRenderedLocation, this.location)
+        }
       }
 
       this.scrolled = true

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -14,8 +14,8 @@
     <a name="named-anchor"></a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
     <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/visit.html">Redirection link</a></p>
-    <a id="named-anchor" href="#named-anchor">Named1</a>
-    <a id="named-anchor-two" href="#named-anchor-two">Named2</a>
+    <a id="anchor-one" href="#anchor-one">Anchor 1</a>
+    <a id="anchor-two" href="#anchor-two">Anchor 2</a>
 
     <turbo-frame id="navigate-top">
       Replaced only the frame

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -14,6 +14,8 @@
     <a name="named-anchor"></a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
     <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/visit.html">Redirection link</a></p>
+    <a id="named-anchor" href="#named-anchor">Named1</a>
+    <a id="named-anchor-two" href="#named-anchor-two">Named2</a>
 
     <turbo-frame id="navigate-top">
       Replaced only the frame

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -411,10 +411,10 @@ test("hashchange events on restoration visits between same-page anchors", async 
   await page.goto("/src/tests/fixtures/one.html")
   await page.waitForLoadState()
 
-  await page.click("#named-anchor")
+  await page.click("#anchor-one")
   await nextBeat()
 
-  await page.click("#named-anchor-two")
+  await page.click("#anchor-two")
   await nextBeat()
 
   await page.evaluate(() => {
@@ -430,12 +430,12 @@ test("hashchange events on restoration visits between same-page anchors", async 
 
   assert.deepEqual(
     await page.evaluate("window.hashchangeEvents"),
-    [{ oldURL: baseURL(page) + "#named-anchor-two", newURL: baseURL(page) + "#named-anchor" }]
+    [{ oldURL: baseURL(page) + "#anchor-two", newURL: baseURL(page) + "#anchor-one" }]
   )
 })
 
 test("moving between multiple same-page anchors", async ({ page }) => {
-  await page.click("#same-origin-anchored-link-named")
+  await page.goto("/src/tests/fixtures/one.html#anchor-one")
   await page.waitForLoadState()
 
   await page.evaluate(() => {
@@ -450,21 +450,21 @@ test("moving between multiple same-page anchors", async ({ page }) => {
     })
   })
 
-  await page.click("#named-anchor-two")
+  await page.click("#anchor-two")
   await nextBeat()
 
   assert.deepEqual(
     await page.evaluate("window.hashchangeEvents"),
-    [{ oldURL: baseURL(page) + "#named-anchor", newURL: baseURL(page) + "#named-anchor-two" }]
+    [{ oldURL: baseURL(page) + "#anchor-one", newURL: baseURL(page) + "#anchor-two" }]
   )
   await page.evaluate("window.hashchangeEvents = []")
 
-  await page.click("#named-anchor")
+  await page.click("#anchor-one")
   await nextBeat()
 
   assert.deepEqual(
     await page.evaluate("window.hashchangeEvents"),
-    [{ oldURL: baseURL(page) + "#named-anchor-two", newURL: baseURL(page) + "#named-anchor" }]
+    [{ oldURL: baseURL(page) + "#anchor-two", newURL: baseURL(page) + "#anchor-one" }]
   )
   assert.deepEqual(await page.evaluate("window.visitEvents"), [])
 })

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -37,6 +37,11 @@ export function hash(url) {
   return hash
 }
 
+export function baseURL(page) {
+  const url = new URL(page.url())
+  return url.origin + url.pathname
+}
+
 export async function hasSelector(page, selector) {
   return !!(await page.locator(selector).count())
 }


### PR DESCRIPTION
When navigating around between multiple anchor links on the same page there's a number of weird behaviours that can come up with how the navigations are handled and the subsequent `hashchange` events that get fired:

- The `hashchange` event's value for `event.oldURL` often contains an incorrect URL (wrong hash)

- Using the back or forwards buttons (restoration visits) causes two `hashchange` events to be fired each time instead of one, and the duplicate contains incorrect information

- Moving between multiple anchors on the same page can trigger an unexpected page visit in some cases, including a network request and repainting the DOM (`turbo:load`) when it shouldn't

Related issues/discussions here: https://github.com/hotwired/turbo/issues/539 and here: https://github.com/hotwired/turbo/issues/876#issuecomment-1492878908