### PR TITLE
Add `Navigator#locationWithActionIsPageRefresh` for native adapter use

### DIFF
--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -139,6 +139,10 @@ export class Navigator {
     )
   }
 
+  locationWithActionIsPageRefresh(location, action) {
+    return this.view.lastRenderedLocation.pathname === location.pathname && action === "replace"
+  }
+
   visitScrolledToSamePageLocation(oldURL, newURL) {
     this.delegate.visitScrolledToSamePageLocation(oldURL, newURL)
   }

--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -56,7 +56,7 @@ export class PageView extends View {
   }
 
   isPageRefresh(visit) {
-    return !visit || (this.lastRenderedLocation.pathname === visit.location.pathname && visit.action === "replace")
+    return !visit || visit.isPageRefresh
   }
 
   shouldPreserveScrollPosition(visit) {

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -84,7 +84,7 @@ export class Visit {
     this.snapshotHTML = snapshotHTML
     this.response = response
     this.isSamePage = this.delegate.locationWithActionIsSamePage(this.location, this.action)
-    this.isPageRefresh = this.view.isPageRefresh(this)
+    this.isPageRefresh = this.delegate.locationWithActionIsPageRefresh(this.location, this.action)
     this.visitCachedSnapshot = visitCachedSnapshot
     this.willRender = willRender
     this.updateHistory = updateHistory

--- a/src/tests/unit/export_tests.js
+++ b/src/tests/unit/export_tests.js
@@ -24,3 +24,8 @@ test("Turbo interface", () => {
 test("StreamActions interface", () => {
   assert.equal(typeof StreamActions, "object")
 })
+
+test("Turbo.navigator interface", () => {
+  assert.equal(typeof Turbo.navigator.locationWithActionIsPageRefresh, "function")
+  assert.equal(typeof Turbo.navigator.locationWithActionIsSamePage, "function")
+})


### PR DESCRIPTION
Related to https://github.com/hotwired/turbo-ios/pull/178 in Turbo iOS.

In order to support refreshes in Turbo Native, the native adapters need to determine if a proposed visit is a refresh visit. This PR adds a new method `locationWithActionIsPageRefresh` to `Navigator`, which the native adapters can call instead of implementing the logic on their own to determine if a proposed visit is a refresh action or not.

This way, the native adapters do not need to care about _how_ to determine if a visit is refresh; this is kept inside Turbo and can be updated without having to publish new native modules.

This PR also adds tests for the methods on `Navigator` which the native adapters use today, so that we make sure that whatever refactoring of Turbo still keep the required interface intact for supporting the native adapters.

See discussion in: https://github.com/hotwired/turbo-ios/pull/178#discussion_r1500266398

There will be a corresponding PR in Turbo iOS using this method.