### PR TITLE
Render `<turbo-stream-source>` as `display: none`

### DIFF
--- a/src/elements/stream_source_element.js
+++ b/src/elements/stream_source_element.js
@@ -1,7 +1,18 @@
 import { connectStreamSource, disconnectStreamSource } from "../core/index"
 
+const template = Object.assign(document.createElement("template"), {
+  innerHTML: "<style>:host { display: none; }</style>"
+})
+
 export class StreamSourceElement extends HTMLElement {
   streamSource = null
+
+  constructor() {
+    super()
+
+    this.attachShadow({ mode: "open" })
+    this.shadowRoot.appendChild(template.content.cloneNode(true))
+  }
 
   connectedCallback() {
     this.streamSource = this.src.match(/^ws{1,2}:/) ? new WebSocket(this.src) : new EventSource(this.src)

--- a/src/tests/functional/stream_tests.js
+++ b/src/tests/functional/stream_tests.js
@@ -1,4 +1,4 @@
-import { test } from "@playwright/test"
+import { expect, test } from "@playwright/test"
 import { assert } from "chai"
 import {
   hasSelector,
@@ -111,6 +111,9 @@ test("receiving a stream message over SSE", async ({ page }) => {
       `<turbo-stream-source id="stream-source" src="/__turbo/messages"></turbo-stream-source>`
     )
   })
+
+  await expect(page.locator("#stream-source")).toHaveCSS("display", "none")
+
   await nextBeat()
   assert.equal(await getReadyState(page, "stream-source"), await page.evaluate(() => EventSource.OPEN))
 


### PR DESCRIPTION
Since the `<turbo-cable-stream-source>` is a Custom Element, it has a default `style:` property of `display: inline`. As a visible element, it participates in the page's layout.

This commit changes the element to always be `display: none` so that it no longer participates in the layout.