### PR TITLE
Re-connect Stream Source when attribute change

### DIFF
--- a/src/elements/stream_source_element.js
+++ b/src/elements/stream_source_element.js
@@ -1,19 +1,30 @@
 import { connectStreamSource, disconnectStreamSource } from "../core/index"
 
 export class StreamSourceElement extends HTMLElement {
+  static observedAttributes = ["src"]
+
   streamSource = null
 
   connectedCallback() {
     this.streamSource = this.src.match(/^ws{1,2}:/) ? new WebSocket(this.src) : new EventSource(this.src)
 
     connectStreamSource(this.streamSource)
+    this.setAttribute("connected", "")
   }
 
   disconnectedCallback() {
+    this.removeAttribute("connected")
     if (this.streamSource) {
       this.streamSource.close()
 
       disconnectStreamSource(this.streamSource)
+    }
+  }
+
+  attributeChangedCallback() {
+    if (this.streamSource) {
+      this.disconnectedCallback()
+      this.connectedCallback()
     }
   }
 


### PR DESCRIPTION
Related to [hotwired/turbo-rails#638][]

Recent changes to integrate with morphing have altered the mental model for some Turbo custom elements, including the
`<turbo-stream-source>` element.

Custom Elements' `connectedCallback()` and `disconnectedCallback()` (along with Stimulus' `connect()` and `disconnect()`) improved upon invoking code immediately, or listening for `DOMContentLoaded` events.

There are similar improvements to be made to integrate with morphing. First, [observe attribute changes][] by declaring their own `static observedAttributes` properties along with
`attributeChangedCallback(name, oldValue, newValue)` callbacks. Those callbacks execute the same initialization code as their current `connectedCallback()` and `disconnectedCallback()` methods.

That'll help resolve this issue. In addition to those changes, it's important to emphasize this pattern for consumer applications moving forward. JavaScript code (whether Stimulus controller or otherwise) should be implemented in a way that' resilient to both asynchronous connection and disconnection *as well as* asynchronous modification of attributes.

[hotwired/turbo-rails#638]: https://github.com/hotwired/turbo-rails/issues/638
[observe attribute changes]: https://developer.mozilla.org/en-US/docs/Web/API/Web_Components/Using_custom_elements#responding_to_attribute_changes