### PR TITLE
Add Turbo stream morph action

### DIFF
--- a/src/core/streams/actions/morph.js
+++ b/src/core/streams/actions/morph.js
@@ -1,0 +1,68 @@
+import { Idiomorph } from "idiomorph/dist/idiomorph.esm"
+import { dispatch } from "../../../util"
+
+export default function morph(streamElement) {
+  const morphStyle = streamElement.hasAttribute("children-only") ? "innerHTML" : "outerHTML"
+  streamElement.targetElements.forEach((element) => {
+    try {
+      Idiomorph.morph(element, streamElement.templateContent, {
+        morphStyle: morphStyle,
+        ignoreActiveValue: true,
+        callbacks: {
+          beforeNodeAdded,
+          beforeNodeMorphed,
+          beforeAttributeUpdated,
+          beforeNodeRemoved,
+          afterNodeMorphed,
+        },
+      })
+    } catch (e) {
+      console.error(e)
+    }
+  })
+}
+
+function beforeNodeAdded(node) {
+  return !(node.id && node.hasAttribute("data-turbo-permanent") && document.getElementById(node.id))
+}
+
+function beforeNodeRemoved(node) {
+  return beforeNodeAdded(node)
+}
+
+function beforeNodeMorphed(target, newElement) {
+  if (target instanceof HTMLElement && !target.hasAttribute("data-turbo-permanent")) {
+    const event = dispatch("turbo:before-morph-element", {
+      cancelable: true,
+      detail: {
+        target,
+        newElement,
+      },
+    })
+    return !event.defaultPrevented
+  }
+  return false
+}
+
+function beforeAttributeUpdated(attributeName, target, mutationType) {
+  const event = dispatch("turbo:before-morph-attribute", {
+    cancelable: true,
+    target,
+    detail: {
+      attributeName,
+      mutationType,
+    },
+  })
+  return !event.defaultPrevented
+}
+
+function afterNodeMorphed(target, newElement) {
+  if (newElement instanceof HTMLElement) {
+    dispatch("turbo:morph-element", {
+      target,
+      detail: {
+        newElement,
+      },
+    })
+  }
+}

--- a/src/core/streams/actions/morph.js
+++ b/src/core/streams/actions/morph.js
@@ -4,21 +4,16 @@ import { dispatch } from "../../../util"
 export default function morph(streamElement) {
   const morphStyle = streamElement.hasAttribute("children-only") ? "innerHTML" : "outerHTML"
   streamElement.targetElements.forEach((element) => {
-    try {
-      Idiomorph.morph(element, streamElement.templateContent, {
-        morphStyle: morphStyle,
-        ignoreActiveValue: true,
-        callbacks: {
-          beforeNodeAdded,
-          beforeNodeMorphed,
-          beforeAttributeUpdated,
-          beforeNodeRemoved,
-          afterNodeMorphed,
-        },
-      })
-    } catch (e) {
-      console.error(e)
-    }
+    Idiomorph.morph(element, streamElement.templateContent, {
+      morphStyle: morphStyle,
+      callbacks: {
+        beforeNodeAdded,
+        beforeNodeMorphed,
+        beforeAttributeUpdated,
+        beforeNodeRemoved,
+        afterNodeMorphed
+      }
+    })
   })
 }
 
@@ -34,10 +29,10 @@ function beforeNodeMorphed(target, newElement) {
   if (target instanceof HTMLElement && !target.hasAttribute("data-turbo-permanent")) {
     const event = dispatch("turbo:before-morph-element", {
       cancelable: true,
+      target,
       detail: {
-        target,
-        newElement,
-      },
+        newElement
+      }
     })
     return !event.defaultPrevented
   }
@@ -50,8 +45,8 @@ function beforeAttributeUpdated(attributeName, target, mutationType) {
     target,
     detail: {
       attributeName,
-      mutationType,
-    },
+      mutationType
+    }
   })
   return !event.defaultPrevented
 }
@@ -61,8 +56,8 @@ function afterNodeMorphed(target, newElement) {
     dispatch("turbo:morph-element", {
       target,
       detail: {
-        newElement,
-      },
+        newElement
+      }
     })
   }
 }

--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -1,7 +1,6 @@
 import { session } from "../"
-import { morph } from "idiomorph"
+import { Idiomorph } from "idiomorph/dist/idiomorph.esm.js"
 import { dispatch } from "../../util"
-
 
 export const StreamActions = {
   after() {
@@ -39,38 +38,75 @@ export const StreamActions = {
 
   refresh() {
     session.refresh(this.baseURI, this.requestId)
-  }
+  },
 
   morph() {
     this.targetElements.forEach((targetElement) => {
       try {
-        const morphStyle = this.getAttribute("data-turbo-morph-style") || "outerHTML"
-        const ignoreActive = this.getAttribute("data-turbo-morph-ignore-active") || true
-        const ignoreActiveValue  = this.getAttribute("data-turbo-morph-ignore-active-value") || true
-        const head = this.getAttribute("data-turbo-morph-head") || 'merge'
-        morph(targetElement, this.templateContent, {
+        const morphStyle = targetElement.getAttribute("data-turbo-morph-style") || "outerHTML"
+        Idiomorph.morph(targetElement, this.templateContent, {
           morphStyle: morphStyle,
-          ignoreActive: ignoreActive,
-          ignoreActiveValue: ignoreActiveValue,
-          head: head,
+          ignoreActiveValue: true,
           callbacks: {
-            beforeNodeAdded: (node) => {
-              return !(node.id && node.hasAttribute("data-turbo-permanent") && document.getElementById(node.id))
-            },
-            afterNodeMorphed: (oldNode, newNode) => {
-              if (newNode instanceof HTMLElement) {
-                dispatch("turbo:morph-element", {
-                  target: oldNode,
-                  detail: {
-                    newElement: newNode
-                  }
-                })
-              }
-            }
+            beforeNodeAdded,
+            beforeNodeMorphed,
+            beforeAttributeUpdated,
+            beforeNodeRemoved,
+            afterNodeMorphed
+          }
+        })
+
+        dispatch("turbo:morph", {
+          detail: {
+            currentElement: targetElement,
+            newElement: this.templateContent
           }
         })
       } catch (error) {
         console.error(error)
+      }
+    })
+  }
+}
+
+const beforeNodeAdded = (node) => {
+  return !(node.id && node.hasAttribute("data-turbo-permanent") && document.getElementById(node.id))
+}
+
+const beforeNodeMorphed = (target, newElement) => {
+  if (target instanceof HTMLElement && !target.hasAttribute("data-turbo-permanent")) {
+    const event = dispatch("turbo:before-morph-element", {
+      cancelable: true,
+      detail: {
+        target,
+        newElement
+      }
+    })
+    return !event.defaultPrevented
+  }
+  return false
+}
+
+const beforeAttributeUpdated = (attributeName, target, mutationType) => {
+  const event = dispatch("turbo:before-morph-attribute", {
+    cancelable: true,
+    target,
+    detail: {
+      attributeName,
+      mutationType
+    }
+  })
+  return !event.defaultPrevented
+}
+
+const beforeNodeRemoved = beforeNodeMorphed
+
+const afterNodeMorphed = (target, newElement) => {
+  if (newElement instanceof HTMLElement) {
+    dispatch("turbo:morph-element", {
+      target,
+      detail: {
+        newElement
       }
     })
   }

--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -1,4 +1,7 @@
 import { session } from "../"
+import { morph } from "idiomorph"
+import { dispatch } from "../../util"
+
 
 export const StreamActions = {
   after() {
@@ -36,5 +39,39 @@ export const StreamActions = {
 
   refresh() {
     session.refresh(this.baseURI, this.requestId)
+  }
+
+  morph() {
+    this.targetElements.forEach((targetElement) => {
+      try {
+        const morphStyle = this.getAttribute("data-turbo-morph-style") || "outerHTML"
+        const ignoreActive = this.getAttribute("data-turbo-morph-ignore-active") || true
+        const ignoreActiveValue  = this.getAttribute("data-turbo-morph-ignore-active-value") || true
+        const head = this.getAttribute("data-turbo-morph-head") || 'merge'
+        morph(targetElement, this.templateContent, {
+          morphStyle: morphStyle,
+          ignoreActive: ignoreActive,
+          ignoreActiveValue: ignoreActiveValue,
+          head: head,
+          callbacks: {
+            beforeNodeAdded: (node) => {
+              return !(node.id && node.hasAttribute("data-turbo-permanent") && document.getElementById(node.id))
+            },
+            afterNodeMorphed: (oldNode, newNode) => {
+              if (newNode instanceof HTMLElement) {
+                dispatch("turbo:morph-element", {
+                  target: oldNode,
+                  detail: {
+                    newElement: newNode
+                  }
+                })
+              }
+            }
+          }
+        })
+      } catch (error) {
+        console.error(error)
+      }
+    })
   }
 }

--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -1,6 +1,5 @@
 import { session } from "../"
-import { Idiomorph } from "idiomorph/dist/idiomorph.esm.js"
-import { dispatch } from "../../util"
+import morph from "./actions/morph"
 
 export const StreamActions = {
   after() {
@@ -41,73 +40,6 @@ export const StreamActions = {
   },
 
   morph() {
-    this.targetElements.forEach((targetElement) => {
-      try {
-        const morphStyle = targetElement.getAttribute("data-turbo-morph-style") || "outerHTML"
-        Idiomorph.morph(targetElement, this.templateContent, {
-          morphStyle: morphStyle,
-          ignoreActiveValue: true,
-          callbacks: {
-            beforeNodeAdded,
-            beforeNodeMorphed,
-            beforeAttributeUpdated,
-            beforeNodeRemoved,
-            afterNodeMorphed
-          }
-        })
-
-        dispatch("turbo:morph", {
-          detail: {
-            currentElement: targetElement,
-            newElement: this.templateContent
-          }
-        })
-      } catch (error) {
-        console.error(error)
-      }
-    })
-  }
-}
-
-const beforeNodeAdded = (node) => {
-  return !(node.id && node.hasAttribute("data-turbo-permanent") && document.getElementById(node.id))
-}
-
-const beforeNodeMorphed = (target, newElement) => {
-  if (target instanceof HTMLElement && !target.hasAttribute("data-turbo-permanent")) {
-    const event = dispatch("turbo:before-morph-element", {
-      cancelable: true,
-      detail: {
-        target,
-        newElement
-      }
-    })
-    return !event.defaultPrevented
-  }
-  return false
-}
-
-const beforeAttributeUpdated = (attributeName, target, mutationType) => {
-  const event = dispatch("turbo:before-morph-attribute", {
-    cancelable: true,
-    target,
-    detail: {
-      attributeName,
-      mutationType
-    }
-  })
-  return !event.defaultPrevented
-}
-
-const beforeNodeRemoved = beforeNodeMorphed
-
-const afterNodeMorphed = (target, newElement) => {
-  if (newElement instanceof HTMLElement) {
-    dispatch("turbo:morph-element", {
-      target,
-      detail: {
-        newElement
-      }
-    })
-  }
+    morph(this)
+  },
 }

--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -41,5 +41,5 @@ export const StreamActions = {
 
   morph() {
     morph(this)
-  },
+  }
 }

--- a/src/tests/fixtures/morph_stream_action.html
+++ b/src/tests/fixtures/morph_stream_action.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <title>Morph Stream Action</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="turbo-refresh-method" content="replace">
+  </head>
+
+  <body>
+    <div id="message_1">
+      <div>Morph me</div>
+    </div>
+  </body>
+</html>

--- a/src/tests/functional/morph_stream_action_tests.js
+++ b/src/tests/functional/morph_stream_action_tests.js
@@ -1,0 +1,48 @@
+import { test, expect } from "@playwright/test"
+import { nextEventOnTarget, noNextEventOnTarget } from "../helpers/page"
+
+test("dispatches a turbo:before-morph-element & turbo:morph-element for each morph stream action", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/morph_stream_action.html")
+
+  await page.evaluate(() => {
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="morph" target="message_1">
+        <template>
+          <div id="message_1">
+            <h1>Morphed</h1>
+          </div>
+        </template>
+      </turbo-stream>
+    `)
+  })
+
+  await nextEventOnTarget(page, "message_1", "turbo:before-morph-element")
+  await nextEventOnTarget(page, "message_1", "turbo:morph-element")
+  await expect(page.locator("#message_1")).toHaveText("Morphed")
+})
+
+test("preventing a turbo:before-morph-element prevents the morph", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/morph_stream_action.html")
+
+  await page.evaluate(() => {
+    addEventListener("turbo:before-morph-element", (event) => {
+      event.preventDefault()
+    })
+  })
+
+  await page.evaluate(() => {
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="morph" target="message_1">
+        <template>
+          <div id="message_1">
+            <h1>Morphed</h1>
+          </div>
+        </template>
+      </turbo-stream>
+    `)
+  })
+
+  await nextEventOnTarget(page, "message_1", "turbo:before-morph-element")
+  await noNextEventOnTarget(page, "message_1", "turbo:morph-element")
+  await expect(page.locator("#message_1")).toHaveText("Morph me")
+})

--- a/src/tests/unit/stream_element_tests.js
+++ b/src/tests/unit/stream_element_tests.js
@@ -196,3 +196,16 @@ test("test action=refresh discarded when matching request id", async () => {
 
   assert.ok(document.body.hasAttribute("data-modified"))
 })
+
+test("action=morph", async () => {
+  const templateElement = createTemplateElement(`<div id="hello">Hello Turbo Morphed</div>`)
+  const element = createStreamElement("morph", "hello", templateElement)
+  
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.notOk(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo Morphed")
+})

--- a/src/tests/unit/stream_element_tests.js
+++ b/src/tests/unit/stream_element_tests.js
@@ -210,12 +210,12 @@ test("action=morph", async () => {
   assert.equal(subject.find("h1#hello")?.textContent, "Hello Turbo Morphed")
 })
 
-test("action=morph with data-turbo-morph-style='innerHTML'", async () => {
+test("action=morph children-only", async () => {
   const templateElement = createTemplateElement(`<h1 id="hello-child-element">Hello Turbo Morphed</h1>`)
   const element = createStreamElement("morph", "hello", templateElement)
   const target = subject.find("div#hello")
   assert.equal(target?.textContent, "Hello Turbo")
-  target.setAttribute("data-turbo-morph-style", "innerHTML")
+  element.setAttribute("children-only", true)
 
   subject.append(element)
 
@@ -225,4 +225,3 @@ test("action=morph with data-turbo-morph-style='innerHTML'", async () => {
   assert.ok(subject.find("div#hello > h1#hello-child-element"))
   assert.equal(subject.find("div#hello > h1#hello-child-element").textContent, "Hello Turbo Morphed")
 })
-

--- a/src/tests/unit/stream_element_tests.js
+++ b/src/tests/unit/stream_element_tests.js
@@ -198,14 +198,31 @@ test("test action=refresh discarded when matching request id", async () => {
 })
 
 test("action=morph", async () => {
-  const templateElement = createTemplateElement(`<div id="hello">Hello Turbo Morphed</div>`)
+  const templateElement = createTemplateElement(`<h1 id="hello">Hello Turbo Morphed</h1>`)
   const element = createStreamElement("morph", "hello", templateElement)
-  
-  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  assert.equal(subject.find("div#hello")?.textContent, "Hello Turbo")
 
   subject.append(element)
   await nextAnimationFrame()
 
-  assert.notOk(subject.find("#hello")?.textContent, "Hello Turbo")
-  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo Morphed")
+  assert.notOk(subject.find("div#hello"))
+  assert.equal(subject.find("h1#hello")?.textContent, "Hello Turbo Morphed")
 })
+
+test("action=morph with data-turbo-morph-style='innerHTML'", async () => {
+  const templateElement = createTemplateElement(`<h1 id="hello-child-element">Hello Turbo Morphed</h1>`)
+  const element = createStreamElement("morph", "hello", templateElement)
+  const target = subject.find("div#hello")
+  assert.equal(target?.textContent, "Hello Turbo")
+  target.setAttribute("data-turbo-morph-style", "innerHTML")
+
+  subject.append(element)
+
+  await nextAnimationFrame()
+
+  assert.ok(subject.find("div#hello"))
+  assert.ok(subject.find("div#hello > h1#hello-child-element"))
+  assert.equal(subject.find("div#hello > h1#hello-child-element").textContent, "Hello Turbo Morphed")
+})
+


### PR DESCRIPTION
This PR introduces a morph Turbo Stream action. The motivation for this addition stems from the recent discussions and suggestions in issue [#1163](https://github.com/hotwired/turbo/issues/1163). There is a clear interest in providing users with more flexible options for DOM manipulation, especially for those not ready or looking to fully transition to using Turbo's full page morphing capabilities.

turbo-rails PR https://github.com/hotwired/turbo-rails/pull/583
documentation PR https://github.com/hotwired/turbo-site/pull/169