### PR TITLE
Bugfix: Don't use Bardo during morphing frame render (its only for non-morphing renders)

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -93,6 +93,7 @@ export class FrameController {
     if (this.element.shouldReloadWithMorph) {
       this.element.addEventListener("turbo:before-frame-render", ({ detail }) => {
         detail.render = MorphingFrameRenderer.renderElement
+        detail.preservingPermanentElements = MorphingFrameRenderer.preservingPermanentElements
       }, { once: true })
     }
 
@@ -266,11 +267,16 @@ export class FrameController {
 
     const {
       defaultPrevented,
-      detail: { render }
+      detail: { render, preservingPermanentElements }
     } = event
 
-    if (this.view.renderer && render) {
-      this.view.renderer.renderElement = render
+    if (this.view.renderer) {
+      if (render) {
+        this.view.renderer.renderElement = render
+      }
+      if (preservingPermanentElements) {
+        this.view.renderer.preservingPermanentElements = preservingPermanentElements
+      }
     }
 
     return !defaultPrevented

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -11,4 +11,7 @@ export class MorphingFrameRenderer extends FrameRenderer {
 
     morphChildren(currentElement, newElement)
   }
+  static async preservingPermanentElements(callback) {
+    return await callback()
+  }
 }

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -41,6 +41,7 @@
       <a id="link-frame-with-search-params" href="/src/tests/fixtures/frames/frame.html?key=value">Navigate #frame with ?key=value</a>
       <a id="link-nested-frame-action-advance" href="/src/tests/fixtures/frames/frame.html" data-turbo-action="advance">Navigate #frame from within with a[data-turbo-action="advance"]</a>
       <a id="link-top" href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
+      <input id="permanent-input" data-turbo-permanent>
       <form action="/src/tests/fixtures/one.html" data-turbo-frame="_top">
         <button id="form-submit-top">Visit one.html</button>
       </form>

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -306,6 +306,18 @@ test("calling reload on a frame[refresh=morph] morphs the contents", async ({ pa
   expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
 })
 
+test("calling reload on a frame[refresh=morph] preserves [data-turbo-permanent] elements", async ({ page }) => {
+  await page.click("#add-src-to-frame")
+  await page.click("#add-refresh-morph-to-frame")
+  const input = await page.locator("#permanent-input")
+
+  await input.fill("Preserve me")
+  await page.evaluate(() => document.getElementById("frame").reload())
+
+  await expect(input).toBeFocused()
+  await expect(input).toHaveValue("Preserve me")
+})
+
 test("following a link in rapid succession cancels the previous request", async ({ page }) => {
   await page.click("#outside-frame-form")
   await page.click("#outer-frame-link")


### PR DESCRIPTION
Using the turbo frame morph renderer with permanent elements results in incorrect morphs. On v8.0.5, I'm seeing duplicate elements, missing elements, and other strange behavior. This took a while to track down!

It turns out that the `data-turbo-permanent` functionality is implemented via two different strategies: `Bardo` for non-morphing renderers, and `DefaultIdiomorphCallbacks` for morphing renders.

`MorphingFrameRenderer`'s parent class `FrameRenderer` uses `Bardo`, so `MorphingFrameRenderer` continues to use that _in addition_ to `DefaultIdiomorphCallbacks`, resulting in incorrect morphs.

Looking at how the morphing and non-morphing page renderers handle this strategy switch, `MorphingPageRenderer` works correctly, because its overwriting its `preservingPermanentElements` function with a no-op, so let's just copy that strategy in `MorphingFrameRenderer`, et voila.