### PR TITLE
Morph with `ignoreActiveValue: true`

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "chai": "~4.3.4",
     "eslint": "^8.13.0",
     "express": "^4.18.2",
-    "idiomorph": "^0.3.0",
+    "idiomorph": "https://github.com/bigskysoftware/idiomorph.git",
     "multer": "^1.4.2",
     "rollup": "^2.35.1"
   },

--- a/src/core/drive/morph_renderer.js
+++ b/src/core/drive/morph_renderer.js
@@ -29,6 +29,7 @@ export class MorphRenderer extends Renderer {
     this.isMorphingTurboFrame = this.#isFrameReloadedWithMorph(currentElement)
 
     Idiomorph.morph(currentElement, newElement, {
+      ignoreActiveValue: true,
       morphStyle: morphStyle,
       callbacks: {
         beforeNodeAdded: this.#shouldAddElement,

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -88,6 +88,13 @@
       <input>
     </div>
 
+    <form method="get" data-turbo-action="replace" oninput="this.requestSubmit()">
+      <label>
+        Search
+        <input name="query">
+      </label>
+      <button>Form with params to refresh the page</button>
+    </form>
     <p><a id="replace-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html?param=something">Link with params to refresh the page</a></p>
     <p><a id="link" href="/src/tests/fixtures/one.html">Link to another page</a></p>
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1865,10 +1865,9 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-idiomorph@^0.3.0:
+"idiomorph@https://github.com/bigskysoftware/idiomorph.git":
   version "0.3.0"
-  resolved "https://registry.yarnpkg.com/idiomorph/-/idiomorph-0.3.0.tgz#f6675bc5bef1a72c94021e43141a3f605d2d6288"
-  integrity sha512-UhV1Ey5xCxIwR9B+OgIjQa+1Jx99XQ1vQHUsKBU1RpQzCx1u+b+N6SOXgf5mEJDqemUI/ffccu6+71l2mJUsRA==
+  resolved "https://github.com/bigskysoftware/idiomorph.git#b5115add9f7ab04c04af0624385540dff04e0735"
 
 ieee754@^1.1.13:
   version "1.2.1"


### PR DESCRIPTION
Morph with the [ignoreActiveValue: true][] option to morph the currently focused element's attributes, but preserve its value.

This behavior can be extremely helpful when paired with an auto-submitting `<form>` element, like a typeahead `[role="combobox"]`, or an auto-submitting [`<input type="search">`][search].

This commit depends on a fork of `idiomorph` that [fixes a bug related to `ignoreActiveValue: true`][bigskysoftware/idiomorph#34].


https://github.com/hotwired/turbo/assets/2575027/ca40524f-da6c-40fd-aacf-1bbe74be72f5



[ignoreActiveValue: true]: https://github.com/bigskysoftware/idiomorph#options
[search]: https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/search
[bigskysoftware/idiomorph#34]: https://github.com/bigskysoftware/idiomorph/pull/34