### PR TITLE
Don't include Turbo-Frame header in promoted frame navigations

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -192,7 +192,9 @@ export class FrameController {
   // Fetch request delegate
 
   prepareRequest(request) {
-    request.headers["Turbo-Frame"] = this.id
+    if (!this.action) {
+      request.headers["Turbo-Frame"] = this.id
+    }
 
     if (this.currentNavigationElement?.hasAttribute("data-turbo-stream")) {
       request.acceptResponseType(StreamMessage.contentType)


### PR DESCRIPTION
This PR changes the behavior of frame navigations promoted with the `[data-turbo-action]` attribute so that they don't include the `Turbo-Frame` header in their requests. This mimics the existing behavior of frame navigations promoted with `[data-turbo-target=_top]`.

If we don't do this turbo-rails will see the `Turbo-Frame` header and render the response as a frame update, with a minimal layout that doesn't include any assets. When Turbo receives the response it believes it's a full page response in which the assets have gone stale and it issues a full page reload with `tracked_element_mismatch` as the reason.

Fixes https://github.com/hotwired/turbo/issues/1047

This is similar to https://github.com/hotwired/turbo/pull/1138

//cc @seanpdoyle @domchristie 