### PR TITLE
Update 422 status name to "Unprocessable Content"

### DIFF
--- a/src/tests/fixtures/422.html
+++ b/src/tests/fixtures/422.html
@@ -1,13 +1,13 @@
 <html>
   <head>
-    <title>Unprocessable Entity</title>
+    <title>Unprocessable Content</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
   <body>
-    <h1>Unprocessable Entity</h1>
+    <h1>Unprocessable Content</h1>
 
     <turbo-frame id="frame">
-      <h2>Frame: Unprocessable Entity</h2>
+      <h2>Frame: Unprocessable Content</h2>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/422_morph.html
+++ b/src/tests/fixtures/422_morph.html
@@ -1,16 +1,16 @@
 <html>
   <head>
-    <meta name="turbo-refresh-method" content="morph">
-    <meta name="turbo-refresh-scroll" content="preserve">
+    <meta name="turbo-refresh-method" content="morph" />
+    <meta name="turbo-refresh-scroll" content="preserve" />
 
-    <title>Unprocessable Entity</title>
+    <title>Unprocessable Content</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
   <body>
-    <h1>Unprocessable Entity</h1>
+    <h1>Unprocessable Content</h1>
 
     <turbo-frame id="frame">
-      <h2>Frame: Unprocessable Entity</h2>
+      <h2>Frame: Unprocessable Content</h2>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/422_tall.html
+++ b/src/tests/fixtures/422_tall.html
@@ -1,13 +1,13 @@
 <html>
   <head>
-    <title>Unprocessable Entity</title>
+    <title>Unprocessable Content</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
   <body>
     <main style="height: 1000vh">
-      <h1>Unprocessable Entity</h1>
+      <h1>Unprocessable Content</h1>
       <turbo-frame id="frame">
-        <h2>Frame: Unprocessable Entity</h2>
+        <h2>Frame: Unprocessable Content</h2>
       </turbo-frame>
     </main>
   </body>

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -1,7 +1,7 @@
-<!DOCTYPE html>
+<!doctype html>
 <html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end turbo:fetch-request-error">
   <head>
-    <meta charset="utf-8">
+    <meta charset="utf-8" />
     <title>Form</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
@@ -16,40 +16,42 @@
     <h1>Form</h1>
     <div id="standard">
       <form id="standard-form" action="/__turbo/redirect" method="post" class="redirect">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <input type="hidden" name="greeting" value="Hello from a redirect">
-        <input id="standard-post-form-submit" type="submit" value="form[method=post]">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <input type="hidden" name="greeting" value="Hello from a redirect" />
+        <input id="standard-post-form-submit" type="submit" value="form[method=post]" />
       </form>
       <form action="/__turbo/redirect" method="get" class="redirect">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <input type="hidden" name="greeting" value="Hello from a redirect">
-        <input id="standard-get-form-submit" type="submit" value="form[method=get]">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <input type="hidden" name="greeting" value="Hello from a redirect" />
+        <input id="standard-get-form-submit" type="submit" value="form[method=get]" />
       </form>
       <form action="/__turbo/redirect" method="post" class="redirect" data-turbo-frame="_top">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
         <button>form[data-turbo-frame=_top]</button>
       </form>
       <form action="/__turbo/redirect" method="get" data-turbo-stream class="redirect">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <input type="hidden" name="greeting" value="Hello from a redirect">
-        <input id="standard-get-form-with-stream-opt-in-submit" type="submit" value="form[method=get]">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <input type="hidden" name="greeting" value="Hello from a redirect" />
+        <input id="standard-get-form-with-stream-opt-in-submit" type="submit" value="form[method=get]" />
       </form>
       <form action="/__turbo/redirect" class="redirect">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <button id="standard-get-form-with-stream-opt-in-submitter" data-turbo-stream>form[method=get] button[data-turbo-stream]</button>
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <button id="standard-get-form-with-stream-opt-in-submitter" data-turbo-stream>
+          form[method=get] button[data-turbo-stream]
+        </button>
       </form>
       <form action="/__turbo/redirect" method="post" class="redirect">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <input type="hidden" name="greeting" value="Hello from a redirect">
-        <input id="submits-with-form-input" type="submit" value="Save" data-turbo-submits-with="Saving...">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <input type="hidden" name="greeting" value="Hello from a redirect" />
+        <input id="submits-with-form-input" type="submit" value="Save" data-turbo-submits-with="Saving..." />
       </form>
       <form action="/__turbo/redirect" method="post" class="redirect">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <input type="hidden" name="sleep" value="200">
-        <input type="hidden" name="greeting" value="Hello from a redirect">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <input type="hidden" name="sleep" value="200" />
+        <input type="hidden" name="greeting" value="Hello from a redirect" />
         <button id="submits-with-form-button" type="submit" data-turbo-submits-with="Saving...">Save</button>
       </form>
-      <hr>
+      <hr />
       <form>
         <button id="form-action-none-q-a" name="q" value="a">Submit ?q=a to form:not([action])</button>
       </form>
@@ -63,58 +65,68 @@
       <form action="/__turbo/redirect?path=%2Fsrc%2Ftests%2Ffixtures%2Fform.html%3Fsort%3Dasc" method="post">
         <button id="form-action-post-redirect-self-q-b" name="q" value="b">POST q=b to form[action]</button>
       </form>
-      <hr>
+      <hr />
       <form action="/__turbo/messages" method="post" class="created">
-        <input type="hidden" name="content" value="Hello!">
-        <input type="submit" style="">
+        <input type="hidden" name="content" value="Hello!" />
+        <input type="submit" style="" />
       </form>
       <form action="/__turbo/messages" method="post" class="no-content">
-        <input type="hidden" name="content" value="Hello!">
-        <input type="hidden" name="status" value="204">
-        <input type="submit" style="">
+        <input type="hidden" name="content" value="Hello!" />
+        <input type="hidden" name="status" value="204" />
+        <input type="submit" style="" />
       </form>
       <form action="/__turbo/redirect" method="post" class="no-enctype">
-        <input type="submit">
+        <input type="submit" />
       </form>
       <form action="/__turbo/redirect" method="post" enctype="multipart/form-data">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <input type="submit">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <input type="submit" />
       </form>
       <form action="/__turbo/redirect" method="get" enctype="multipart/form-data">
-        <input type="submit">
+        <input type="submit" />
       </form>
       <form action="/__turbo/redirect" method="get" class="greeting">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
-        <input type="hidden" name="greeting" value="Hello from a form">
-        <input type="submit">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
+        <input type="hidden" name="greeting" value="Hello from a form" />
+        <input type="submit" />
       </form>
       <form action="/__turbo/redirect" method="post" class="sleep">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <input type="hidden" name="sleep" value="500">
-        <input type="submit">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <input type="hidden" name="sleep" value="500" />
+        <input type="submit" />
       </form>
       <form action="/src/tests/fixtures/form.html?query=1" method="get" class="conflicting-values">
-        <input type="hidden" name="query" value="2">
-        <input type="submit">
+        <input type="hidden" name="query" value="2" />
+        <input type="submit" />
       </form>
       <form action="/__turbo/redirect" method="post" class="confirm" data-turbo-confirm="Are you sure?">
-        <input type="submit">
-        <button type="submit" name="greeting" id="secondary_submitter" data-turbo-confirm="Are you really sure?" formaction="/__turbo/redirect?path=/src/tests/fixtures/one.html" formmethod="post" value="secondary_submitter">Secondary action</button>
+        <input type="submit" />
+        <button
+          type="submit"
+          name="greeting"
+          id="secondary_submitter"
+          data-turbo-confirm="Are you really sure?"
+          formaction="/__turbo/redirect?path=/src/tests/fixtures/one.html"
+          formmethod="post"
+          value="secondary_submitter"
+        >
+          Secondary action
+        </button>
       </form>
     </div>
-    <hr>
+    <hr />
     <div id="no-action">
       <form class="single">
-        <input type="hidden" name="query" value="1">
-        <input type="submit">
+        <input type="hidden" name="query" value="1" />
+        <input type="submit" />
       </form>
       <form class="multiple">
-        <input type="hidden" name="query" value="1">
-        <input type="hidden" name="query" value="2">
-        <input type="submit">
+        <input type="hidden" name="query" value="1" />
+        <input type="hidden" name="query" value="2" />
+        <input type="submit" />
       </form>
       <form method="get" class="button-param">
-        <input type="hidden" name="query" value="1">
+        <input type="hidden" name="query" value="1" />
         <button type="submit" name="button">Submit</button>
       </form>
     </div>
@@ -123,43 +135,50 @@
         <button formaction="">Submit</button>
       </form>
     </div>
-    <hr>
+    <hr />
     <div id="action-input">
       <form class="no-action">
-        <input type="hidden" name="action" value="1">
-        <input type="hidden" name="query" value="1">
-        <input type="submit">
+        <input type="hidden" name="action" value="1" />
+        <input type="hidden" name="query" value="1" />
+        <input type="submit" />
       </form>
       <form class="action" action="/src/tests/fixtures/one.html">
-        <input type="hidden" name="action" value="1">
-        <input type="hidden" name="query" value="1">
-        <input type="submit">
+        <input type="hidden" name="action" value="1" />
+        <input type="hidden" name="query" value="1" />
+        <input type="submit" />
       </form>
     </div>
-    <hr>
+    <hr />
     <div id="reject">
-      <form class="unprocessable_entity" action="/__turbo/reject" method="post" style="margin-top:100vh">
-        <input type="hidden" name="status" value="422">
-        <input type="submit">
+      <form class="unprocessable_content" action="/__turbo/reject" method="post" style="margin-top: 100vh">
+        <input type="hidden" name="status" value="422" />
+        <input type="submit" />
       </form>
-      <form class="unprocessable_entity_with_tall_form" action="/__turbo/reject/tall" method="post">
-        <input type="hidden" name="status" value="422">
-        <input type="submit" style="margin-top:1000vh">
+      <form class="unprocessable_content_with_tall_form" action="/__turbo/reject/tall" method="post">
+        <input type="hidden" name="status" value="422" />
+        <input type="submit" style="margin-top: 1000vh" />
       </form>
       <form id="reject-form" class="internal_server_error" action="/__turbo/reject" method="post">
-        <input type="hidden" name="status" value="500">
-        <input type="submit">
+        <input type="hidden" name="status" value="500" />
+        <input type="submit" />
       </form>
     </div>
-    <hr>
+    <hr />
     <div id="submitter">
       <form action="/src/tests/fixtures/one.html" method="get">
-        <button type="submit" formmethod="post" formaction="/__turbo/redirect"
-            name="path" value="/src/tests/fixtures/two.html">Submit</button>
+        <button
+          type="submit"
+          formmethod="post"
+          formaction="/__turbo/redirect"
+          name="path"
+          value="/src/tests/fixtures/two.html"
+        >
+          Submit
+        </button>
       </form>
       <form action="/__turbo/redirect" method="post">
-        <input type="hidden" name="path" value="/src/tests/fixtures/form.html">
-        <input type="submit" formenctype="multipart/form-data">
+        <input type="hidden" name="path" value="/src/tests/fixtures/form.html" />
+        <input type="submit" formenctype="multipart/form-data" />
       </form>
 
       <form action="/src/tests/fixtures/frames/form.html" method="get">
@@ -167,23 +186,23 @@
       </form>
 
       <form action="/__turbo/redirect" method="post">
-        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html" />
         <button type="submit" data-turbo-frame="frame">POST to Frame</button>
       </form>
     </div>
-    <hr>
+    <hr />
     <div id="turbo-false">
       <form action="/__turbo/redirect" method="post" data-turbo="false">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
-        <input type="submit">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
+        <input type="submit" />
       </form>
 
       <form action="/__turbo/redirect" method="post">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
-        <input type="submit" data-turbo="false">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
+        <input type="submit" data-turbo="false" />
       </form>
     </div>
-    <hr>
+    <hr />
     <div id="skipped">
       <dialog id="dialog-method" open>
         <form method="dialog">
@@ -193,27 +212,27 @@
 
       <dialog id="dialog-formmethod" open>
         <form action="/__turbo/redirect" method="post">
-          <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+          <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
           <button formmethod="dialog">Close</button>
         </form>
       </dialog>
 
-      <hr>
+      <hr />
       <dialog id="dialog-method-turbo-frame" open>
         <form action="/__turbo/redirect" method="dialog">
-          <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+          <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html" />
           <button>Close</button>
         </form>
       </dialog>
 
       <dialog id="dialog-formmethod-turbo-frame" open>
         <form action="/__turbo/redirect" method="post" data-turbo-frame="frame">
-          <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+          <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html" />
           <button formmethod="dialog">Close</button>
         </form>
       </dialog>
 
-      <hr>
+      <hr />
       <form action="/src/tests/fixtures/one.html" method="get" target="iframe">
         <button>Submit iframe target</button>
       </form>
@@ -222,123 +241,203 @@
         <button formtarget="iframe">Submit iframe formtarget</button>
       </form>
     </div>
-    <hr>
+    <hr />
     <div id="targets-frame">
       <form id="form_one" action="/__turbo/redirect" method="post" data-turbo-frame="frame" class="one">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
         <button type="submit">Submit</button>
       </form>
 
       <form action="/__turbo/redirect" method="post" data-turbo-frame="frame">
-        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html" />
         <button id="targets-frame-post-form-submit" type="submit">targets-frame form[method=post]</button>
       </form>
 
       <form action="/__turbo/redirect" method="get" data-turbo-frame="frame">
-        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html" />
         <button id="targets-frame-get-form-submit" type="submit">targets-frame form[method=get]</button>
       </form>
 
       <form action="/__turbo/redirect" method="post" data-turbo-frame="frame" class="frame">
-        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/frame.html" />
         <button type="submit">Submit</button>
       </form>
     </div>
     <turbo-frame id="frame">
       <h2>Frame: Form</h2>
       <form action="/__turbo/redirect" method="post" class="redirect">
-        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html">
-        <input type="submit">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html" />
+        <input type="submit" />
       </form>
       <form action="/__turbo/redirect" method="post" class="redirect" data-turbo-frame="_top">
-        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/form.html" />
         <button>#frame form[data-turbo-frame=_top]</button>
       </form>
       <form action="/__turbo/messages" method="post" class="created">
-        <input type="hidden" name="content" value="Hello!">
-        <input type="submit" style="">
+        <input type="hidden" name="content" value="Hello!" />
+        <input type="submit" style="" />
       </form>
       <form action="/__turbo/messages" method="post" class="no-content">
-        <input type="hidden" name="content" value="Hello!">
-        <input type="hidden" name="status" value="204">
-        <input type="submit" style="">
+        <input type="hidden" name="content" value="Hello!" />
+        <input type="hidden" name="status" value="204" />
+        <input type="submit" style="" />
       </form>
-      <form class="unprocessable_entity" action="/__turbo/reject" method="post">
-        <input type="hidden" name="status" value="422">
-        <input type="submit">
+      <form class="unprocessable_content" action="/__turbo/reject" method="post">
+        <input type="hidden" name="status" value="422" />
+        <input type="submit" />
       </form>
       <form class="internal_server_error" action="/__turbo/reject" method="post">
-        <input type="hidden" name="status" value="500">
-        <input type="submit">
+        <input type="hidden" name="status" value="500" />
+        <input type="submit" />
       </form>
       <form action="/__turbo/redirect" method="post" data-turbo="false">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
-        <input type="submit">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
+        <input type="submit" />
       </form>
       <form action="/__turbo/redirect" method="post">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
-        <input type="submit" data-turbo="false">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
+        <input type="submit" data-turbo="false" />
       </form>
       <form action="/__turbo/messages" method="post" class="stream">
-        <input type="hidden" name="type" value="stream">
-        <input type="hidden" name="content" value="Hello!">
-        <input type="submit">
+        <input type="hidden" name="type" value="stream" />
+        <input type="hidden" name="content" value="Hello!" />
+        <input type="submit" />
       </form>
-      <a href="/src/tests/fixtures/frames/frame.html" data-turbo-method="get" id="link-method-inside-frame">Method link inside frame</a><br />
-      <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" data-turbo-frame="_top" id="link-method-inside-frame-target-top">Break-out of frame with method link inside frame</a><br />
-      <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" data-turbo-frame="hello" id="link-method-inside-frame-with-target">Method link inside frame targeting another frame</a><br />
-      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-inside-frame">Stream link inside frame</a>
-      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="get" data-turbo-stream id="stream-link-get-method-inside-frame">Stream link GET inside frame</a>
-      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-stream id="stream-link-inside-frame">Stream link (no method) inside frame</a>
-      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" data-turbo-confirm="Are you sure?" id="link-method-inside-frame-with-confirmation"data-turbo-confirm="Are you sure?">Stream link inside frame with confirmation</a>
+      <a href="/src/tests/fixtures/frames/frame.html" data-turbo-method="get" id="link-method-inside-frame"
+        >Method link inside frame</a
+      ><br />
+      <a
+        href="/src/tests/fixtures/frames/hello.html"
+        data-turbo-method="get"
+        data-turbo-frame="_top"
+        id="link-method-inside-frame-target-top"
+        >Break-out of frame with method link inside frame</a
+      ><br />
+      <a
+        href="/src/tests/fixtures/frames/hello.html"
+        data-turbo-method="get"
+        data-turbo-frame="hello"
+        id="link-method-inside-frame-with-target"
+        >Method link inside frame targeting another frame</a
+      ><br />
+      <a
+        href="/__turbo/messages?content=Link!&type=stream"
+        data-turbo-method="post"
+        id="stream-link-method-inside-frame"
+        >Stream link inside frame</a
+      >
+      <a
+        href="/__turbo/messages?content=Link!&type=stream"
+        data-turbo-method="get"
+        data-turbo-stream
+        id="stream-link-get-method-inside-frame"
+        >Stream link GET inside frame</a
+      >
+      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-stream id="stream-link-inside-frame"
+        >Stream link (no method) inside frame</a
+      >
+      <a
+        href="/__turbo/messages?content=Link!&type=stream"
+        data-turbo-method="post"
+        data-turbo-confirm="Are you sure?"
+        id="link-method-inside-frame-with-confirmation"
+        data-turbo-confirm="Are you sure?"
+        >Stream link inside frame with confirmation</a
+      >
       <form>
-        <a href="/src/tests/fixtures/frames/frame.html" data-turbo-method="get" id="method-link-within-form-inside-frame">Method link within form inside frame</a><br />
-        <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-within-form-inside-frame">Stream link within form inside frame</a>
+        <a
+          href="/src/tests/fixtures/frames/frame.html"
+          data-turbo-method="get"
+          id="method-link-within-form-inside-frame"
+          >Method link within form inside frame</a
+        ><br />
+        <a
+          href="/__turbo/messages?content=Link!&type=stream"
+          data-turbo-method="post"
+          id="stream-link-method-within-form-inside-frame"
+          >Stream link within form inside frame</a
+        >
       </form>
       <form action="/__turbo/messages/1" method="put" class="stream put">
-        <input type="hidden" name="type" value="stream">
-        <input type="hidden" name="content" value="Hello!">
-        <input type="submit">
+        <input type="hidden" name="type" value="stream" />
+        <input type="hidden" name="content" value="Hello!" />
+        <input type="submit" />
       </form>
       <form action="/src/tests/fixtures/one.html" method="get">
         <button type="submit" data-turbo-frame="_top">Break-out of Frame with GET</button>
       </form>
       <form action="/__turbo/redirect" method="post">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
         <button type="submit" data-turbo-frame="_top">Break-out of Frame with POST</button>
       </form>
       <form action="/src/tests/fixtures/frames/hello.html" method="get">
         <button type="submit" data-turbo-frame="hello">Navigate other Frame with GET</button>
       </form>
       <form action="/__turbo/redirect" method="post">
-        <input type="hidden" name="path" value="/src/tests/fixtures/frames/hello.html">
+        <input type="hidden" name="path" value="/src/tests/fixtures/frames/hello.html" />
         <button type="submit" data-turbo-frame="hello">Navigate other Frame with POST</button>
       </form>
-      <div id="messages">
-      </div>
-      <form id="form-with-external-inputs" action="/src/tests/fixtures/frames/hello.html" data-turbo-action="replace" data-turbo-frame="hello"></form>
+      <div id="messages"></div>
+      <form
+        id="form-with-external-inputs"
+        action="/src/tests/fixtures/frames/hello.html"
+        data-turbo-action="replace"
+        data-turbo-frame="hello"
+      ></form>
       <select id="external-select" form="form-with-external-inputs" name="greeting">
         <option selected>Hello from a replace Visit</option>
       </select>
       <form id="form-with-buttons-triggered-by-js" action="/__turbo/redirect" data-turbo-frame="_top" method="post">
-        <input type="hidden" name="path" value="/src/tests/fixtures/one.html">
-        <button type="submit" formaction="/src/tests/fixtures/frames/hello.html" formmethod="get" id="button-triggered-by-js" data-turbo-action="replace" data-turbo-frame="hello">Navigate other Frame with GET</button>
-        <button type="button" onclick="this.form.requestSubmit(document.getElementById('button-triggered-by-js'))" id="request-submit-trigger">Trigger Navigate other Frame with GET</button>
+        <input type="hidden" name="path" value="/src/tests/fixtures/one.html" />
+        <button
+          type="submit"
+          formaction="/src/tests/fixtures/frames/hello.html"
+          formmethod="get"
+          id="button-triggered-by-js"
+          data-turbo-action="replace"
+          data-turbo-frame="hello"
+        >
+          Navigate other Frame with GET
+        </button>
+        <button
+          type="button"
+          onclick="this.form.requestSubmit(document.getElementById('button-triggered-by-js'))"
+          id="request-submit-trigger"
+        >
+          Trigger Navigate other Frame with GET
+        </button>
       </form>
     </turbo-frame>
-    <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-outside-frame">Method link outside frame</a><br />
-    <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-outside-frame">Stream link outside frame</a>
+    <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-outside-frame"
+      >Method link outside frame</a
+    ><br />
+    <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-outside-frame"
+      >Stream link outside frame</a
+    >
     <form>
-      <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-within-form-outside-frame">Method link within form outside frame</a><br />
-      <a href="/__turbo/messages?content=Link!&type=stream" data-turbo-method="post" id="stream-link-method-within-form-outside-frame">Stream link within form outside frame</a>
+      <a href="/src/tests/fixtures/frames/hello.html" data-turbo-method="get" id="link-method-within-form-outside-frame"
+        >Method link within form outside frame</a
+      ><br />
+      <a
+        href="/__turbo/messages?content=Link!&type=stream"
+        data-turbo-method="post"
+        id="stream-link-method-within-form-outside-frame"
+        >Stream link within form outside frame</a
+      >
     </form>
-    <hr>
+    <hr />
     <form method="post" action="https://httpbin.org/post">
       <button id="submit-external">POST to https://httpbin.org/post</button>
     </form>
-     <a href="/__turbo/redirect?path=%2Fsrc%2Ftests%2Ffixtures%2Fframes%2Fhello.html" data-turbo-method="post" data-turbo-frame="hello" id="turbo-method-post-to-targeted-frame">Turbo method post to targeted frame</a>
+    <a
+      href="/__turbo/redirect?path=%2Fsrc%2Ftests%2Ffixtures%2Fframes%2Fhello.html"
+      data-turbo-method="post"
+      data-turbo-frame="hello"
+      id="turbo-method-post-to-targeted-frame"
+      >Turbo method post to targeted frame</a
+    >
     <turbo-frame id="hello"></turbo-frame>
-    <hr>
+    <hr />
 
     <turbo-frame id="ignored">
       <form method="post" action="https://httpbin.org/post">

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -1,12 +1,12 @@
-<!DOCTYPE html>
+<!doctype html>
 <html id="html" data-skip-event-details="turbo:submit-start turbo:submit-end turbo:fetch-request-error">
   <head>
-    <meta charset="utf-8">
-    <meta name="turbo-refresh-method" content="morph">
-    <meta name="turbo-refresh-scroll" content="preserve">
+    <meta charset="utf-8" />
+    <meta name="turbo-refresh-method" content="morph" />
+    <meta name="turbo-refresh-scroll" content="preserve" />
 
     <title>Turbo</title>
-    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=" />
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
     <script type="module">
@@ -18,7 +18,9 @@
         if (target instanceof HTMLInputElement && !target.hasAttribute("data-turbo-permanent")) {
           target.toggleAttribute("data-turbo-permanent", true)
 
-          target.addEventListener("focusout", () => target.toggleAttribute("data-turbo-permanent", false), { once: true })
+          target.addEventListener("focusout", () => target.toggleAttribute("data-turbo-permanent", false), {
+            once: true
+          })
         }
       })
 
@@ -32,7 +34,10 @@
       })
 
       addEventListener("turbo:before-morph-attribute", (event) => {
-        const { target, detail: { attributeName, mutationType } } = event
+        const {
+          target,
+          detail: { attributeName, mutationType }
+        } = event
 
         for (const { element, context } of application.controllers) {
           const pattern = new RegExp(`data-${context.identifier}-\\w+-value`)
@@ -43,18 +48,21 @@
         }
       })
 
-      application.register("test", class extends Controller {
-        static targets = ["output"]
-        static values = { state: String }
+      application.register(
+        "test",
+        class extends Controller {
+          static targets = ["output"]
+          static values = { state: String }
 
-        capture({ target }) {
-          this.stateValue = target.value
-        }
+          capture({ target }) {
+            this.stateValue = target.value
+          }
 
-        outputTargetConnected(target) {
-          target.textContent = "connected"
+          outputTargetConnected(target) {
+            target.textContent = "connected"
+          }
         }
-      })
+      )
 
       document.getElementById("add-new-assets").addEventListener("click", () => {
         const stylesheet = document.createElement("link")
@@ -67,14 +75,14 @@
     </script>
 
     <style>
-        body {
-            margin: 0;
-            padding: 0;
+      body {
+        margin: 0;
+        padding: 0;
 
-            /* Ensure the page is large enough to scroll */
-            width: 150vw;
-            height: 150vh;
-        }
+        /* Ensure the page is large enough to scroll */
+        width: 150vw;
+        height: 150vh;
+      }
     </style>
   </head>
   <body>
@@ -107,37 +115,44 @@
       <h3>Element with Stimulus controller</h3>
 
       <div id="test-output" data-test-target="output">reset</div>
-      <input>
+      <input />
     </div>
 
     <form method="get" data-turbo-action="replace" oninput="this.requestSubmit()">
       <label>
         Search
-        <input name="query">
+        <input name="query" />
       </label>
       <button>Form with params to refresh the page</button>
     </form>
-    <p><a id="replace-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html?param=something">Link with params to refresh the page</a></p>
-    <p><a id="refresh-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html">Link to the same page</a></p>
+    <p>
+      <a id="replace-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html?param=something"
+        >Link with params to refresh the page</a
+      >
+    </p>
+    <p>
+      <a id="refresh-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html"
+        >Link to the same page</a
+      >
+    </p>
     <p><a id="link" href="/src/tests/fixtures/one.html">Link to another page</a></p>
 
     <form id="form" action="/__turbo/refresh" method="post" class="redirect">
-      <input id="form-text" type="text" name="text" value="">
-      <input type="hidden" name="path" value="/src/tests/fixtures/page_refresh.html">
-      <input type="hidden" name="sleep" value="50">
-      <input id="form-submit" type="submit" value="form[method=post]">
+      <input id="form-text" type="text" name="text" value="" />
+      <input type="hidden" name="path" value="/src/tests/fixtures/page_refresh.html" />
+      <input type="hidden" name="sleep" value="50" />
+      <input id="form-submit" type="submit" value="form[method=post]" />
     </form>
 
     <button id="add-new-assets">Add new assets</button>
 
     <div id="reject">
-      <form class="unprocessable_entity" action="/__turbo/reject/morph" method="post" style="margin-top:100vh">
-        <input type="hidden" name="status" value="422">
-        <input type="submit">
+      <form class="unprocessable_content" action="/__turbo/reject/morph" method="post" style="margin-top: 100vh">
+        <input type="hidden" name="status" value="422" />
+        <input type="submit" />
       </form>
     </div>
 
-    <div id="container">
-    </div>
+    <div id="container"></div>
   </body>
 </html>

--- a/src/tests/functional/form_submission_tests.js
+++ b/src/tests/functional/form_submission_tests.js
@@ -544,22 +544,22 @@ test("input named action with action attribute", async ({ page }) => {
   assert.equal(getSearchParam(page.url(), "query"), "1")
 })
 
-test("invalid form submission with unprocessable entity status", async ({ page }) => {
-  await page.click("#reject form.unprocessable_entity input[type=submit]")
+test("invalid form submission with unprocessable content status", async ({ page }) => {
+  await page.click("#reject form.unprocessable_content input[type=submit]")
   await nextBody(page)
 
   const title = await page.locator("h1")
-  assert.equal(await title.textContent(), "Unprocessable Entity", "renders the response HTML")
+  assert.equal(await title.textContent(), "Unprocessable Content", "renders the response HTML")
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
 
 test("invalid form submission with long form", async ({ page }) => {
-  await scrollToSelector(page, "#reject form.unprocessable_entity_with_tall_form input[type=submit]")
-  await page.click("#reject form.unprocessable_entity_with_tall_form input[type=submit]")
+  await scrollToSelector(page, "#reject form.unprocessable_content_with_tall_form input[type=submit]")
+  await page.click("#reject form.unprocessable_content_with_tall_form input[type=submit]")
   await nextBody(page)
 
   const title = await page.locator("h1")
-  assert.equal(await title.textContent(), "Unprocessable Entity", "renders the response HTML")
+  assert.equal(await title.textContent(), "Unprocessable Content", "renders the response HTML")
   assert(await isScrolledToTop(page), "page is scrolled to the top")
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
@@ -827,8 +827,8 @@ test("frame form submission within a frame submits the Turbo-Frame header", asyn
   assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
 })
 
-test("invalid frame form submission with unprocessable entity status", async ({ page }) => {
-  await page.click("#frame form.unprocessable_entity input[type=submit]")
+test("invalid frame form submission with unprocessable content status", async ({ page }) => {
+  await page.click("#frame form.unprocessable_content input[type=submit]")
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
   await nextEventNamed(page, "turbo:before-fetch-request")
@@ -842,7 +842,7 @@ test("invalid frame form submission with unprocessable entity status", async ({ 
 
   const title = await page.locator("#frame h2")
   assert.ok(await hasSelector(page, "#reject form"), "only replaces frame")
-  assert.equal(await title.textContent(), "Frame: Unprocessable Entity")
+  assert.equal(await title.textContent(), "Frame: Unprocessable Content")
 })
 
 test("invalid frame form submission with internal server error status", async ({ page }) => {

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -311,15 +311,15 @@ test("it preserves data-turbo-permanent elements that don't match when their ids
   await expect(page.locator("#preserve-me")).toHaveText("Preserve me, I have a family!")
 })
 
-test("renders unprocessable entity responses with morphing", async ({ page }) => {
+test("renders unprocessable content responses with morphing", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 
-  await page.click("#reject form.unprocessable_entity input[type=submit]")
+  await page.click("#reject form.unprocessable_content input[type=submit]")
   await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
   await nextBody(page)
 
   const title = await page.locator("h1")
-  assert.equal(await title.textContent(), "Unprocessable Entity", "renders the response HTML")
+  assert.equal(await title.textContent(), "Unprocessable Content", "renders the response HTML")
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
 


### PR DESCRIPTION
I don't know when this changed, but it's now the official name for this response status. I found out about this when Rack 3.1+ stopped supporting `:unprocessable_entity` in favor of `:unprocessable_content`.
