### PR TITLE
Fix Turbo Frame prefetching bug

### DIFF
--- a/src/tests/fixtures/hover_to_prefetch.html
+++ b/src/tests/fixtures/hover_to_prefetch.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html id="html">
   <head>
     <meta charset="utf-8" />
     <title>Hover to Prefetch</title>
@@ -50,11 +50,11 @@
     <iframe src="/src/tests/fixtures/hover_to_prefetch_iframe.html" name="prefetch_iframe"> </iframe>
 
     <turbo-frame id="frame_for_prefetch">
-      <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_in_frame">Hover to prefetch me</a>
+      <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_in_frame">Hover to prefetch /prefetched.html frame</a>
     </turbo-frame>
 
     <turbo-frame id="frame_for_prefetch_top" target="_top">
-      <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_in_frame_target_top">Hover to prefetch me</a>
+      <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_in_frame_target_top">Hover to prefetch /prefetched.html page</a>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -197,6 +197,35 @@ test("it prefetches links inside a turbo frame", async ({ page }) => {
   }})
 })
 
+test("prefetching a page-wide request does not affect frame requests", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+
+  const pageLink = page.locator("#anchor_for_prefetch_in_frame_target_top")
+  const frameLink = page.locator("#anchor_for_prefetch_in_frame")
+
+  await pageLink.hover()
+  await sleep(25)
+  await frameLink.click()
+
+  const { fetchOptions } = await nextEventOnTarget(page, "frame_for_prefetch", "turbo:before-fetch-request")
+
+  expect(fetchOptions.headers["Turbo-Frame"]).toEqual("frame_for_prefetch")
+})
+
+test("prefetching a frame request does not affect page-wide requests", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+
+  const pageLink = page.locator("#anchor_for_prefetch_in_frame_target_top")
+  const frameLink = page.locator("#anchor_for_prefetch_in_frame")
+
+  await frameLink.hover()
+  await sleep(25)
+  await pageLink.click()
+
+  const { fetchOptions } = await nextEventOnTarget(page, "html", "turbo:before-fetch-request")
+
+  expect(fetchOptions.headers["Turbo-Frame"]).toEqual(undefined)
+})
 
 test("doesn't include a turbo-frame header when the link is inside a turbo frame with a target=_top", async ({ page}) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })


### PR DESCRIPTION
Closes [#1191][]

Ensure Prefetching does not share cache entries for requests with differing `Turbo-Frame:` HTTP headers.

[#1191]: https://github.com/hotwired/turbo/issues/1191