### PR TITLE
Support back button (restore) even if page loaded in frame does not contain matching HEAD

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -270,6 +270,8 @@ export class FrameController {
 
   viewRenderedSnapshot(_snapshot, _isPreview, _renderMethod) {}
 
+  setLastRenderedLocation() {}
+
   preloadOnLoadLinksForView(element) {
     session.preloadOnLoadLinksForView(element)
   }

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -327,8 +327,12 @@ export class Session {
   }
 
   viewRenderedSnapshot(_snapshot, _isPreview, renderMethod) {
-    this.view.lastRenderedLocation = this.history.location
+    this.setLastRenderedLocation()
     this.notifyApplicationAfterRender(renderMethod)
+  }
+
+  setLastRenderedLocation() {
+    this.view.lastRenderedLocation = this.history.location
   }
 
   preloadOnLoadLinksForView(element) {

--- a/src/core/view.js
+++ b/src/core/view.js
@@ -84,6 +84,8 @@ export class View {
       }
     } else if (shouldInvalidate) {
       this.invalidate(renderer.reloadReason)
+    } else {
+      this.delegate.setLastRenderedLocation();
     }
   }
 

--- a/src/tests/fixtures/tabs/three.html
+++ b/src/tests/fixtures/tabs/three.html
@@ -3,7 +3,6 @@
   <head>
     <meta charset="utf-8">
     <title>Frame</title>
-    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
   </head>
   <body>


### PR DESCRIPTION
## Purpose

Resolves #1241 

## Approach

Set the location on the session even if the `PageView` does not render because the `trackedElementsAreIdentical` is false.

## Test

This test illustrates the issue, once you remove line 6 from `three.html`
`npx playwright test -g "promoted frame navigations are cached"`