### PR TITLE
Ensure fetch method is always uppercase

### DIFF
--- a/src/http/fetch_request.js
+++ b/src/http/fetch_request.js
@@ -56,7 +56,7 @@ export class FetchRequest {
     this.fetchOptions = {
       credentials: "same-origin",
       redirect: "follow",
-      method: method,
+      method: method.toUpperCase(),
       headers: { ...this.defaultHeaders },
       body: body,
       signal: this.abortSignal,
@@ -79,7 +79,7 @@ export class FetchRequest {
 
     this.url = url
     this.fetchOptions.body = body
-    this.fetchOptions.method = fetchMethod
+    this.fetchOptions.method = fetchMethod.toUpperCase()
   }
 
   get headers() {

--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -93,7 +93,7 @@ export class LinkPrefetchObserver {
   }
 
   #tryToUsePrefetchedRequest = (event) => {
-    if (event.target.tagName !== "FORM" && event.detail.fetchOptions.method === "get") {
+    if (event.target.tagName !== "FORM" && event.detail.fetchOptions.method === "GET") {
       const cached = prefetchCache.get(event.detail.url.toString())
 
       if (cached) {

--- a/src/tests/functional/form_submission_tests.js
+++ b/src/tests/functional/form_submission_tests.js
@@ -188,7 +188,7 @@ test("supports transforming a POST submission to a GET in a turbo:submit-start l
 test("supports transforming a GET submission to a POST in a turbo:submit-start listener", async ({ page }) => {
   await page.evaluate(() =>
     addEventListener("turbo:submit-start", (({ detail }) => {
-      detail.formSubmission.method = "post"
+      detail.formSubmission.method = "POST"
       detail.formSubmission.body.set("path", "/src/tests/fixtures/one.html")
       detail.formSubmission.body.set("greeting", "Hello, from an event listener")
     }))
@@ -992,7 +992,7 @@ test("link method form submission submits a single request", async ({ page }) =>
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
-  assert.equal(fetchOptions.method, "post", "[data-turbo-method] overrides the GET method")
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 1, "submits a single HTTP request")
 })
 
@@ -1006,7 +1006,7 @@ test("link method form submission inside frame submits a single request", async 
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
-  assert.equal(fetchOptions.method, "post", "[data-turbo-method] overrides the GET method")
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 1, "submits a single HTTP request")
 })
 
@@ -1020,7 +1020,7 @@ test("link method form submission targeting frame submits a single request", asy
   const { fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
 
   assert.ok(await noNextEventNamed(page, "turbo:before-fetch-request"))
-  assert.equal(fetchOptions.method, "post", "[data-turbo-method] overrides the GET method")
+  assert.equal(fetchOptions.method, "POST", "[data-turbo-method] overrides the GET method")
   assert.equal(requestCounter, 2, "submits a single HTTP request then follows a redirect")
 })
 

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -106,7 +106,7 @@ test("turbo:before-fetch-request event.detail", async ({ page }) => {
   await page.click("#same-origin-link")
   const { url, fetchOptions } = await nextEventNamed(page, "turbo:before-fetch-request")
 
-  assert.equal(fetchOptions.method, "get")
+  assert.equal(fetchOptions.method, "GET")
   assert.ok(url.includes("/src/tests/fixtures/one.html"))
 })
 


### PR DESCRIPTION
Fixes #1100

In 7.3 this was always upper cased but in v8 it is not. This breaks forms that use formmethod on buttons. On chrome and firefox puma returns a 400 but once the method is uppercased it works.

https://github.com/hotwired/turbo/blob/4593d06ce58d17af5b17495ad8524eaa9bc2f5d2/src/http/fetch_request.ts#L143