### PR TITLE
Ensure that page refreshes do not trigger a snapshot cache

### DIFF
--- a/src/core/session.js
+++ b/src/core/session.js
@@ -110,8 +110,7 @@ export class Session {
   refresh(url, requestId) {
     const isRecentRequest = requestId && this.recentRequests.has(requestId)
     if (!isRecentRequest) {
-      this.cache.exemptPageFromPreview()
-      this.visit(url, { action: "replace" })
+      this.visit(url, { action: "replace", shouldCacheSnapshot: false })
     }
   }
 

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -33,6 +33,7 @@ test("async page refresh with turbo-stream", async ({ page }) => {
 
   await expect(page.locator("#title")).not.toHaveText("Updated")
   await expect(page.locator("#title")).toHaveText("Page to be refreshed")
+  expect(await noNextEventNamed(page, "turbo:before-cache")).toBeTruthy()
 })
 
 test("dispatches a turbo:before-morph-element and turbo:morph-element event for each morphed element", async ({ page }) => {


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/hotwired/turbo/pull/1146

`exemptPageFromPreview()` adds a `<meta>` tag to the `<head>` setting `turbo-cache-control` to `no-preview`. However, since the MorphRenderer now inherits from the PageRenderer, it can update meta tags in the head and remove the `turbo-cache-control` tag. This means that the snapshot cache will be used for the next visit, which is not what we want.

Specifying `shouldCacheSnapshot: false` in the `visit` options ensures that the snapshot cache is not used for the refresh visit.