### PR TITLE
Use Bardo for all permanence handling to fix lost permanent elements in reordering morphs

### DIFF
--- a/src/core/bardo.js
+++ b/src/core/bardo.js
@@ -35,7 +35,9 @@ export class Bardo {
 
   replaceCurrentPermanentElementWithClone(permanentElement) {
     const clone = permanentElement.cloneNode(true)
+    const shouldRefocus = document.activeElement == permanentElement
     permanentElement.replaceWith(clone)
+    if (shouldRefocus) clone.focus()
   }
 
   replacePlaceholderWithPermanentElement(permanentElement) {

--- a/src/core/drive/morphing_page_renderer.js
+++ b/src/core/drive/morphing_page_renderer.js
@@ -18,10 +18,6 @@ export class MorphingPageRenderer extends PageRenderer {
     dispatch("turbo:morph", { detail: { currentElement, newElement } })
   }
 
-  async preservingPermanentElements(callback) {
-    return await callback()
-  }
-
   get renderMethod() {
     return "morph"
   }

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -11,8 +11,4 @@ export class MorphingFrameRenderer extends FrameRenderer {
 
     morphChildren(currentElement, newElement)
   }
-
-  async preservingPermanentElements(callback) {
-    return await callback()
-  }
 }

--- a/src/core/morphing.js
+++ b/src/core/morphing.js
@@ -21,13 +21,9 @@ class DefaultIdiomorphCallbacks {
     this.#beforeNodeMorphed = beforeNodeMorphed || (() => true)
   }
 
-  beforeNodeAdded = (node) => {
-    return !(node.id && node.hasAttribute("data-turbo-permanent") && document.getElementById(node.id))
-  }
-
   beforeNodeMorphed = (currentElement, newElement) => {
     if (currentElement instanceof Element) {
-      if (!currentElement.hasAttribute("data-turbo-permanent") && this.#beforeNodeMorphed(currentElement, newElement)) {
+      if (this.#beforeNodeMorphed(currentElement, newElement)) {
         const event = dispatch("turbo:before-morph-element", {
           cancelable: true,
           target: currentElement,

--- a/src/core/snapshot.js
+++ b/src/core/snapshot.js
@@ -21,6 +21,10 @@ export class Snapshot {
     return anchor ? this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`) : null
   }
 
+  getElementById(id) {
+    return this.element.querySelector(`#${id}`)
+  }
+
   get isConnected() {
     return this.element.isConnected
   }
@@ -42,7 +46,7 @@ export class Snapshot {
 
     for (const currentPermanentElement of this.permanentElements) {
       const { id } = currentPermanentElement
-      const newPermanentElement = snapshot.getPermanentElementById(id)
+      const newPermanentElement = snapshot.getElementById(id)
       if (newPermanentElement) {
         permanentElementMap[id] = [currentPermanentElement, newPermanentElement]
       }

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -15,10 +15,12 @@
       const application = Application.start()
 
       addEventListener("focusin", ({ target }) => {
-        if (target instanceof HTMLInputElement && !target.hasAttribute("data-turbo-permanent")) {
+        if (target instanceof HTMLInputElement && target.hasAttribute("data-toggle-permanent-on-focus")) {
           target.toggleAttribute("data-turbo-permanent", true)
 
-          target.addEventListener("focusout", () => target.toggleAttribute("data-turbo-permanent", false), { once: true })
+          target.addEventListener("focusout", () => {
+            target.toggleAttribute("data-turbo-permanent", false)
+          }, { once: true })
         }
       })
 
@@ -114,7 +116,7 @@
     <form method="get" data-turbo-action="replace" oninput="this.requestSubmit()">
       <label>
         Search
-        <input name="query">
+        <input id="query" name="query" data-toggle-permanent-on-focus>
       </label>
       <button>Form with params to refresh the page</button>
     </form>

--- a/src/tests/fixtures/permanent_children.html
+++ b/src/tests/fixtures/permanent_children.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <meta name="turbo-refresh-method" content="morph">
+    <meta name="turbo-refresh-scroll" content="preserve">
+
+    <title>Turbo</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <section>
+      <h1>Permanent children</h1>
+    </section>
+
+    <ul>
+      <li id="first-li">
+        <input id="first-checkbox" type="checkbox" data-turbo-permanent>
+        <label for="first-checkbox">First checkbox</label>
+      </li>
+      <li id="second-li">
+        <input id="second-checkbox" type="checkbox" data-turbo-permanent>
+        <label for="second-checkbox">Second checkbox</label>
+      </li>
+    </ul>
+
+    <form id="form" action="/__turbo/refresh" method="post" class="redirect">
+      <input type="hidden" name="path" value="/src/tests/fixtures/permanent_children.html">
+      <input type="hidden" name="sleep" value="50">
+      <input id="form-submit" type="submit" value="form[method=post]">
+    </form>
+
+  </body>
+</html>
+

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -331,6 +331,28 @@ test("it preserves data-turbo-permanent elements that don't match when their ids
   await expect(page.locator("#preserve-me")).toHaveText("Preserve me, I have a family!")
 })
 
+test("it preserves data-turbo-permanent children", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/permanent_children.html")
+
+  await page.evaluate(() => {
+    // simulate result of client-side drag-and-drop reordering
+    document.getElementById("first-li").before(document.getElementById("second-li"))
+
+    // set state of data-turbo-permanent checkbox
+    document.getElementById("second-checkbox").checked = true
+  })
+
+  // morph page back to original li ordering
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  // data-turbo-permanent checkbox should still be checked
+  assert.ok(
+    await hasSelector(page, "#second-checkbox:checked"),
+    "retains state of data-turbo-permanent child"
+  )
+})
+
 test("renders unprocessable entity responses with morphing", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -280,7 +280,7 @@ test("it preserves focus across morphs", async ({ page }) => {
   await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
 
   await expect(input).toBeFocused()
-  await expect(input).toHaveValue("Preserve me")
+  await expect(input).toHaveValue("")
 })
 
 test("it preserves focus and the [data-turbo-permanent] element's value across morphs", async ({ page }) => {


### PR DESCRIPTION
Hi folks, thanks a ton for Turbo! I have been building a collaborative issue tracker app, and being able to write 99% of it in Ruby makes me smile every time. :D

## Motivating use-case
However, one of the issue tracker app's primary use-cases has exposed a bug in the integration between Idiomorph and the `data-turbo-permanent` attribute. Each ticket contains a `data-turbo-permanent` checkbox to keep track of the client-side state of whether or not the ticket is currently expanded for that client or not. We also allow tickets to be reordered via drag-and-drop. The issue is that this `data-turbo-permanent` checkbox is not always preserved across morphs involving ticket reorders. There are other more serious ramifications of this bug (data loss!), but this is the simplest case to illustrate the issue.

## Diagnosis
I have reduced this scenario down to the failing test case in this PR. I've dug into the `DefaultIdiomorphCallbacks` integration class and into the Idiomorph code itself, and I believe the issue ultimately lies within Idiomorph, specifically here: https://github.com/bigskysoftware/idiomorph/blob/f75fba125e6e3cbfaa31dfa2af11be94455c6a38/src/idiomorph.js#L212 . In the specific reordering case captured in the test, it seems that one of the two nodes is being removed completely and then added anew with fresh DOM elements, rather than being moved and morphed. Thus, the `data-turbo-permanent` handling in `DefaultIdiomorphCallbacks` is never even run. Or at least that's my assessment. I don't claim to have a full understanding of Idiomorph's internals yet! I would love another pair of eyes on this.

## Next steps?
Also, I'm unsure of how to proceed. On one hand this could be considered a bug in Idiomorph, for not morphing as much as it conceivably could. But on the other hand, the `data-turbo-permanent` functionality is ultimately a Turbo feature, so perhaps this is within Turbo's purview, and maybe its worth looking into integrating Idiomorph with Bardo instead to provide the `data-turbo-permanent` functionality?

What are your thoughts?