### PR TITLE
Fix stale refresh URL caused by debouncing

### DIFF
--- a/src/core/session.js
+++ b/src/core/session.js
@@ -109,7 +109,8 @@ export class Session {
 
   refresh(url, requestId) {
     const isRecentRequest = requestId && this.recentRequests.has(requestId)
-    if (!isRecentRequest && !this.navigator.currentVisit) {
+    const isCurrentUrl = url === document.baseURI
+    if (!isRecentRequest && !this.navigator.currentVisit && isCurrentUrl) {
       this.visit(url, { action: "replace", shouldCacheSnapshot: false })
     }
   }

--- a/src/tests/fixtures/page_refresh_stream_action.html
+++ b/src/tests/fixtures/page_refresh_stream_action.html
@@ -14,6 +14,7 @@
 
   <div id="content">
     <span>Hello</span>
+    <a id="regular-link" href="/src/tests/fixtures/one.html">Regular link</a>
   </div>
 </body>
 </html>

--- a/src/tests/functional/page_refresh_stream_action_tests.js
+++ b/src/tests/functional/page_refresh_stream_action_tests.js
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test"
 import { assert } from "chai"
-import { nextPageRefresh, readEventLogs } from "../helpers/page"
+import { nextPageRefresh, readEventLogs, pathname } from "../helpers/page"
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh_stream_action.html")
@@ -54,6 +54,20 @@ test("debounce stream page refreshes", async ({ page }) => {
   assert.equal(requestLogs.length, 2)
 })
 
+test("debounced refresh of stale URL does not hijack new location navigated to", async ({ page }) => {
+  await setLongerPageRefreshDebouncePeriod(page)
+  const urlBeforeVisit = page.url()
+
+  await page.click("#refresh button")
+  await page.click("#regular-link")
+  await nextPageRefresh(page)
+
+  const urlAfterVisit = page.url()
+  assert.notEqual(urlBeforeVisit, urlAfterVisit)
+  const expectedPath = "/src/tests/fixtures/one.html"
+  assert.equal(pathname(urlAfterVisit), expectedPath)
+})
+
 async function textContent(page) {
   const messages = await page.locator("#content")
   return await messages.textContent()
@@ -64,4 +78,8 @@ async function fetchRequestId(page) {
     const response = await window.Turbo.fetch("/__turbo/request_id_header")
     return response.text()
   })
+}
+
+async function setLongerPageRefreshDebouncePeriod(page, period = 500) {
+  return page.evaluate((period) => window.Turbo.session.pageRefreshDebouncePeriod = period, period)
 }


### PR DESCRIPTION
There is a race condition with Turbo 8 refreshes and regular navigation through the application, caused by passing the URL to be refreshed into the debounced function.

If user visits another page, **in between** the page refresh arriving and the debounced refresh execution, the stale URL in the debounced refresh will navigate back to the page the user just came from.

This behavior is most apparent when there is a steady stream of turbo refreshes coming in and user is navigating through pages that receive these refreshes, but could happen at any (low) volume of page refreshes, if the timing is right.

Here's a video of the issue:

https://github.com/hotwired/turbo-rails/assets/32981/48f438a6-244f-4070-9439-44044c043d92

* At the end you can observe I click on "Show this item" of the item named "Two", yet I remain on the index page. You can notice the desired page blinked in and out for a few microseconds too.
* The cause is visible in the console: The second to last turbo visit to `/items/2` is my user initiated action.
* The following (last) entry in the console is the turbo refresh of the current `/items` page that just executed after the default debounce delay (you can see the Updated at times changed from from :05 to :06). This refresh essentially hijacked my click and resulted in me being returned to the index page.

This is on Safari 17.4.1. I also replicated the same issue in latest Chrome.

I created a [simple Rails 7.1 app to demonstrate the issue](https://github.com/klevo/rails-turbo-refresh-click-hijack) that is used in the above video with full instructions.