### PR TITLE
Add ability to click link in a frame with a `data-turbo-stream="true"`

### DIFF
--- a/src/http/fetch_request.js
+++ b/src/http/fetch_request.js
@@ -124,6 +124,7 @@ export class FetchRequest {
     const event = await this.#allowRequestToBeIntercepted(fetchOptions)
     try {
       this.delegate.requestStarted(this)
+      this.delegate.changeHistory()
 
       if (event.detail.fetchRequest) {
         this.response = event.detail.fetchRequest.response


### PR DESCRIPTION
So, I guess it would be fine to have the ability to change the URL with turbo_stream request for some reason: when you have pagination or other type of request, like filters, you need to provide for user URL with its parameters, so in my case me too need. So, with this type of pages-request you'll update the page by parts with turbo_stream but it affects the URL, and the only way to solve it is to use JS code like stimulusUse with its mutate or create some workarounds that solve It by handling turbo events.
So, when contributors added the ability to create a `turbo_stream` with a GET request we also need the ability to show this GET request for the browser to add an ability for the user to share it, or find it, to be on the same page after page reloading. So, let me solve this problem, help or just complete this issue, please
solves #1151
solves #792 