### PR TITLE
Add `turbo:before-prefetch` test coverage

### DIFF
--- a/src/tests/fixtures/hover_to_prefetch.html
+++ b/src/tests/fixtures/hover_to_prefetch.html
@@ -4,6 +4,7 @@
     <meta charset="utf-8" />
     <title>Hover to Prefetch</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
     <meta name="turbo-prefetch" content="true" />
   </head>
 

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -73,6 +73,7 @@
   "turbo:before-visit",
   "turbo:load",
   "turbo:render",
+  "turbo:before-prefetch",
   "turbo:before-fetch-request",
   "turbo:submit-start",
   "turbo:submit-end",


### PR DESCRIPTION
Expand the link prefetching functional test coverage to exercise prefetching in relation to the events dispatched during the lifecycle. For example, include coverage for:

* `turbo:before-prefetch` being dispatched
* `turbo:before-prefetch` being canceled
* `turbo:before-fetch-request` dispatched only once during a successful prefetch