### PR TITLE
Cache snapshot before doing page refresh

### DIFF
--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -114,10 +114,15 @@ export class Visit {
     return this.isSamePage
   }
 
-  start() {
+  async start() {
     if (this.state == VisitState.initialized) {
       this.recordTimingMetric(TimingMetric.visitStart)
       this.state = VisitState.started
+
+      if (this.isPageRefresh) {
+        await this.cacheSnapshot()
+      }
+
       this.adapter.visitStarted(this)
       this.delegate.visitStarted(this)
     }
@@ -410,9 +415,14 @@ export class Visit {
     }
   }
 
-  cacheSnapshot() {
+  async cacheSnapshot() {
     if (!this.snapshotCached) {
-      this.view.cacheSnapshot(this.snapshot).then((snapshot) => snapshot && this.visitCachedSnapshot(snapshot))
+      const snapshot = await this.view.cacheSnapshot(this.snapshot)
+
+      if (snapshot) {
+        this.visitCachedSnapshot(snapshot)
+      }
+
       this.snapshotCached = true
     }
   }

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -110,7 +110,6 @@ export class Session {
   refresh(url, requestId) {
     const isRecentRequest = requestId && this.recentRequests.has(requestId)
     if (!isRecentRequest) {
-      this.cache.exemptPageFromPreview()
       this.visit(url, { action: "replace" })
     }
   }

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -308,6 +308,13 @@ test("doesn't render previews when morphing", async ({ page }) => {
   assert.equal(await title.textContent(), "Page to be refreshed")
 })
 
+test("it snapshots page before starting a page refresh", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:before-cache")
+})
+
 async function assertPageScroll(page, top, left) {
   const [scrollTop, scrollLeft] = await page.evaluate(() => {
     return [


### PR DESCRIPTION
This PR aims to fix issues related to white flickering and loading indicators on Turbo Native:
* https://github.com/hotwired/turbo-ios/issues/175
* https://github.com/hotwired/turbo-ios/issues/136

Previously, any `refresh` visit would exempt itself from the snapshot cache before issuing a `visit(..., action: "replace")`. In a browser, this keeps the existing body in-place while refreshing the page and then performing morphing. The visit would have `hasSnapshot: false`.

In Turbo Native, when a visit is performed without a snapshot, a spinner will be shown and in some cases the WebView will be blanked as well while the page is fetched. This is especially painful when refresh stream actions are broadcasted, as the WebView will at random become unresponsible and/or flickr.

This PR changes so that a snapshot of the page is cached _before_ issuing a refreshing visit. The cached snapshot will be of the recent state of the page and the native adapters will not blank the page while fetching the refreshed page.

I think it makes sense that page refreshes are storing the latest version of the page as a snapshot before refreshing; it is the most recent version of the content.

