### PR TITLE
Set script element async true if data-eval is async

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -10,7 +10,11 @@ export function activateScriptElement(element) {
       createdScriptElement.nonce = cspNonce
     }
     createdScriptElement.textContent = element.textContent
-    createdScriptElement.async = false
+    if (element.getAttribute("data-eval") == "async") {
+      createdScriptElement.async = true
+    } else {
+      createdScriptElement.async = false
+    }
     copyElementAttributes(createdScriptElement, element)
     return createdScriptElement
   }


### PR DESCRIPTION
Hello! 
Recently faced issue on script execution. 
I tried execute script with Ruby code through (wasm) from script that I received inside turbo-stream, but got this.
![image](https://github.com/hotwired/turbo/assets/39821754/d6d41516-08fb-45b8-929d-50e2741a1972)
I don't know was `.async` setted to `false` accidently, by security or for other reason.