### PR TITLE
[fix] loading after completed lazy loading and restored visit

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -50,7 +50,11 @@ export class FrameController {
     if (!this.#connected) {
       this.#connected = true
       if (this.loadingStyle == FrameLoadingStyle.lazy) {
-        this.appearanceObserver.start()
+        if (this.complete) {
+          this.#hasBeenLoaded = true
+        } else {
+          this.appearanceObserver.start()
+        }
       } else {
         this.#loadSourceURL()
       }

--- a/src/tests/fixtures/frames/hello.html
+++ b/src/tests/fixtures/frames/hello.html
@@ -20,6 +20,9 @@
       <form id="permanent-form-in-frame" data-turbo-permanent>
         <input id="permanent-descendant-input-in-frame" type="text" name="query" placeholder="Permanent descendant input in frame">
       </form>
+
+      <a id="two" href="/src/tests/fixtures/two.html" data-turbo-frame="_top">Two</a>
+      <a id="hello2" href="/src/tests/fixtures/frames/hello_2.html">To hello 2</a>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/frames/hello_2.html
+++ b/src/tests/fixtures/frames/hello_2.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frames: Hello 2</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Hello 2</h1>
+    <turbo-frame id="hello">
+      <h2>Hello 2 from a frame</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/functional/loading_tests.js
+++ b/src/tests/functional/loading_tests.js
@@ -38,6 +38,24 @@ test("lazy loading within a details element", async ({ page }) => {
   assert.ok(await hasSelector(page, "#loading-lazy turbo-frame[complete]"), "has [complete] attribute")
 })
 
+test("loading after completed lazy loading and restored visit", async ({ page }) => {
+  const frameContents = "#loading-lazy turbo-frame h2"
+  await page.click("#loading-lazy summary")
+  await nextBeat()
+
+  const contents = await page.locator(frameContents)
+  assert.equal(await contents.textContent(), "Hello from a frame")
+  await page.click("#two")
+  await nextBeat()
+
+  await page.goBack()
+  await page.click("#hello2")
+  await nextBeat()
+
+  const contents2 = await page.locator(frameContents)
+  assert.equal(await contents2.textContent(), "Hello 2 from a frame")
+})
+
 test("changing loading attribute from lazy to eager loads frame", async ({ page }) => {
   const frameContents = "#loading-lazy turbo-frame h2"
   await nextBeat()


### PR DESCRIPTION
## Description

There is a problem with loading after lazy loading is completed and then visit restored. The frames that have completed lazy loading do not execute their loading processes. This problem occurs during visit restoration because the status information indicating that lazy loading has already been completed is not being fully restored. To reproduce this successfully, we need to set `#hasBeenLoaded` to true when connecting to the frame.

https://github.com/hotwired/turbo/compare/main...yasu551:turbo:fix/frame-loading-lazy-restoration-visit#diff-c202bf76718319f756622258d06264c47dd74d0611ab50b8a28d7b6de0fe3ff5R52-R57

### Before this PR

###  After this PR

## Relations
Closes https://github.com/hotwired/turbo/issues/886