### PR TITLE
Don't lose focus due to autofocus when morphing pages

### DIFF
--- a/src/core/drive/morph_renderer.js
+++ b/src/core/drive/morph_renderer.js
@@ -11,6 +11,10 @@ export class MorphRenderer extends PageRenderer {
     return "morph"
   }
 
+  get shouldAutofocus() {
+    return false
+  }
+
   // Private
 
   async #morphBody() {

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -16,6 +16,10 @@ export class Renderer {
     return true
   }
 
+  get shouldAutofocus() {
+    return true
+  }
+
   get reloadReason() {
     return
   }
@@ -40,9 +44,11 @@ export class Renderer {
   }
 
   focusFirstAutofocusableElement() {
-    const element = this.connectedSnapshot.firstAutofocusableElement
-    if (element) {
-      element.focus()
+    if (this.shouldAutofocus) {
+      const element = this.connectedSnapshot.firstAutofocusableElement
+      if (element) {
+        element.focus()
+      }
     }
   }
 

--- a/src/tests/fixtures/autofocus.html
+++ b/src/tests/fixtures/autofocus.html
@@ -5,6 +5,8 @@
     <title>Autofocus</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
   </head>
   <body>
     <h1>Autofocus</h1>
@@ -22,5 +24,12 @@
     <turbo-frame id="drives-frame" target="frame">
       <a id="drives-frame-target-link" href="/src/tests/fixtures/frames/form.html">#drives-frame link to frames/form.html</a>
     </turbo-frame>
+
+    <form id="form" action="/__turbo/refresh" method="post" class="redirect">
+      <input id="form-text" type="text" name="text" value="" autofocus>
+      <input type="hidden" name="path" value="/src/tests/fixtures/autofocus.html">
+      <input type="hidden" name="sleep" value="50">
+      <input id="form-submit" type="submit" value="form[method=post]">
+    </form>
   </body>
 </html>

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -109,7 +109,7 @@ test("renders a page refresh with morphing when the paths are the same but searc
   await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
 })
 
-test("renders a page refresh with morphing when the GET form paths are the same but search params are diferent", async ({ page }) => {
+test("renders a page refresh with morphing when the GET form paths are the same but search params are different", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 
   const input = page.locator("form[method=get] input[name=query]")


### PR DESCRIPTION
Before this change, Turbo would always focus on the first element with `[autofocus]` when a page refresh with morphing happened  (default behavior inherited from `PageRenderer`). With this change, it will never autofocus when a page refresh with morphing happens.

This is meant to solve the problem where you are writing on a form, and it loses the focus because a broadcasted page refresh arrives.