### PR TITLE
Add more prefetch conditions

### DIFF
--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -176,8 +176,17 @@ const linkOptsOut = (link) => {
 
 const nonSafeLink = (link) => {
   const turboMethod = link.getAttribute("data-turbo-method")
-  if (turboMethod !== "get") return true
+  if (turboMethod && turboMethod.toLowerCase() !== "get") return true
+
+  if (isUJS(link)) return true
+  if (link.hasAttribute("data-turbo-confirm")) return true
+  if (link.hasAttribute("data-turbo-stream")) return true
+
   return false
+}
+
+const isUJS = (link) => {
+  return link.hasAttribute("data-remote") || link.hasAttribute("data-behavior") || link.hasAttribute("data-confirm") || link.hasAttribute("data-method")
 }
 
 const eventPrevented = (link) => {

--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -5,7 +5,6 @@ import {
   findClosestRecursively
 } from "../util"
 
-import { StreamMessage } from "../core/streams/stream_message"
 import { FetchMethod, FetchRequest } from "../http/fetch_request"
 import { prefetchCache, cacheTtl } from "../core/drive/prefetch_cache"
 
@@ -116,10 +115,6 @@ export class LinkPrefetchObserver {
 
     if (turboFrameTarget && turboFrameTarget !== "_top") {
       request.headers["Turbo-Frame"] = turboFrameTarget
-    }
-
-    if (link.hasAttribute("data-turbo-stream")) {
-      request.acceptResponseType(StreamMessage.contentType)
     }
   }
 

--- a/src/tests/fixtures/hover_to_prefetch.html
+++ b/src/tests/fixtures/hover_to_prefetch.html
@@ -27,8 +27,6 @@
       >Won't prefetch when hovering me</a>
     <a href="/src/tests/fixtures/prefetched.html" id="anchor_with_turbo_false" data-turbo="false"
       >Won't prefetch when hovering me</a>
-    <a href="/src/tests/fixtures/prefetched.html" id="anchor_with_remote_true" data-remote="true"
-      >Won't prefetch when hovering me</a>
     <a href="/src/tests/fixtures/hover_to_prefetch.html" id="anchor_for_same_location"
       >Won't prefetch when hovering me</a>
     <a href="/src/tests/fixtures/prefetched.html?foo=bar" id="anchor_for_same_location_with_query"

--- a/src/tests/fixtures/hover_to_prefetch.html
+++ b/src/tests/fixtures/hover_to_prefetch.html
@@ -27,6 +27,12 @@
       >Won't prefetch when hovering me</a>
     <a href="/src/tests/fixtures/prefetched.html" id="anchor_with_turbo_false" data-turbo="false"
       >Won't prefetch when hovering me</a>
+    <a href="/src/tests/fixtures/prefetched.html" id="anchor_with_remote_true" data-remote="true"
+      >Won't prefetch when hovering me</a>
+    <a href="/src/tests/fixtures/prefetched.html" id="anchor_with_turbo_stream" data-turbo-stream="true"
+      >Won't prefetch when hovering me</a>
+    <a href="/src/tests/fixtures/prefetched.html" id="anchor_with_turbo_confirm" data-turbo-confirm="Are you sure?"
+      >Won't prefetch when hovering me</a>
     <a href="/src/tests/fixtures/hover_to_prefetch.html" id="anchor_for_same_location"
       >Won't prefetch when hovering me</a>
     <a href="/src/tests/fixtures/prefetched.html?foo=bar" id="anchor_for_same_location_with_query"

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -78,6 +78,21 @@ test("allows to cancel prefetch requests with custom logic", async ({ page }) =>
   await assertNotPrefetchedOnHover({ page, selector: "#anchor_for_prefetch" })
 })
 
+test("it doesn't prefetch UJS links", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+  await assertNotPrefetchedOnHover({ page, selector: "#anchor_with_remote_true" })
+})
+
+test("it doesn't prefetch data-turbo-stream links", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+  await assertNotPrefetchedOnHover({ page, selector: "#anchor_with_turbo_stream" })
+})
+
+test("it doesn't prefetch data-turbo-confirm links", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+  await assertNotPrefetchedOnHover({ page, selector: "#anchor_with_turbo_confirm" })
+})
+
 test("it doesn't prefetch the page when link has the same location", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
   await assertNotPrefetchedOnHover({ page, selector: "#anchor_for_same_location" })

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -65,7 +65,7 @@ test("it doesn't prefetch the page when link has data-turbo=false", async ({ pag
 test("allows to cancel prefetch requests with custom logic", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
 
-  await assertPrefetchedOnHover({ page, selector: "#anchor_with_remote_true" })
+  await assertPrefetchedOnHover({ page, selector: "#anchor_for_prefetch" })
 
   await page.evaluate(() => {
     document.body.addEventListener("turbo:before-prefetch", (event) => {
@@ -75,7 +75,7 @@ test("allows to cancel prefetch requests with custom logic", async ({ page }) =>
     })
   })
 
-  await assertNotPrefetchedOnHover({ page, selector: "#anchor_with_remote_true" })
+  await assertNotPrefetchedOnHover({ page, selector: "#anchor_for_prefetch" })
 })
 
 test("it doesn't prefetch the page when link has the same location", async ({ page }) => {

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -153,17 +153,6 @@ test("it caches the request for 1 millisecond when turbo-prefetch-cache-time is 
   await assertPrefetchedOnHover({ page, selector: "#anchor_for_prefetch" })
 })
 
-test("it adds text/vnd.turbo-stream.html header to the Accept header when link has data-turbo-stream", async ({
-  page
-}) => {
-  await goTo({ page, path: "/hover_to_prefetch.html" })
-  await assertPrefetchedOnHover({ page, selector: "#anchor_with_turbo_stream", callback: (request) => {
-    const headers = request.headers()["accept"].split(",").map((header) => header.trim())
-
-    assert.includeMembers(headers, ["text/vnd.turbo-stream.html", "text/html", "application/xhtml+xml"])
-  }})
-})
-
 test("it prefetches links with inner elements", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
   await assertPrefetchedOnHover({ page, selector: "#anchor_with_inner_elements" })


### PR DESCRIPTION
This PR adds some more conditions where a link is not considered safe to be prefetched.

The risk/reward ratio favors a more conservative approach. If we don't prefetch a link the interaction can be a bit slower, but if we prefetch a link that is not safe, we may trigger a bug.

The conditions are quite specific, in any case, so they shouldn't trigger often.

The new conditions are:

- If the link is a UJS link (i.e. it has a `data-remote` attribute).
- If the link has a data-turbo-confirm attribute.
- If the link has a data-turbo-stream attribute.

The PR also cleans up the code a bit, extracting each of the conditions into helper methods.

Fixes https://github.com/hotwired/turbo/issues/1170
Fixes https://github.com/hotwired/turbo/issues/1174
