### PR TITLE
Add a test that stream actions rendered into the HTML are executed

### DIFF
--- a/src/tests/functional/stream_tests.js
+++ b/src/tests/functional/stream_tests.js
@@ -226,6 +226,25 @@ test("preventing a turbo:before-morph-element prevents the morph", async ({ page
   await expect(page.locator("#message_1")).toHaveText("Morph me")
 })
 
+test("rendering a stream message into the HTML executes it", async ({ page }) => {
+  await page.evaluate(() => {
+    document.body.insertAdjacentHTML(
+      "afterbegin",
+      `
+        <turbo-stream action="append" target="messages">
+          <template>
+            <div class="message">Hello world!</div>
+          </template>
+        </turbo-stream>
+      `
+    )
+  })
+  await nextBeat()
+
+  const messages = await page.locator("#messages .message")
+  assert.deepEqual(await messages.allTextContents(), ["First", "Hello world!"])
+})
+
 async function getReadyState(page, id) {
   return page.evaluate((id) => {
     const element = document.getElementById(id)


### PR DESCRIPTION
Resolves: https://github.com/hotwired/turbo/issues/1258
It's paired with: https://github.com/hotwired/turbo-site/pull/192

As a consequence of the fundamental way in which Stream actions are implemented, they can also be executed by rendering them within any HTML that's included on the dom.

Since this is already being used as the feature in the community, adding this test will ensure this keeps working.