### PR TITLE
Fix turbo-confirm for links without a turbo-method

### DIFF
--- a/src/observers/form_link_click_observer.js
+++ b/src/observers/form_link_click_observer.js
@@ -30,7 +30,7 @@ export class FormLinkClickObserver {
   willFollowLinkToLocation(link, location, originalEvent) {
     return (
       this.delegate.willSubmitFormLinkToLocation(link, location, originalEvent) &&
-      (link.hasAttribute("data-turbo-method") || link.hasAttribute("data-turbo-stream"))
+      (link.hasAttribute("data-turbo-method") || link.hasAttribute("data-turbo-stream") || link.hasAttribute("data-turbo-confirm"))
     )
   }
 

--- a/src/tests/fixtures/drive.html
+++ b/src/tests/fixtures/drive.html
@@ -11,6 +11,8 @@
 
     <div>
       <a id="drive_enabled" href="/src/tests/fixtures/drive.html">Drive enabled link</a>
+      <a id="drive_enabled_with_confirm_without_method" href="/src/tests/fixtures/drive.html?confirmed=true" data-turbo-confirm="Are you sure?">Drive enabled link with confirm</a>
+      <a id="drive_enabled_with_confirm_and_method" data-turbo-method="GET" href="/src/tests/fixtures/drive.html?confirmed=true" data-turbo-confirm="Are you sure?">Drive enabled link with confirm</a>
       <a id="drive_enabled_external" href="https://example.com">Drive enabled external link</a>
     </div>
 

--- a/src/tests/fixtures/drive.html
+++ b/src/tests/fixtures/drive.html
@@ -12,7 +12,7 @@
     <div>
       <a id="drive_enabled" href="/src/tests/fixtures/drive.html">Drive enabled link</a>
       <a id="drive_enabled_with_confirm_without_method" href="/src/tests/fixtures/drive.html?confirmed=true" data-turbo-confirm="Are you sure?">Drive enabled link with confirm</a>
-      <a id="drive_enabled_with_confirm_and_method" data-turbo-method="GET" href="/src/tests/fixtures/drive.html?confirmed=true" data-turbo-confirm="Are you sure?">Drive enabled link with confirm</a>
+      <a id="drive_enabled_with_confirm_and_method" data-turbo-method="GET" href="/src/tests/fixtures/drive.html?confirmed=true" data-turbo-confirm="Are you sure?">Drive enabled link with confirm and method</a>
       <a id="drive_enabled_external" href="https://example.com">Drive enabled external link</a>
     </div>
 

--- a/src/tests/functional/drive_tests.js
+++ b/src/tests/functional/drive_tests.js
@@ -1,6 +1,6 @@
 import { test } from "@playwright/test"
 import { assert } from "chai"
-import { nextBody, pathname, visitAction } from "../helpers/page"
+import { nextBody, pathname, visitAction, search } from "../helpers/page"
 
 const path = "/src/tests/fixtures/drive.html"
 
@@ -32,4 +32,49 @@ test("drive enabled by default; click link inside data-turbo='false'", async ({ 
 
   assert.equal(pathname(page.url()), path)
   assert.equal(await visitAction(page), "load")
+})
+
+test("link with confirmation without method confirmed", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Are you sure?")
+    alert.accept()
+  })
+
+  await page.click("#drive_enabled_with_confirm_without_method")
+  await nextBody(page)
+  assert.equal(search(page.url()), "?confirmed=true")
+})
+
+test("link with confirmation without method cancelled", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Are you sure?")
+    alert.dismiss()
+  })
+
+  await page.click("#drive_enabled_with_confirm_without_method")
+  await nextBody(page)
+  assert.notEqual(search(page.url()), "?confirmed=true")
+})
+
+
+test("link with confirmation with method confirmed", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Are you sure?")
+    alert.accept()
+  })
+
+  await page.click("#drive_enabled_with_confirm_and_method")
+  await nextBody(page)
+  assert.equal(search(page.url()), "?confirmed=true")
+})
+
+test("link with confirmation with method cancelled", async ({ page }) => {
+  page.on("dialog", (alert) => {
+    assert.equal(alert.message(), "Are you sure?")
+    alert.dismiss()
+  })
+
+  await page.click("#drive_enabled_with_confirm_and_method")
+  await nextBody(page)
+  assert.notEqual(search(page.url()), "?confirmed=true")
 })


### PR DESCRIPTION
Resolves https://github.com/hotwired/turbo/issues/1264

It appears that the turbo-confirm feature implementation relies on the link being captured by the FormLinkClickObserver rather than the LinkClickObserver. Without a data-turbo-method (or data-turbo-stream) attribute, the FormLinkClickObserver will ignore the link and the confirm feature will not fire.

This small bug fix adds the data-turbo-confirm attribute to the other two attributes that indicate to the FormLinkClickObserver that it should handle the link.