### PR TITLE
Delegate `Turbo.session` properties to `Turbo.config`

### DIFF
--- a/src/core/session.js
+++ b/src/core/session.js
@@ -144,6 +144,22 @@ export class Session {
     return config.drive.progressBarDelay
   }
 
+  set drive(value) {
+    config.drive.enabled = value
+  }
+
+  get drive() {
+    return config.drive.enabled
+  }
+
+  set formMode(value) {
+    config.forms.mode = value
+  }
+
+  get formMode() {
+    return config.forms.mode
+  }
+
   get location() {
     return this.history.location
   }

--- a/src/tests/fixtures/drive_disabled.html
+++ b/src/tests/fixtures/drive_disabled.html
@@ -15,7 +15,7 @@
       })
     </script>
     <script>
-      Turbo.config.drive = false
+      Turbo.config.drive.enabled = false
     </script>
   </head>
   <body>

--- a/src/tests/unit/export_tests.js
+++ b/src/tests/unit/export_tests.js
@@ -19,7 +19,26 @@ test("Turbo interface", () => {
   assert.equal(typeof Turbo.cache.clear, "function")
   assert.equal(typeof Turbo.navigator, "object")
   assert.equal(typeof Turbo.session, "object")
+  assert.equal(typeof Turbo.session.drive, "boolean")
+  assert.equal(typeof Turbo.session.formMode, "string")
   assert.equal(typeof Turbo.fetch, "function")
+})
+
+test("Session interface", () => {
+  const { session, config } = Turbo
+
+  assert.equal(true, session.drive)
+  assert.equal(true, config.drive.enabled)
+  assert.equal("on", session.formMode)
+  assert.equal("on", config.forms.mode)
+
+  session.drive = false
+  session.formMode = "off"
+
+  assert.equal(false, session.drive)
+  assert.equal(false, config.drive.enabled)
+  assert.equal("off", session.formMode)
+  assert.equal("off", config.forms.mode)
 })
 
 test("StreamActions interface", () => {


### PR DESCRIPTION
Follow-up to comment on [238ec2688b2f4907e05ad1eaeb011e93bae75995][]

[hotwired/turbo#1216][] unintentionally removed support for the `Turbo.session.drive` boolean property and the `Turbo.session.formMode` string property.

This commit re-introduces that support by delegating reads and writes to those properties to their corresponding `Turbo.config` versions.

[hotwired/turbo#1216]: https://github.com/hotwired/turbo/pull/1216
[238ec2688b2f4907e05ad1eaeb011e93bae75995]: https://github.com/hotwired/turbo/commit/238ec2688b2f4907e05ad1eaeb011e93bae75995#commitcomment-145954235