### PR TITLE
Ensure that the turbo-frame header is not sent when the turbo-frame has a target of _top

### DIFF
--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -100,14 +100,11 @@ export class LinkPrefetchObserver {
 
     request.headers["Sec-Purpose"] = "prefetch"
 
-    if (link.dataset.turboFrame && link.dataset.turboFrame !== "_top") {
-      request.headers["Turbo-Frame"] = link.dataset.turboFrame
-    } else if (link.dataset.turboFrame !== "_top") {
-      const turboFrame = link.closest("turbo-frame")
+    const turboFrame = link.closest("turbo-frame")
+    const turboFrameTarget = link.dataset.turboFrame || turboFrame?.getAttribute("target") || turboFrame?.id
 
-      if (turboFrame) {
-        request.headers["Turbo-Frame"] = turboFrame.id
-      }
+    if (turboFrameTarget && turboFrameTarget !== "_top") {
+      request.headers["Turbo-Frame"] = turboFrameTarget
     }
 
     if (link.hasAttribute("data-turbo-stream")) {

--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -101,7 +101,7 @@ export class LinkPrefetchObserver {
     request.headers["Sec-Purpose"] = "prefetch"
 
     const turboFrame = link.closest("turbo-frame")
-    const turboFrameTarget = link.dataset.turboFrame || turboFrame?.getAttribute("target") || turboFrame?.id
+    const turboFrameTarget = link.getAttribute("data-turbo-frame") || turboFrame?.getAttribute("target") || turboFrame?.id
 
     if (turboFrameTarget && turboFrameTarget !== "_top") {
       request.headers["Turbo-Frame"] = turboFrameTarget

--- a/src/tests/fixtures/hover_to_prefetch.html
+++ b/src/tests/fixtures/hover_to_prefetch.html
@@ -41,5 +41,13 @@
     <a href="/src/tests/fixtures/prefetched.html" data-turbo-method="post" id="anchor_with_post_method"
       >Won't prefetch when hovering me</a>
     <iframe src="/src/tests/fixtures/hover_to_prefetch_iframe.html" name="prefetch_iframe"> </iframe>
+
+    <turbo-frame id="frame_for_prefetch">
+      <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_in_frame">Hover to prefetch me</a>
+    </turbo-frame>
+
+    <turbo-frame id="frame_for_prefetch_top" target="_top">
+      <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_in_frame_target_top">Hover to prefetch me</a>
+    </turbo-frame>
   </body>
 </html>


### PR DESCRIPTION
With Instaclick enabled and given an HTML structure like this:

```html
<turbo-frame id="frame" target="_top">
  <a href="/src/tests/fixtures/prefetched.html">Hover to prefetch me</a>
</turbo-frame>
```

When the user hovers over the link, the turbo-frame header should not be sent in the prefetch request because the wrapping turbo-frame has a target of `_top`.

If we don't respect this turbo-rails sees the turbo-frame header and renders a turbo-frame response with a minimal layout that doesn't include any assets in the head. When turbo processes the response it may find a missmatch in tracked assets and cause a reload.

//cc @davidalejandroaguilar 