### PR TITLE
Add support for `data-turbo-replace-method="morph"` to force a morph

### DIFF
--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -10,7 +10,6 @@ export class Navigator {
   }
 
   proposeVisit(location, options = {}) {
-    console.log(`proposeVisit ${location}`, options)
     if (this.delegate.allowsVisitingLocationWithAction(location, options.action)) {
       this.delegate.visitProposedToLocation(location, options)
     }
@@ -70,7 +69,6 @@ export class Navigator {
   }
 
   async formSubmissionSucceededWithResponse(formSubmission, fetchResponse) {
-    console.log(`formSubmissionSucceededWithResponse`)
     if (formSubmission == this.formSubmission) {
       const responseHTML = await fetchResponse.responseHTML
       if (responseHTML) {
@@ -82,14 +80,12 @@ export class Navigator {
         const { statusCode, redirected } = fetchResponse
         const action = this.#getActionForFormSubmission(formSubmission, fetchResponse)
         const replaceMethod = this.#getReplaceMethodForFormSubmission(formSubmission, fetchResponse)
-        console.log(`action = ${action} and replaceMethod = ${replaceMethod}`)
         const visitOptions = {
           action,
           replaceMethod,
           shouldCacheSnapshot,
           response: { statusCode, responseHTML, redirected }
         }
-        console.log(`calling proposeVisit from formSubmission`)
         this.proposeVisit(fetchResponse.location, visitOptions)
       }
     }

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -16,7 +16,7 @@ export class PageView extends View {
   }
 
   renderPage(snapshot, isPreview = false, willRender = true, visit) {
-    const shouldMorphPage = this.shouldMorphPage(snapshot, visit)
+    const shouldMorphPage = snapshot.shouldMorphPage && this.isMorphableVisit(visit)
     const rendererClass = shouldMorphPage ? MorphRenderer : PageRenderer
 
     const renderer = new rendererClass(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)
@@ -55,9 +55,8 @@ export class PageView extends View {
     return this.snapshotCache.get(location)
   }
 
-  shouldMorphPage(snapshot, visit) {
-    return snapshot.shouldMorphPage &&
-            (this.isPageRefresh(visit) || this.isReplaceMethodMorph(visit))
+  isMorphableVisit(visit) {
+    return this.isPageRefresh(visit) || this.isReplaceMethodMorph(visit)
   }
 
   isPageRefresh(visit) {
@@ -65,7 +64,7 @@ export class PageView extends View {
   }
 
   isReplaceMethodMorph(visit) {
-    return !visit || (visit.action === "replace" && visit.replaceMethod === "morph")
+    return visit.action === "replace" && visit.replaceMethod === "morph"
   }
 
   shouldPreserveScrollPosition(visit) {

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -17,7 +17,6 @@ export class PageView extends View {
 
   renderPage(snapshot, isPreview = false, willRender = true, visit) {
     const shouldMorphPage = this.shouldMorphPage(snapshot, visit)
-    console.log(`should morph? ${shouldMorphPage}`)
     const rendererClass = shouldMorphPage ? MorphRenderer : PageRenderer
 
     const renderer = new rendererClass(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)
@@ -57,7 +56,6 @@ export class PageView extends View {
   }
 
   shouldMorphPage(snapshot, visit) {
-    console.log(`shouldMorphPage snapshot? ${snapshot.shouldMorphPage}... ${visit.action} and ${visit.replaceMethod}`)
     return snapshot.shouldMorphPage &&
             (this.isPageRefresh(visit) || this.isReplaceMethodMorph(visit))
   }

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -61,7 +61,7 @@ export class PageView extends View {
   }
 
   isPageRefresh(visit) {
-    return !visit || (this.lastRenderedLocation.pathname === visit.location.pathname && visit.action === "replace")
+    return !visit || (this.lastRenderedLocation.href === visit.location.href && visit.action === "replace")
   }
 
   isReplaceMethodMorph(visit) {

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -16,7 +16,8 @@ export class PageView extends View {
   }
 
   renderPage(snapshot, isPreview = false, willRender = true, visit) {
-    const shouldMorphPage = this.isPageRefresh(visit) && this.snapshot.shouldMorphPage
+    const shouldMorphPage = this.shouldMorphPage(snapshot, visit)
+    console.log(`should morph? ${shouldMorphPage}`)
     const rendererClass = shouldMorphPage ? MorphRenderer : PageRenderer
 
     const renderer = new rendererClass(this.snapshot, snapshot, PageRenderer.renderElement, isPreview, willRender)
@@ -55,8 +56,18 @@ export class PageView extends View {
     return this.snapshotCache.get(location)
   }
 
+  shouldMorphPage(snapshot, visit) {
+    console.log(`shouldMorphPage snapshot? ${snapshot.shouldMorphPage}... ${visit.action} and ${visit.replaceMethod}`)
+    return snapshot.shouldMorphPage &&
+            (this.isPageRefresh(visit) || this.isReplaceMethodMorph(visit))
+  }
+
   isPageRefresh(visit) {
     return !visit || (this.lastRenderedLocation.pathname === visit.location.pathname && visit.action === "replace")
+  }
+
+  isReplaceMethodMorph(visit) {
+    return !visit || (visit.action === "replace" && visit.replaceMethod === "morph")
   }
 
   shouldPreserveScrollPosition(visit) {

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -62,6 +62,7 @@ export class Visit {
 
     const {
       action,
+      replaceMethod,
       historyChanged,
       referrer,
       snapshot,
@@ -78,6 +79,7 @@ export class Visit {
       ...options
     }
     this.action = action
+    this.replaceMethod = replaceMethod
     this.historyChanged = historyChanged
     this.referrer = referrer
     this.snapshot = snapshot

--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -147,6 +147,7 @@ export class FrameController {
   // Appearance observer delegate
 
   elementAppearedInViewport(element) {
+    // TODO: Determine if I need to check replaceMethod() here — I need to find the corresponding tests
     this.proposeVisitIfNavigatedWithAction(element, getVisitAction(element))
     this.#loadSourceURL()
   }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -34,6 +34,10 @@ export function registerAdapter(adapter) {
  * @param options Options to apply
  * @param options.action Type of history navigation to apply ("restore",
  * "replace" or "advance")
+ * @param options.frame If specified, finds a turbo-frame element with an [id]
+ * attribute that matches this.
+ * @param options.replaceMethod If specified, changes the method used to
+ * perform a replace ("morph" or else it defaults to "body" replace)
  * @param options.historyChanged Specifies whether the browser history has
  * already been changed for this visit or not
  * @param options.referrer Specifies the referrer of this visit such that

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -228,7 +228,6 @@ export class Session {
     const replaceMethod = this.getVisitReplaceMethodForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
 
-    console.log(`followedLinkToLocation`)
     this.visit(location.href, { action, replaceMethod, acceptsStreamResponse })
   }
 

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -13,7 +13,7 @@ import { ScrollObserver } from "../observers/scroll_observer"
 import { StreamMessage } from "./streams/stream_message"
 import { StreamMessageRenderer } from "./streams/stream_message_renderer"
 import { StreamObserver } from "../observers/stream_observer"
-import { clearBusyState, dispatch, findClosestRecursively, getVisitAction, markAsBusy, debounce } from "../util"
+import { clearBusyState, dispatch, findClosestRecursively, getVisitAction, getVisitReplaceMethod, markAsBusy, debounce } from "../util"
 import { PageView } from "./drive/page_view"
 import { FrameElement } from "../elements/frame_element"
 import { Preloader } from "./drive/preloader"
@@ -225,9 +225,11 @@ export class Session {
 
   followedLinkToLocation(link, location) {
     const action = this.getActionForLink(link)
+    const replaceMethod = this.getVisitReplaceMethodForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
 
-    this.visit(location.href, { action, acceptsStreamResponse })
+    console.log(`followedLinkToLocation`)
+    this.visit(location.href, { action, replaceMethod, acceptsStreamResponse })
   }
 
   // Navigator delegate
@@ -464,6 +466,12 @@ export class Session {
 
   getActionForLink(link) {
     return getVisitAction(link) || "advance"
+  }
+
+  getVisitReplaceMethodForLink(link) {
+    if (this.getActionForLink(link) !== "replace") return
+
+    return getVisitReplaceMethod(link) || "body"
   }
 
   get snapshot() {

--- a/src/observers/form_link_click_observer.js
+++ b/src/observers/form_link_click_observer.js
@@ -53,6 +53,7 @@ export class FormLinkClickObserver {
     const turboFrame = link.getAttribute("data-turbo-frame")
     if (turboFrame) form.setAttribute("data-turbo-frame", turboFrame)
 
+    // TODO: Determine if I need to check data-turbo-replace-method here — I need to find the corresponding tests
     const turboAction = getVisitAction(link)
     if (turboAction) form.setAttribute("data-turbo-action", turboAction)
 

--- a/src/tests/fixtures/destination_for_morphing.html
+++ b/src/tests/fixtures/destination_for_morphing.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html id="one">
+  <head>
+    <meta charset="utf-8">
+    <title>One</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="test" content="foo">
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
+  </head>
+  <body>
+    <h1>One</h1>
+
+    <!--styles ensure that the element will be scrolled to top when navigated to via an anchored link -->
+    <a name="named-anchor"></a>
+    <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
+    <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/visit.html">Redirection link</a></p>
+    <p><a id="page-refresh-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html">Page refresh link</a></p>
+
+    <turbo-frame id="navigate-top">
+      Replaced only the frame
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -20,6 +20,7 @@
       <p><a id="same-origin-unannotated-link" href="/src/tests/fixtures/one.html">Same-origin unannotated link</a></p>
       <p><a id="same-origin-unannotated-link-search-params" href="/src/tests/fixtures/one.html?key=value">Same-origin unannotated link ?key=value</a></p>
       <p><form id="same-origin-unannotated-form" method="get" action="/src/tests/fixtures/one.html"><button>Same-origin unannotated form</button></form></p>
+
       <p><a id="same-origin-replace-link" href="/src/tests/fixtures/one.html" data-turbo-action="replace">Same-origin data-turbo-action=replace link</a></p>
       <p><form id="same-origin-replace-form-get" action="/src/tests/fixtures/one.html" data-turbo-action="replace"><button>Same-origin data-turbo-action=replace form</button></form></p>
       <p><form id="same-origin-replace-form-submitter-get" action="/src/tests/fixtures/one.html"><button data-turbo-action="replace">Same-origin data-turbo-action=replace form</button></form></p>
@@ -31,6 +32,20 @@
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
         <button data-turbo-action="replace">Same-origin form[method="post"] button[data-turbo-action="replace"]</button>
       </form>
+
+      <p><a id="same-origin-replace-morph-link" href="/src/tests/fixtures/destination_for_morphing.html" data-turbo-action="replace" data-turbo-replace-method="morph">Same-origin data-turbo-action=replace data-turbo-replace-method=morph link</a></p>
+      <p><a id="same-origin-advance-morph-link" href="/src/tests/fixtures/destination_for_morphing.html" data-turbo-action="advance" data-turbo-replace-method="morph">Same-origin data-turbo-action=advance data-turbo-replace-method=morph link</a></p>
+      <p><form id="same-origin-replace-morph-form-get" action="/src/tests/fixtures/destination_for_morphing.html" data-turbo-action="replace" data-turbo-replace-method="morph"><button>Same-origin data-turbo-action=replace data-turbo-replace-method=morph form</button></form></p>
+      <p><form id="same-origin-replace-morph-form-submitter-get" action="/src/tests/fixtures/destination_for_morphing.html"><button data-turbo-action="replace" data-turbo-replace-method="morph">Same-origin data-turbo-action=replace data-turbo-replace-method=morph form</button></form></p>
+      <form id="same-origin-replace-morph-form-post" method="post" action="/__turbo/redirect" data-turbo-action="replace" data-turbo-replace-method="morph">
+        <input type="hidden" name="path" value="/src/tests/fixtures/destination_for_morphing.html">
+        <button>Same-origin form[method="post"][data-turbo-action="replace"][data-turbo-replace-method="morph"]</button>
+      </form>
+      <form id="same-origin-replace-morph-form-submitter-post" method="post" action="/__turbo/redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/destination_for_morphing.html">
+        <button data-turbo-action="replace">Same-origin form[method="post"] button[data-turbo-action="replace"]</button>
+      </form>
+
       <form id="form-post" method="post" action="/__turbo/redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
         <input type="submit" id="form-post-submit" value="Submit"/>

--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -36,14 +36,24 @@
       <p><a id="same-origin-replace-morph-link" href="/src/tests/fixtures/destination_for_morphing.html" data-turbo-action="replace" data-turbo-replace-method="morph">Same-origin data-turbo-action=replace data-turbo-replace-method=morph link</a></p>
       <p><a id="same-origin-advance-morph-link" href="/src/tests/fixtures/destination_for_morphing.html" data-turbo-action="advance" data-turbo-replace-method="morph">Same-origin data-turbo-action=advance data-turbo-replace-method=morph link</a></p>
       <p><form id="same-origin-replace-morph-form-get" action="/src/tests/fixtures/destination_for_morphing.html" data-turbo-action="replace" data-turbo-replace-method="morph"><button>Same-origin data-turbo-action=replace data-turbo-replace-method=morph form</button></form></p>
+      <p><form id="same-origin-advance-morph-form-get" action="/src/tests/fixtures/destination_for_morphing.html" data-turbo-action="advance" data-turbo-replace-method="morph"><button>Same-origin data-turbo-action=advance data-turbo-replace-method=morph form</button></form></p>
       <p><form id="same-origin-replace-morph-form-submitter-get" action="/src/tests/fixtures/destination_for_morphing.html"><button data-turbo-action="replace" data-turbo-replace-method="morph">Same-origin data-turbo-action=replace data-turbo-replace-method=morph form</button></form></p>
+      <p><form id="same-origin-advance-morph-form-submitter-get" action="/src/tests/fixtures/destination_for_morphing.html"><button data-turbo-action="advance" data-turbo-replace-method="morph">Same-origin data-turbo-action=advance data-turbo-replace-method=morph form</button></form></p>
       <form id="same-origin-replace-morph-form-post" method="post" action="/__turbo/redirect" data-turbo-action="replace" data-turbo-replace-method="morph">
         <input type="hidden" name="path" value="/src/tests/fixtures/destination_for_morphing.html">
         <button>Same-origin form[method="post"][data-turbo-action="replace"][data-turbo-replace-method="morph"]</button>
       </form>
+      <form id="same-origin-advance-morph-form-post" method="post" action="/__turbo/redirect" data-turbo-action="advance" data-turbo-replace-method="morph">
+        <input type="hidden" name="path" value="/src/tests/fixtures/destination_for_morphing.html">
+        <button>Same-origin form[method="post"][data-turbo-action="advance"][data-turbo-replace-method="morph"]</button>
+      </form>
       <form id="same-origin-replace-morph-form-submitter-post" method="post" action="/__turbo/redirect">
         <input type="hidden" name="path" value="/src/tests/fixtures/destination_for_morphing.html">
-        <button data-turbo-action="replace">Same-origin form[method="post"] button[data-turbo-action="replace"]</button>
+        <button data-turbo-action="replace" data-turbo-replace-method="morph">Same-origin form[method="post"] button[data-turbo-action="replace"][data-turbo-replace-method="morph"]</button>
+      </form>
+      <form id="same-origin-advance-morph-form-submitter-post" method="post" action="/__turbo/redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/destination_for_morphing.html">
+        <button data-turbo-action="advance" data-turbo-advance-method="morph">Same-origin form[method="post"] button[data-turbo-action="advance"][data-turbo-replace-method="morph"]</button>
       </form>
 
       <form id="form-post" method="post" action="/__turbo/redirect">

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -112,7 +112,8 @@
       </label>
       <button>Form with params to refresh the page</button>
     </form>
-    <p><a id="replace-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html?param=something">Link with params to refresh the page</a></p>
+    <p><a id="replace-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html?tab=something">Link with params should not refresh the page</a></p>
+    <p><a id="replace-link-method-morph" data-turbo-action="replace" data-turbo-replace-method="morph" href="/src/tests/fixtures/page_refresh.html?tab=something">Link with different params will morph if specified</a></p>
     <p><a id="refresh-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html">Link to the same page</a></p>
     <p><a id="link" href="/src/tests/fixtures/one.html">Link to another page</a></p>
 

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -197,14 +197,9 @@ test("following a same-origin POST form button[data-turbo-action=replace]", asyn
   expect(await noNextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
 })
 
-
-
 test("following a same-origin data-turbo-action=replace and data-turbo-replace-method=morph link", async ({ page }) => {
-  page.on('console', message => console.log(message.text()))
-
   await page.click("#same-origin-replace-morph-link")
   await nextBody(page)
-  console.log(`url = ${pathname(page.url())}`)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
   assert.equal(await visitAction(page), "replace")
   assert.equal(await visitReplaceMethod(page), "morph")
@@ -216,8 +211,7 @@ test("following a same-origin data-turbo-action=advance and data-turbo-replace-m
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
   assert.equal(await visitAction(page), "advance")
-  console.log(`== ${await visitReplaceMethod(page)}`)
-  assert.equal(await visitReplaceMethod(page), "body")
+  assert.notEqual(await visitReplaceMethod(page), "morph")
   expect(await noNextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
 })
 

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -206,7 +206,7 @@ test("following a same-origin data-turbo-action=replace and data-turbo-replace-m
   expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
 })
 
-test("following a same-origin data-turbo-action=advance and data-turbo-replace-method=morph link should ignore method", async ({ page }) => {
+test("following a same-origin data-turbo-action=advance and data-turbo-replace-method=morph link should ignore morph method", async ({ page }) => {
   await page.click("#same-origin-advance-morph-link")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
@@ -216,14 +216,21 @@ test("following a same-origin data-turbo-action=advance and data-turbo-replace-m
 })
 
 test("following a same-origin GET form[data-turbo-action=replace][data-turbo-replace-method=morph]", async ({ page }) => {
-  page.on('console', message => console.log(message.text()))
-
   await page.click("#same-origin-replace-morph-form-get button")
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
   assert.equal(await visitAction(page), "replace")
-  console.log(await visitReplaceMethod(page))
-  //expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+  assert.equal(await visitReplaceMethod(page), "morph")
+  expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+})
+
+test("following a same-origin GET form[data-turbo-action=advance][data-turbo-replace-method=morph] should ignore morph method", async ({ page }) => {
+  await page.click("#same-origin-advance-morph-form-get button")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.notEqual(await visitReplaceMethod(page), "morph")
+  expect(await noNextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
 })
 
 test("following a same-origin GET form button[data-turbo-action=replace][data-turbo-replace-method=morph]", async ({ page }) => {
@@ -231,31 +238,56 @@ test("following a same-origin GET form button[data-turbo-action=replace][data-tu
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
   assert.equal(await visitAction(page), "replace")
-  console.log(await visitReplaceMethod(page))
-  //expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+  assert.equal(await visitReplaceMethod(page), "morph")
+  expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+})
+
+test("following a same-origin GET form button[data-turbo-action=advance][data-turbo-replace-method=morph] should ignore morph method", async ({ page }) => {
+  await page.click("#same-origin-advance-morph-form-submitter-get button")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.notEqual(await visitReplaceMethod(page), "morph")
+  expect(await noNextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
 })
 
 test("following a same-origin POST form[data-turbo-action=replace][data-turbo-replace-method=morph]", async ({ page }) => {
   await page.click("#same-origin-replace-morph-form-post button")
   await nextBody(page)
-
   assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
   assert.equal(await visitAction(page), "replace")
-  console.log(await visitReplaceMethod(page))
-  //expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+  assert.equal(await visitReplaceMethod(page), "morph")
+  expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+})
+
+test("following a same-origin POST form[data-turbo-action=advance][data-turbo-replace-method=morph] should ignore morph method", async ({ page }) => {
+  await page.click("#same-origin-advance-morph-form-post button")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.notEqual(await visitReplaceMethod(page), "morph")
+  expect(await noNextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
 })
 
 test("following a same-origin POST form button[data-turbo-action=replace][data-turbo-replace-method=morph]", async ({ page }) => {
   await page.click("#same-origin-replace-morph-form-submitter-post button")
-  await nextEventNamed(page, "turbo:load")
+  expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+  expect(await nextEventNamed(page, "turbo:load")).toBeTruthy()
 
   assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
   assert.equal(await visitAction(page), "replace")
-  console.log(await visitReplaceMethod(page))
-  //expect(await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+  assert.equal(await visitReplaceMethod(page), "morph")
 })
 
+test("following a same-origin POST form button[data-turbo-action=advance][data-turbo-replace-method=morph] should ignore morph method", async ({ page }) => {
+  await page.click("#same-origin-advance-morph-form-submitter-post button")
+  expect(await noNextEventNamed(page, "turbo:render", { renderMethod: "morph" })).toBeTruthy()
+  expect(await nextEventNamed(page, "turbo:load")).toBeTruthy()
 
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/destination_for_morphing.html")
+  assert.equal(await visitAction(page), "advance")
+  assert.notEqual(await visitReplaceMethod(page), "morph")
+})
 
 test("following a POST form clears cache", async ({ page }) => {
   await page.evaluate(() => {

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -102,10 +102,17 @@ test("page refreshes cause a reload when assets change", async ({ page }) => {
   await expect(page.locator("#new-stylesheet")).toHaveCount(0)
 })
 
-test("renders a page refresh with morphing when the paths are the same but search params are different", async ({ page }) => {
+test("does not render a page refresh with morphing when params are different", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 
   await page.click("#replace-link")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "replace" })
+})
+
+test("does render a page refresh with morphing when params are different when explicitly specified", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.click("#replace-link-method-morph")
   await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
 })
 

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -96,12 +96,12 @@ export async function nextPageRefresh(page, timeout = 500) {
   return sleep(pageRefreshDebouncePeriod + timeout)
 }
 
-export async function nextEventNamed(page, eventName, expectedDetail = {}) {
+export async function nextEventNamed(page, expectedName, expectedDetail = {}) {
   let record
   while (!record) {
     const records = await readEventLogs(page, 1)
     record = records.find(([name, detail]) => {
-      return name == eventName && Object.entries(expectedDetail).every(([key, value]) => detail[key] === value)
+      return name == expectedName && Object.entries(expectedDetail).every(([key, value]) => detail[key] === value)
     })
   }
   return record[1]

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -291,6 +291,16 @@ export function visitAction(page) {
   })
 }
 
+export function visitReplaceMethod(page) {
+  return page.evaluate(() => {
+    try {
+      return window.Turbo.navigator.currentVisit.replaceMethod
+    } catch (error) {
+      return "load"
+    }
+  })
+}
+
 export function waitForPathname(page, pathname) {
   return page.waitForURL((url) => url.pathname == pathname)
 }

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -171,7 +171,6 @@ router.get("/messages", (request, response) => {
 function receiveMessage(content, id, target) {
   const data = renderSSEData(renderMessage(content, id, target))
   for (const response of streamResponses) {
-    console.log("delivering message to stream", response.socket?.remotePort)
     response.write(data)
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -154,14 +154,24 @@ export function getHistoryMethodForAction(action) {
   }
 }
 
-export function isAction(action) {
+export function isValidAction(action) {
   return action == "advance" || action == "replace" || action == "restore"
 }
 
 export function getVisitAction(...elements) {
   const action = getAttribute("data-turbo-action", ...elements)
 
-  return isAction(action) ? action : null
+  return isValidAction(action) ? action : null
+}
+
+export function isValidReplaceMethod(method) {
+  return method == "morph" || method == "body"
+}
+
+export function getVisitReplaceMethod(...elements) {
+  const method = getAttribute("data-turbo-replace-method", ...elements)
+
+  return isValidReplaceMethod(method) ? method : null
 }
 
 export function getMetaElement(name) {


### PR DESCRIPTION
This PR allows you to add an optional `data-turbo-replace-method="morph"` in the cases where a `data-turbo-action="replace"`. If you try to specify `morph` when the action is `advance` it will be ignored. It is an alternate, and more general, solution to #1079 so it also reverts that behavior. 

**Background:** After introducing the concept of morphing _page refresh_, Turbo detects when the current page is being refreshed again in order to decide if it should morph. It determines this by comparing the url of the previous location and the new location. This automatic detection works great, most of the time. However, there are some times when the href may include some tracking query string parameters so the href does not match and a refresh is not triggered. PR #1079 was an attempt to address this.

**Problem:** However, [this discussion](https://github.com/hotwired/turbo-ios/pull/178#discussion_r1501357383) pointed out that while query string parameters are sometimes unimportant, other times they completely change the behavior of the page (e.g. `?tab=overview`). In addition, there are some situations where we are doing a replace and that replace is effectively a refresh, even though the URL has changed. Imagine the user is on `/posts/new`, clicks "save draft", and redirect to `/posts/:id` to continue editing. You designate this as a `replace` action (not `advance`) and you want to morph this page since it's the same form and same template.

**Solution:** This PR introduces adds support for `data-turbo-replace-method="morph"`. There are explicit tests for all the relevant cases within `navigation_tests.js`, specifically:

* Within `a href` links
* Within `<form>` tags (get & post)
* Within the `<button>` tag within a `<form>` (get & post)