### PR TITLE
Fix test to verify no network request on prefetched link click

### DIFF
--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -246,11 +246,8 @@ test("it resets the cache when a link is hovered", async ({ page }) => {
 
 test("it does not make a network request when clicking on a link that has been prefetched", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
-  await hoverSelector({ page, selector: "#anchor_for_prefetch" })
-
-  await sleep(100)
-
-  await assertNotPrefetchedOnHover({ page, selector: "#anchor_for_prefetch" })
+  await assertPrefetchedOnHover({ page, selector: "#anchor_for_prefetch" })
+  await assertRequestNotMadeOnClick({ page, selector: "#anchor_for_prefetch" })
 })
 
 test("it follows the link using the cached response when clicking on a link that has been prefetched", async ({
@@ -294,6 +291,13 @@ const assertNotPrefetchedOnHover = async ({ page, selector, callback }) => {
   await sleep(100)
 
   assert.equal(requestMade, false, "Network request was made when it should not have been.")
+}
+
+const assertRequestNotMadeOnClick = async ({ page, selector }) => {
+  let requestMade = false
+  page.on("request", async (request) => (requestMade = true))
+  await clickSelector({ page, selector })
+  assertRequestNotMade(requestMade)
 }
 
 const assertRequestMade = (requestMade) => {

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -195,35 +195,28 @@ test("doesn't include a turbo-frame header when the link is inside a turbo frame
 test("it prefetches links with a delay", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
 
-  let requestMade = false
-  page.on("request", async (request) => (requestMade = true))
+  await assertRequestNotMade(page, async () => {
+    await page.hover("#anchor_for_prefetch")
+    await sleep(75)
+  })
 
-  await page.hover("#anchor_for_prefetch")
-  await sleep(75)
-
-  assertRequestNotMade(requestMade)
-
-  await sleep(100)
-
-  assertRequestMade(requestMade)
+  await assertRequestMade(page, async () => {
+    await sleep(100)
+  })
 })
 
 test("it cancels the prefetch request if the link is no longer hovered", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
 
-  let requestMade = false
-  page.on("request", async (request) => (requestMade = true))
+  await assertRequestNotMade(page, async () => {
+    await page.hover("#anchor_for_prefetch")
+    await sleep(75)
+  })
 
-  await page.hover("#anchor_for_prefetch")
-  await sleep(75)
-
-  assertRequestNotMade(requestMade)
-
-  await page.mouse.move(0, 0)
-
-  await sleep(100)
-
-  assertRequestNotMade(requestMade)
+  await assertRequestNotMade(page, async () => {
+    await page.mouse.move(0, 0)
+    await sleep(100)
+  })
 })
 
 test("it resets the cache when a link is hovered", async ({ page }) => {
@@ -261,51 +254,51 @@ test("it follows the link using the cached response when clicking on a link that
 })
 
 const assertPrefetchedOnHover = async ({ page, selector, callback }) => {
-  let requestMade = false
+  await assertRequestMade(page, async () => {
+    await hoverSelector({ page, selector })
 
-  page.on("request", (request) => {
-    requestMade = request
+    await sleep(100)
+  }, callback)
+}
+
+const assertNotPrefetchedOnHover = async ({ page, selector, callback }) => {
+  await assertRequestNotMade(page, async () => {
+    await hoverSelector({ page, selector })
+
+    await sleep(100)
+  }, callback)
+}
+
+const assertRequestNotMadeOnClick = async ({ page, selector }) => {
+  await assertRequestNotMade(page, async () => {
+    await clickSelector({ page, selector })
   })
+}
 
-  await hoverSelector({ page, selector })
+const assertRequestMade = async (page, action, callback) => {
+  let requestMade = false
+  page.on("request", async (request) => requestMade = request)
 
-  await sleep(100)
+  await action()
+
+  assert.equal(!!requestMade, true, "Network request wasn't made when it should have been.")
 
   if (callback) {
     await callback(requestMade)
   }
-
-  assertRequestMade(!!requestMade)
 }
 
-const assertNotPrefetchedOnHover = async ({ page, selector, callback }) => {
+const assertRequestNotMade = async (page, action, callback) => {
   let requestMade = false
+  page.on("request", async (request) => requestMade = request)
 
-  page.on("request", (request) => {
-    callback && callback(request)
-    requestMade = true
-  })
+  await action()
 
-  await hoverSelector({ page, selector })
+  assert.equal(!!requestMade, false, "Network request was made when it should not have been.")
 
-  await sleep(100)
-
-  assert.equal(requestMade, false, "Network request was made when it should not have been.")
-}
-
-const assertRequestNotMadeOnClick = async ({ page, selector }) => {
-  let requestMade = false
-  page.on("request", async (request) => (requestMade = true))
-  await clickSelector({ page, selector })
-  assertRequestNotMade(requestMade)
-}
-
-const assertRequestMade = (requestMade) => {
-  assert.equal(requestMade, true, "Network request wasn't made when it should have been.")
-}
-
-const assertRequestNotMade = (requestMade) => {
-  assert.equal(requestMade, false, "Network request was made when it should not have been.")
+  if (callback) {
+    await callback(requestMade)
+  }
 }
 
 const goTo = async ({ page, path }) => {


### PR DESCRIPTION
# Description

The test aimed to verify that no network request occurs when clicking a link that had already been prefetched by hovering. However, instead of performing a click, the test erroneously attempted to hover over the link again, which had already been hovered over. Therefore, it failed to test the intended behavior.

This PR makes sure that the test is correctly set up to prevent any regression in this functionality.



