### PR TITLE
Bugfix/enable turbo stream morph on text

### DIFF
--- a/src/core/streams/actions/morph.js
+++ b/src/core/streams/actions/morph.js
@@ -26,19 +26,20 @@ function beforeNodeRemoved(node) {
 }
 
 function beforeNodeMorphed(target, newElement) {
-  if (target instanceof HTMLElement) {
-    if (!target.hasAttribute("data-turbo-permanent")) {
-      const event = dispatch("turbo:before-morph-element", {
-        cancelable: true,
-        target,
-        detail: {
-          newElement
-        }
-      })
-      return !event.defaultPrevented
-    }
-    return false
+  if (!(target instanceof HTMLElement)) {
+    return
   }
+  if (!target.hasAttribute("data-turbo-permanent")) {
+    const event = dispatch("turbo:before-morph-element", {
+      cancelable: true,
+      target,
+      detail: {
+        newElement
+      }
+    })
+    return !event.defaultPrevented
+  }
+  return false
 }
 
 function beforeAttributeUpdated(attributeName, target, mutationType) {

--- a/src/core/streams/actions/morph.js
+++ b/src/core/streams/actions/morph.js
@@ -26,20 +26,19 @@ function beforeNodeRemoved(node) {
 }
 
 function beforeNodeMorphed(target, newElement) {
-  if (!(target instanceof HTMLElement)) {
-    return
+  if (target instanceof HTMLElement) {
+    if (!target.hasAttribute("data-turbo-permanent")) {
+      const event = dispatch("turbo:before-morph-element", {
+        cancelable: true,
+        target,
+        detail: {
+          newElement
+        }
+      })
+      return !event.defaultPrevented
+    }
+    return false
   }
-  if (!target.hasAttribute("data-turbo-permanent")) {
-    const event = dispatch("turbo:before-morph-element", {
-      cancelable: true,
-      target,
-      detail: {
-        newElement
-      }
-    })
-    return !event.defaultPrevented
-  }
-  return false
 }
 
 function beforeAttributeUpdated(attributeName, target, mutationType) {

--- a/src/core/streams/actions/morph.js
+++ b/src/core/streams/actions/morph.js
@@ -26,17 +26,19 @@ function beforeNodeRemoved(node) {
 }
 
 function beforeNodeMorphed(target, newElement) {
-  if (target instanceof HTMLElement && !target.hasAttribute("data-turbo-permanent")) {
-    const event = dispatch("turbo:before-morph-element", {
-      cancelable: true,
-      target,
-      detail: {
-        newElement
-      }
-    })
-    return !event.defaultPrevented
+  if (target instanceof HTMLElement) {
+    if (!target.hasAttribute("data-turbo-permanent")) {
+      const event = dispatch("turbo:before-morph-element", {
+        cancelable: true,
+        target,
+        detail: {
+          newElement
+        }
+      })
+      return !event.defaultPrevented
+    }
+    return false
   }
-  return false
 }
 
 function beforeAttributeUpdated(attributeName, target, mutationType) {

--- a/src/tests/unit/stream_element_tests.js
+++ b/src/tests/unit/stream_element_tests.js
@@ -210,6 +210,19 @@ test("action=morph", async () => {
   assert.equal(subject.find("h1#hello")?.textContent, "Hello Turbo Morphed")
 })
 
+test("action=morph with text content change", async () => {
+  const templateElement = createTemplateElement(`<div id="hello">Hello Turbo Morphed</div>`)
+  const element = createStreamElement("morph", "hello", templateElement)
+
+  assert.equal(subject.find("div#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.ok(subject.find("div#hello"))
+  assert.equal(subject.find("div#hello")?.textContent, "Hello Turbo Morphed")
+})
+
 test("action=morph children-only", async () => {
   const templateElement = createTemplateElement(`<h1 id="hello-child-element">Hello Turbo Morphed</h1>`)
   const element = createStreamElement("morph", "hello", templateElement)


### PR DESCRIPTION
I had the chance to test out @omarluq 's fantastic addition of the Turbo Stream morph action in https://github.com/hotwired/turbo/pull/1185. The feature works as expected, except fails to morph text-only changes. This appears to be due to a misreading of the Turbo-Rails implementation of the `beforeNodeMorph`/`#shouldMorphElement` callback: https://github.com/hotwired/turbo-rails/blob/102a491754d46f7dd924201fcfaf879a0f04b11c/app/assets/javascripts/turbo.js#L3830-L3844.

This PR updates the `beforeNodeMorph` callback to match the Turbo-Rails implementation -- with a tweak to hopefully increase readability -- and enable text-only morphing.