### PR TITLE
Allow different methods of appending turbo-streams to document

### DIFF
--- a/src/core/streams/stream_message_renderer.js
+++ b/src/core/streams/stream_message_renderer.js
@@ -7,7 +7,7 @@ export class StreamMessageRenderer {
     Bardo.preservingPermanentElements(this, getPermanentElementMapForFragment(fragment), () => {
       withAutofocusFromFragment(fragment, () => {
         withPreservedFocus(() => {
-          document.documentElement.appendChild(fragment)
+          this.appendFragment(fragment);
         })
       })
     })
@@ -20,6 +20,10 @@ export class StreamMessageRenderer {
   }
 
   leavingBardo() {}
+
+  appendFragment(fragment) {
+    document.documentElement.appendChild(fragment);
+  }
 }
 
 function getPermanentElementMapForFragment(fragment) {


### PR DESCRIPTION
Right now `<turbo-stream>` elements received in response are added all-at-once to the document. This results in rendering in order of apperance in response, without chance to modify the list of elements. Example response:

![image](https://github.com/hotwired/turbo/assets/7421962/c7a96784-16b8-4078-bf6e-9419f4b392f6)

The problem arises, when you have some custom stream action (in above example: *click*), that needs to modify list of actions client-side. The action *click* in the example is responsible for invoking *onclick* handler - which itself is a call to _renderStreamMessage()_ and renders some template consisting of `<turbo-stream>`s to keep things DRY:

<pre>
Turbo.StreamActions.click = function() {
  this.targetElements.forEach((e) => { e.click() })
}
</pre>

Without modifications, this yields the following order of rendering turbo streams:

![image](https://github.com/hotwired/turbo/assets/7421962/5e97a629-8afa-491b-831b-a69fb84a27ad)

Notice how the additional elements will only be rendered at the end of the chain - which is not our intent. The order matters and we would like to have turbo streams resulting from *click* action rendered right after that action.

Solution:

Allow customization of the method of adding turbo stream templates to document, by separating `appendChild()` call inside `StreamMessageRenderer#render` into separate method (see attached commit). Later this method can be overridden by something like this, to keep order of actions proper in the example above:
<pre>
Turbo.session.streamMessageRenderer.appendFragment = async function (fragment) {
  for (let child of [...fragment.children]) {
    document.documentElement.appendChild(child)
    if (child.action == "click") {
      await new Promise((resolve) => {
        new MutationObserver((mutations, observer) => {
          mutations.forEach((m) => {
            if ([...m.removedNodes].includes(child)) {
              resolve(child)
              observer.disconnect()
            }
          })
        }).observe(document.documentElement, {childList: true})
      })
    }
  }
}
</pre>

That yields expected result:

![image](https://github.com/hotwired/turbo/assets/7421962/ada5281f-9cfc-4819-8edc-f56113322c94)
