### PR TITLE
Allow setting the request method for Turbo Frame requests to avoid 414 Long URL errors

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -314,7 +314,7 @@ export class FrameController {
   }
 
   async #visit(url) {
-    const request = new FetchRequest(this, FetchMethod.get, url, new URLSearchParams(), this.element)
+    const request = new FetchRequest(this, this.visitMethod, url, this.visitRequestBody, this.element)
 
     this.#currentFetchRequest?.cancel()
     this.#currentFetchRequest = request
@@ -535,6 +535,22 @@ export class FrameController {
     const meta = this.element.ownerDocument.querySelector(`meta[name="turbo-root"]`)
     const root = meta?.content ?? "/"
     return expandURL(root)
+  }
+
+  get visitMethod() {
+    if (this.element.method === "post") {
+      return FetchMethod.post
+    } else {
+      return FetchMethod.get
+    }
+  }
+
+  get visitRequestBody() {
+    if (this.element.method === "post") {
+      return new URLSearchParams(this.element.params)
+    } else {
+      return new URLSearchParams()
+    }
   }
 
   #isIgnoringChangesTo(attributeName) {

--- a/src/elements/frame_element.js
+++ b/src/elements/frame_element.js
@@ -177,6 +177,26 @@ export class FrameElement extends HTMLElement {
   get isPreview() {
     return this.ownerDocument?.documentElement?.hasAttribute("data-turbo-preview")
   }
+
+  /**
+   * Determines the HTTP method that should be used to load the frame. Supports GET, POST, or blank (defaults to GET).
+   */
+  get method() {
+    return (this.getAttribute("method") || "get").toLowerCase()
+  }
+
+  /**
+   * Provides the params that should be sent when loading the frame. Only relevant if method is POST.
+   * 
+   * If the params can be parsed as JSON they are returned as JSON, otherwise they are returned as a String.
+   */
+  get params() {
+    try {
+      return JSON.parse(this.getAttribute("params"))
+    } catch (e) {
+      return this.getAttribute("params")
+    }
+  }
 }
 
 function frameLoadingStyleFromString(style) {

--- a/src/tests/fixtures/frames/post.html
+++ b/src/tests/fixtures/frames/post.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frames: Hello</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Hello</h1>
+    <turbo-frame id=":frame_id">
+      <h2>Hello from a frame retrieved via POST. The following POST body was provided: $PARAMS</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/loading.html
+++ b/src/tests/fixtures/loading.html
@@ -22,5 +22,9 @@
     </details>
 
     <p><a id="one" href="one.html">One</a></p>
+
+    <turbo-frame id="post" src="/__turbo/post/post" method="post" params='{"required":true,"type":"string"}'></turbo-frame>
+
+    <turbo-frame id="post-string" src="/__turbo/post/post-string" method="post" params='q=URLUtils.searchParams&topic=api'></turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/loading_tests.js
+++ b/src/tests/functional/loading_tests.js
@@ -195,3 +195,17 @@ test("disconnecting and reconnecting a frame does not reload the frame", async (
   const requestLogs = eventLogs.filter(([name]) => name == "turbo:before-fetch-request")
   assert.equal(requestLogs.length, 0)
 })
+
+test("loading via a POST request - JSON", async ({ page }) => {
+  await nextBeat()
+
+  const contents = await page.locator("#post h2")
+  assert.equal(await contents.textContent(), 'Hello from a frame retrieved via POST. The following POST body was provided: {"required":"true","type":"string"}')
+})
+
+test("loading via a POST request - string", async ({ page }) => {
+  await nextBeat()
+
+  const contents = await page.locator("#post-string h2")
+  assert.equal(await contents.textContent(), 'Hello from a frame retrieved via POST. The following POST body was provided: {"q":"URLUtils.searchParams","topic":"api"}')
+})

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -175,6 +175,14 @@ router.get("/messages", (request, response) => {
   streamResponses.add(response)
 })
 
+router.post("/post/:frame_id", (request, response) => {
+  const template = fs.readFileSync("src/tests/fixtures/frames/post.html").toString()
+  response
+    .type("html")
+    .status(200)
+    .send(template.replace("$PARAMS", JSON.stringify(request.body)).replace(":frame_id", request.params["frame_id"]))
+})
+
 function receiveMessage(content, id, target) {
   const data = renderSSEData(renderMessage(content, id, target))
   for (const response of streamResponses) {


### PR DESCRIPTION
Currently the request that a Turbo Frame makes to load a page is hardcoded to [a GET request](https://github.com/hotwired/turbo/blob/14284e6a8d2ffdf8c6beac61d26373f18491ba72/src/core/frames/frame_controller.js#L317). We came across an edge case where [HTTP 414s](https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/414) were being thrown due to a very large request URL, in a complex form that heavily uses frames with URLs to hold form state.

The general approach to handling 414s is to switch to a POST. This PR adds the ability to declaratively do that on the frame element:

```html
<turbo-frame id="stuff" src="/my/url" method="post" params='{"required":true,"type":"string"}'></turbo-frame>
```

You need to provide: 

- `method`= `"post"`
- `params` = Something that [`URLSearchParams`](https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams) can interpret: stringified JSON, or form params.

This will make a POST to `/my/url`, with the provided `params` in the POST body.