### PR TITLE
Fix drive tests stability by adding 'await' to 'page.click'

### DIFF
--- a/src/tests/functional/drive_tests.js
+++ b/src/tests/functional/drive_tests.js
@@ -9,7 +9,7 @@ test.beforeEach(async ({ page }) => {
 })
 
 test("test drive enabled by default; click normal link", async ({ page }) => {
-  page.click("#drive_enabled")
+  await page.click("#drive_enabled")
   await nextBody(page)
   assert.equal(pathname(page.url()), path)
 })
@@ -19,7 +19,7 @@ test("test drive to external link", async ({ page }) => {
     await route.fulfill({ body: "Hello from the outside world" })
   })
 
-  page.click("#drive_enabled_external")
+  await page.click("#drive_enabled_external")
   await nextBody(page)
 
   assert.equal(await page.evaluate(() => window.location.href), "https://example.com/")
@@ -27,7 +27,7 @@ test("test drive to external link", async ({ page }) => {
 })
 
 test("test drive enabled by default; click link inside data-turbo='false'", async ({ page }) => {
-  page.click("#drive_disabled")
+  await page.click("#drive_disabled")
   await nextBody(page)
   assert.equal(pathname(page.url()), path)
   assert.equal(await visitAction(page), "load")


### PR DESCRIPTION
The drive_tests.js were failing due to potential timing issues, as the 'await' keyword was missing in the 'page.click' calls. This caused the test to proceed before the click operations were fully processed, leading to flakiness. 

To address this, I've gone ahead and added the "await" keyword to the relevant "page.click" calls. This ensures that the tests wait for the click operations to complete before moving on to the next steps. By doing so, we're allowing Playwright to synchronize with any asynchronous actions triggered by the clicks, such as network requests or dynamic page changes.

In essence, this small tweak should enhance the stability of our drive tests, making them more reliable and less prone to timing-related issues.

**Before Fix**
<img width="988" alt="Screenshot 2024-02-12 at 12 24 21" src="https://github.com/hotwired/turbo/assets/15254043/178006a2-238c-4344-8769-0a12ce438381">


**After Fix**
<img width="912" alt="Screenshot 2024-02-12 at 12 09 52 1" src="https://github.com/hotwired/turbo/assets/15254043/96c67bac-55db-469e-ab0b-15f9161b418a">
