### PR TITLE
Disable InstantClick for touch events

### DIFF
--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -36,7 +36,7 @@ export class LinkPrefetchObserver {
       capture: true,
       passive: true
     })
-    this.eventTarget.removeEventListener("mouseleave", this.#checkIfPrefetchValidAfterMouseLeave, {
+    this.eventTarget.removeEventListener("mouseleave", this.#cancelRequestIfObsolete, {
       capture: true,
       passive: true
     })
@@ -50,7 +50,7 @@ export class LinkPrefetchObserver {
       capture: true,
       passive: true
     })
-    this.eventTarget.addEventListener("mouseleave", this.#checkIfPrefetchValidAfterMouseLeave, {
+    this.eventTarget.addEventListener("mouseleave", this.#cancelRequestIfObsolete, {
       capture: true,
       passive: true
     })
@@ -85,7 +85,7 @@ export class LinkPrefetchObserver {
     }
   }
 
-  #checkIfPrefetchValidAfterMouseLeave = (event) => {
+  #cancelRequestIfObsolete = (event) => {
     if (event.target === this.#prefetchedLink) this.#cancelPrefetchRequest()
   }
 

--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -41,19 +41,6 @@ export class LinkPrefetchObserver {
       passive: true
     })
 
-    this.eventTarget.removeEventListener("touchstart", this.#tryToPrefetchRequest, {
-      capture: true,
-      passive: true
-    })
-    this.eventTarget.removeEventListener("touchend", this.#checkIfPrefetchValidAfterTouchChange, {
-      capture: true,
-      passive: true
-    })
-    this.eventTarget.removeEventListener("touchmove", this.#checkIfPrefetchValidAfterTouchChange, {
-      capture: true,
-      passive: true
-    })
-
     this.eventTarget.removeEventListener("turbo:before-fetch-request", this.#tryToUsePrefetchedRequest, true)
     this.started = false
   }
@@ -64,19 +51,6 @@ export class LinkPrefetchObserver {
       passive: true
     })
     this.eventTarget.addEventListener("mouseleave", this.#checkIfPrefetchValidAfterMouseLeave, {
-      capture: true,
-      passive: true
-    })
-
-    this.eventTarget.addEventListener("touchstart", this.#tryToPrefetchRequest, {
-      capture: true,
-      passive: true
-    })
-    this.eventTarget.addEventListener("touchend", this.#checkIfPrefetchValidAfterTouchChange, {
-      capture: true,
-      passive: true
-    })
-    this.eventTarget.addEventListener("touchmove", this.#checkIfPrefetchValidAfterTouchChange, {
       capture: true,
       passive: true
     })
@@ -113,10 +87,6 @@ export class LinkPrefetchObserver {
 
   #checkIfPrefetchValidAfterMouseLeave = (event) => {
     if (event.target === this.#prefetchedLink) this.#cancelPrefetchRequest()
-  }
-
-  #checkIfPrefetchValidAfterTouchChange = (event) => {
-    if (this.#prefetchedLink && !isTouching(event, this.#prefetchedLink)) this.#cancelPrefetchRequest()
   }
 
   #cancelPrefetchRequest = () => {
@@ -217,10 +187,6 @@ export class LinkPrefetchObserver {
 
     return true
   }
-}
-
-const isTouching = (event, target) => {
-  return Array.from(event.targetTouches).some((touch) => touch.target === target)
 }
 
 const targetsIframe = (link) => {

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -240,11 +240,6 @@ test("it resets the cache when a link is hovered", async ({ page }) => {
   assert.equal(requestCount, 2)
 })
 
-test("it prefetches page on touchstart", async ({ page }) => {
-  await goTo({ page, path: "/hover_to_prefetch.html" })
-  await assertPrefetchedOnTouchstart({ page, selector: "#anchor_for_prefetch" })
-})
-
 test("it does not make a network request when clicking on a link that has been prefetched", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
   await hoverSelector({ page, selector: "#anchor_for_prefetch" })
@@ -263,26 +258,6 @@ test("it follows the link using the cached response when clicking on a link that
   await clickSelector({ page, selector: "#anchor_for_prefetch" })
   assert.equal(await page.title(), "Prefetched Page")
 })
-
-const assertPrefetchedOnTouchstart = async ({ page, selector, callback }) => {
-  let requestMade = false
-
-  page.on("request", (request) => {
-    callback && callback(request)
-    requestMade = true
-  })
-
-  const selectorXY = await page.$eval(selector, (el) => {
-    const { x, y } = el.getBoundingClientRect()
-    return { x, y }
-  })
-
-  await page.touchscreen.tap(selectorXY.x, selectorXY.y)
-
-  await sleep(100)
-
-  assertRequestMade(requestMade)
-}
 
 const assertPrefetchedOnHover = async ({ page, selector, callback }) => {
   let requestMade = false


### PR DESCRIPTION
While testing https://github.com/hotwired/turbo/pull/1147 I found an issue on touch devices that often leads to duplicated requests on mobile. The culprit seems a `mouseenter` event that Safari fires after a `touchend` for compatibility reasons. The `mouseenter` was overriding the current prefetch request launched on `touchstart` causing a second one to be triggered.

According to ChatGPT:

> Some browsers may synthesize mouse events (including `mouseenter`) after touch events to ensure compatibility with web content not designed for touch interfaces. This means that a `mouseenter `event might be fired on a touch device, usually after a `touchend` event, as part of the sequence to simulate mouse interaction. This behavior can vary between browsers and might not always be consistent.

Seems we'll need to re-think how we implement Instaclick touch events. In the meantime, let's disable the touch handlers and leave InstantClick for desktop devices where it's working fine.

This PR also removes the `mouseleave` event listener on specific links to avoid memory leaks, as [was the original intention](//github.com/hotwired/turbo/pull/1147#discussion_r1476162113) of https://github.com/hotwired/turbo/pull/1147.

//cc @seanpdoyle @davidalejandroaguilar 