### PR TITLE
Omit `ignoreActiveValue: true` Morph option

### DIFF
--- a/src/core/drive/morph_renderer.js
+++ b/src/core/drive/morph_renderer.js
@@ -29,7 +29,6 @@ export class MorphRenderer extends PageRenderer {
     this.isMorphingTurboFrame = this.#isFrameReloadedWithMorph(currentElement)
 
     Idiomorph.morph(currentElement, newElement, {
-      ignoreActiveValue: true,
       morphStyle: morphStyle,
       callbacks: {
         beforeNodeAdded: this.#shouldAddElement,

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -14,6 +14,14 @@
 
       const application = Application.start()
 
+      addEventListener("focusin", ({ target }) => {
+        if (target instanceof HTMLInputElement && !target.hasAttribute("data-turbo-permanent")) {
+          target.toggleAttribute("data-turbo-permanent", true)
+
+          target.addEventListener("focusout", () => target.toggleAttribute("data-turbo-permanent", false), { once: true })
+        }
+      })
+
       addEventListener("turbo:morph-element", ({ target }) => {
         for (const { element, context } of application.controllers) {
           if (element === target) {


### PR DESCRIPTION
Closes [#1194][]
Rolls back [#1141][]

Don't pass the `ignoreActiveValue: true` option when Morphing. To restore that behavior, applications can set `[data-turbo-permanent]` when form control receives focus (through a `focusin` event listener), then remove it if necessary when the form control loses focus (through a `focusout` event listener).

[#1141]: https://github.com/hotwired/turbo/pull/1141/
[#1194]: https://github.com/hotwired/turbo/issues/1194