### PR TITLE
Remove duplicate siblings when using before/after actions

### DIFF
--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -3,6 +3,7 @@ import morph from "./actions/morph"
 
 export const StreamActions = {
   after() {
+    this.removeDuplicateSiblings()
     this.targetElements.forEach((e) => e.parentElement?.insertBefore(this.templateContent, e.nextSibling))
   },
 
@@ -12,6 +13,7 @@ export const StreamActions = {
   },
 
   before() {
+    this.removeDuplicateSiblings()
     this.targetElements.forEach((e) => e.parentElement?.insertBefore(this.templateContent, e))
   },
 

--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -3,7 +3,7 @@ import morph from "./actions/morph"
 
 export const StreamActions = {
   after() {
-    this.removeDuplicateSiblings()
+    this.removeDuplicateTargetSiblings()
     this.targetElements.forEach((e) => e.parentElement?.insertBefore(this.templateContent, e.nextSibling))
   },
 
@@ -13,7 +13,7 @@ export const StreamActions = {
   },
 
   before() {
-    this.removeDuplicateSiblings()
+    this.removeDuplicateTargetSiblings()
     this.targetElements.forEach((e) => e.parentElement?.insertBefore(this.templateContent, e))
   },
 

--- a/src/elements/stream_element.js
+++ b/src/elements/stream_element.js
@@ -76,6 +76,23 @@ export class StreamElement extends HTMLElement {
   }
 
   /**
+  * Removes duplicate siblings (by ID)
+  */
+  removeDuplicateSiblings() {
+    this.duplicateSiblings.forEach((c) => c.remove())
+  }
+
+  /**
+  * Gets the list of duplicate siblings (i.e. those with the same ID)
+  */
+  get duplicateSiblings() {
+    const existingChildren = this.targetElements.flatMap((e) => [...e.parentElement.children]).filter((c) => !!c.id)
+    const newChildrenIds = [...(this.templateContent?.children || [])].filter((c) => !!c.id).map((c) => c.id)
+
+    return existingChildren.filter((c) => newChildrenIds.includes(c.id))
+  }
+
+  /**
    * Gets the action function to be performed.
    */
   get performAction() {

--- a/src/elements/stream_element.js
+++ b/src/elements/stream_element.js
@@ -78,7 +78,7 @@ export class StreamElement extends HTMLElement {
   /**
   * Removes duplicate siblings (by ID)
   */
-  removeDuplicateSiblings() {
+  removeDuplicateTargetSiblings() {
     this.duplicateSiblings.forEach((c) => c.remove())
   }
 

--- a/src/tests/unit/stream_element_tests.js
+++ b/src/tests/unit/stream_element_tests.js
@@ -157,6 +157,17 @@ test("action=after", async () => {
   assert.isNull(element.parentElement)
 })
 
+
+test("action=after with children ID already present in target", async () => {
+  subject.fixtureHTML = `<div id="hello"><div id="top">Top</div><div id="middle">Middle</div><div id="bottom">Bottom</div></div>`
+  const element = createStreamElement("after", "top", createTemplateElement(' <div id="middle">New Middle</div> tail1 '))
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Top New Middle tail1 Bottom")
+})
+
 test("action=before", async () => {
   const element = createStreamElement("before", "hello", createTemplateElement(`<h1 id="before">Before Turbo</h1>`))
   assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
@@ -168,6 +179,17 @@ test("action=before", async () => {
   assert.ok(subject.find("div#hello"))
   assert.ok(subject.find("h1#before"))
   assert.isNull(element.parentElement)
+})
+
+
+test("action=before with children ID already present in target", async () => {
+  subject.fixtureHTML = `<div id="hello"><div id="top">Top</div><div id="middle">Middle</div><div id="bottom">Bottom</div></div>`
+  const element = createStreamElement("before", "bottom", createTemplateElement(' <div id="middle">New Middle</div> tail1 '))
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Top New Middle tail1 Bottom")
 })
 
 test("test action=refresh", async () => {


### PR DESCRIPTION
## Purpose
Resolves #1288 

## Approach
Similar to #240, simply remove the elements under the parent element which have the same ID as elements within the template.

