### PR TITLE
Read the csp meta tag nonce attribute and fall back to content

### DIFF
--- a/src/core/drive/progress_bar.js
+++ b/src/core/drive/progress_bar.js
@@ -1,4 +1,4 @@
-import { unindent, getMetaContent } from "../../util"
+import { unindent, getCspNonce } from "../../util"
 
 export const ProgressBarID = "turbo-progress-bar"
 
@@ -108,8 +108,9 @@ export class ProgressBar {
     const element = document.createElement("style")
     element.type = "text/css"
     element.textContent = ProgressBar.defaultCSS
-    if (this.cspNonce) {
-      element.nonce = this.cspNonce
+    const cspNonce = getCspNonce()
+    if (cspNonce) {
+      element.nonce = cspNonce
     }
     return element
   }
@@ -118,9 +119,5 @@ export class ProgressBar {
     const element = document.createElement("div")
     element.className = "turbo-progress-bar"
     return element
-  }
-
-  get cspNonce() {
-    return getMetaContent("csp-nonce")
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -5,7 +5,7 @@ export function activateScriptElement(element) {
     return element
   } else {
     const createdScriptElement = document.createElement("script")
-    const cspNonce = getMetaContent("csp-nonce")
+    const cspNonce = getCspNonce()
     if (cspNonce) {
       createdScriptElement.nonce = cspNonce
     }
@@ -164,13 +164,22 @@ export function getVisitAction(...elements) {
   return isAction(action) ? action : null
 }
 
-export function getMetaElement(name) {
+function getMetaElement(name) {
   return document.querySelector(`meta[name="${name}"]`)
 }
 
 export function getMetaContent(name) {
   const element = getMetaElement(name)
   return element && element.content
+}
+
+export function getCspNonce() {
+  const element = getMetaElement("csp-nonce")
+
+  if (element) {
+    const { nonce, content } = element
+    return nonce == "" ? content : nonce
+  }
 }
 
 export function setMetaContent(name, content) {


### PR DESCRIPTION
This PR allows Turbo to support https://github.com/rails/rails/pull/51729. This changes Turbo to read the meta tag's `nonce` attribute first and fall back to the `content` attribute.

As described in https://github.com/rails/rails/issues/51580#issue-2246912613 this makes it harder to extract the nonce value.