### PR TITLE
Revert: Proposal: pass isPreview value into the event detail in render events (#926)

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -258,7 +258,7 @@ export class FrameController {
 
   // View delegate
 
-  allowsImmediateRender({ element: newFrame }, _isPreview, options) {
+  allowsImmediateRender({ element: newFrame }, options) {
     const event = dispatch("turbo:before-frame-render", {
       target: this.element,
       detail: { newFrame, ...options },

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -298,8 +298,8 @@ export class Session {
     }
   }
 
-  allowsImmediateRender({ element }, isPreview, options) {
-    const event = this.notifyApplicationBeforeRender(element, isPreview, options)
+  allowsImmediateRender({ element }, options) {
+    const event = this.notifyApplicationBeforeRender(element, options)
     const {
       defaultPrevented,
       detail: { render }
@@ -312,9 +312,9 @@ export class Session {
     return !defaultPrevented
   }
 
-  viewRenderedSnapshot(_snapshot, isPreview, renderMethod) {
+  viewRenderedSnapshot(_snapshot, _isPreview, renderMethod) {
     this.view.lastRenderedLocation = this.history.location
-    this.notifyApplicationAfterRender(isPreview, renderMethod)
+    this.notifyApplicationAfterRender(renderMethod)
   }
 
   preloadOnLoadLinksForView(element) {
@@ -370,15 +370,15 @@ export class Session {
     return dispatch("turbo:before-cache")
   }
 
-  notifyApplicationBeforeRender(newBody, isPreview, options) {
+  notifyApplicationBeforeRender(newBody, options) {
     return dispatch("turbo:before-render", {
-      detail: { newBody, isPreview, ...options },
+      detail: { newBody, ...options },
       cancelable: true
     })
   }
 
-  notifyApplicationAfterRender(isPreview, renderMethod) {
-    return dispatch("turbo:render", { detail: { isPreview, renderMethod } })
+  notifyApplicationAfterRender(renderMethod) {
+    return dispatch("turbo:render", { detail: { renderMethod } })
   }
 
   notifyApplicationAfterPageLoad(timing = {}) {

--- a/src/core/view.js
+++ b/src/core/view.js
@@ -65,7 +65,7 @@ export class View {
 
         const renderInterception = new Promise((resolve) => (this.#resolveInterceptionPromise = resolve))
         const options = { resume: this.#resolveInterceptionPromise, render: this.renderer.renderElement }
-        const immediateRender = this.delegate.allowsImmediateRender(snapshot, isPreview, options)
+        const immediateRender = this.delegate.allowsImmediateRender(snapshot, options)
         if (!immediateRender) await renderInterception
 
         await this.renderSnapshot(renderer)

--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -36,16 +36,6 @@ test("triggers before-render and render events", async ({ page }) => {
   assert.equal(await newBody, await page.evaluate(() => document.body.outerHTML))
 })
 
-test("includes isPreview in render event details", async ({ page }) => {
-  await page.click("#same-origin-link")
-
-  const { isPreview } = await nextEventNamed(page, "turbo:before-render")
-  assert.equal(isPreview, false)
-
-  await nextEventNamed(page, "turbo:render")
-  assert.equal(await isPreview, false)
-})
-
 test("triggers before-render, render, and load events for error pages", async ({ page }) => {
   await page.click("#nonexistent-link")
   const { newBody } = await nextEventNamed(page, "turbo:before-render")


### PR DESCRIPTION
It is not necessary to pass along isPreview through various methods in order to determine whether a render is a preview since that can be determined via the data-turbo-preview attribute. (As discussed in https://github.com/hotwired/turbo/pull/926#issuecomment-1692292545)