### PR TITLE
Reloading a morphing frame should trigger reloads on its child morphing frames recursively

### DIFF
--- a/src/core/drive/morphing_page_renderer.js
+++ b/src/core/drive/morphing_page_renderer.js
@@ -6,17 +6,15 @@ export class MorphingPageRenderer extends PageRenderer {
   static renderElement(currentElement, newElement) {
     morphElements(currentElement, newElement, {
       callbacks: {
-        beforeNodeMorphed: element => {
-          return !super.shouldRefreshChildFrameWithMorphing(null, element)
+        beforeNodeMorphed: (node, newNode) => {
+          if (super.shouldRefreshChildFrameWithMorphing(null, node, newNode)) {
+            node.reload()
+            return false
+          }
+          return true
         }
       }
     })
-
-    for (const frame of currentElement.querySelectorAll("turbo-frame")) {
-      if (super.shouldRefreshChildFrameWithMorphing(null, frame)) {
-        frame.reload()
-      }
-    }
 
     dispatch("turbo:morph", { detail: { currentElement, newElement } })
   }

--- a/src/core/drive/morphing_page_renderer.js
+++ b/src/core/drive/morphing_page_renderer.js
@@ -1,13 +1,16 @@
 import { PageRenderer } from "./page_renderer"
 import { dispatch } from "../../util"
-import { morphElements } from "../morphing"
+import { morphElements, shouldRefreshFrameWithMorphing, closestFrameReloadableWithMorphing } from "../morphing"
 
 export class MorphingPageRenderer extends PageRenderer {
   static renderElement(currentElement, newElement) {
     morphElements(currentElement, newElement, {
       callbacks: {
         beforeNodeMorphed: (node, newNode) => {
-          if (super.shouldRefreshChildFrameWithMorphing(null, node, newNode)) {
+          if (
+            shouldRefreshFrameWithMorphing(node, newNode) &&
+              !closestFrameReloadableWithMorphing(node)
+          ) {
             node.reload()
             return false
           }

--- a/src/core/drive/morphing_page_renderer.js
+++ b/src/core/drive/morphing_page_renderer.js
@@ -35,5 +35,6 @@ function canRefreshFrame(frame) {
   return frame instanceof FrameElement &&
     frame.src &&
     frame.refresh === "morph" &&
-    !frame.closest("[data-turbo-permanent]")
+    !frame.closest("[data-turbo-permanent]") &&
+    !frame.parentElement.closest("turbo-frame[src][refresh=morph]")
 }

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -11,16 +11,15 @@ export class MorphingFrameRenderer extends FrameRenderer {
 
     morphChildren(currentElement, newElement, {
       callbacks: {
-        beforeNodeMorphed: element => {
-          return !super.shouldRefreshChildFrameWithMorphing(currentElement, element)
+        beforeNodeMorphed: (node, newNode) => {
+          if (super.shouldRefreshChildFrameWithMorphing(currentElement, node, newNode)) {
+            node.reload()
+            return false
+          }
+          return true
         }
       }
     })
-    for (const frame of currentElement.querySelectorAll("turbo-frame")) {
-      if (super.shouldRefreshChildFrameWithMorphing(currentElement, frame)) {
-        frame.reload()
-      }
-    }
   }
 
   async preservingPermanentElements(callback) {

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -1,3 +1,4 @@
+import { FrameElement } from "../../elements/frame_element"
 import { FrameRenderer } from "./frame_renderer"
 import { morphChildren } from "../morphing"
 import { dispatch } from "../../util"
@@ -9,10 +10,25 @@ export class MorphingFrameRenderer extends FrameRenderer {
       detail: { currentElement, newElement }
     })
 
-    morphChildren(currentElement, newElement)
+    morphChildren(currentElement, newElement, {
+      callbacks: {
+        beforeNodeMorphed: element => !canRefreshFrame(element, currentElement)
+      }
+    })
+    for (const frame of currentElement.querySelectorAll("turbo-frame")) {
+      if (canRefreshFrame(frame, currentElement)) frame.reload()
+    }
   }
 
   async preservingPermanentElements(callback) {
     return await callback()
   }
+}
+
+function canRefreshFrame(frame, currentFrame) {
+  return frame instanceof FrameElement &&
+    frame.src &&
+    frame.refresh === "morph" &&
+    !frame.closest("[data-turbo-permanent]") &&
+    frame.parentElement.closest("turbo-frame[src][refresh=morph]").id === currentFrame.id
 }

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -1,5 +1,5 @@
 import { FrameRenderer } from "./frame_renderer"
-import { morphChildren } from "../morphing"
+import { morphChildren, shouldRefreshFrameWithMorphing, closestFrameReloadableWithMorphing } from "../morphing"
 import { dispatch } from "../../util"
 
 export class MorphingFrameRenderer extends FrameRenderer {
@@ -12,7 +12,10 @@ export class MorphingFrameRenderer extends FrameRenderer {
     morphChildren(currentElement, newElement, {
       callbacks: {
         beforeNodeMorphed: (node, newNode) => {
-          if (super.shouldRefreshChildFrameWithMorphing(currentElement, node, newNode)) {
+          if (
+            shouldRefreshFrameWithMorphing(node, newNode) &&
+              closestFrameReloadableWithMorphing(node) === currentElement
+          ) {
             node.reload()
             return false
           }

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -1,4 +1,3 @@
-import { FrameElement } from "../../elements/frame_element"
 import { FrameRenderer } from "./frame_renderer"
 import { morphChildren } from "../morphing"
 import { dispatch } from "../../util"
@@ -12,11 +11,15 @@ export class MorphingFrameRenderer extends FrameRenderer {
 
     morphChildren(currentElement, newElement, {
       callbacks: {
-        beforeNodeMorphed: element => !canRefreshFrame(element, currentElement)
+        beforeNodeMorphed: element => {
+          return !super.shouldRefreshChildFrameWithMorphing(currentElement, element)
+        }
       }
     })
     for (const frame of currentElement.querySelectorAll("turbo-frame")) {
-      if (canRefreshFrame(frame, currentElement)) frame.reload()
+      if (super.shouldRefreshChildFrameWithMorphing(currentElement, frame)) {
+        frame.reload()
+      }
     }
   }
 
@@ -25,10 +28,3 @@ export class MorphingFrameRenderer extends FrameRenderer {
   }
 }
 
-function canRefreshFrame(frame, currentFrame) {
-  return frame instanceof FrameElement &&
-    frame.src &&
-    frame.refresh === "morph" &&
-    !frame.closest("[data-turbo-permanent]") &&
-    frame.parentElement.closest("turbo-frame[src][refresh=morph]").id === currentFrame.id
-}

--- a/src/core/morphing.js
+++ b/src/core/morphing.js
@@ -1,5 +1,7 @@
 import { Idiomorph } from "idiomorph"
+import { FrameElement } from "../elements/frame_element"
 import { dispatch } from "../util"
+import { urlsAreEqual } from "./url"
 
 export function morphElements(currentElement, newElement, { callbacks, ...options } = {}) {
   Idiomorph.morph(currentElement, newElement, {
@@ -13,6 +15,22 @@ export function morphChildren(currentElement, newElement, options = {}) {
     ...options,
     morphStyle: "innerHTML"
   })
+}
+
+export function shouldRefreshFrameWithMorphing(currentFrame, newFrame) {
+  return currentFrame instanceof FrameElement &&
+    // newFrame cannot yet be an instance of FrameElement because custom
+    // elements don't get initialized until they're attached to the DOM, so
+    // test its Element#nodeName instead
+    newFrame instanceof Element && newFrame.nodeName === "TURBO-FRAME" &&
+    currentFrame.shouldReloadWithMorph &&
+    currentFrame.id === newFrame.id &&
+    (!newFrame.getAttribute("src") || urlsAreEqual(currentFrame.src, newFrame.getAttribute("src"))) &&
+    !currentFrame.closest("[data-turbo-permanent]")
+}
+
+export function closestFrameReloadableWithMorphing(node) {
+  return node.parentElement.closest("turbo-frame[src][refresh=morph]")
 }
 
 class DefaultIdiomorphCallbacks {

--- a/src/core/morphing.js
+++ b/src/core/morphing.js
@@ -8,8 +8,9 @@ export function morphElements(currentElement, newElement, { callbacks, ...option
   })
 }
 
-export function morphChildren(currentElement, newElement) {
+export function morphChildren(currentElement, newElement, options = {}) {
   morphElements(currentElement, newElement.childNodes, {
+    ...options,
     morphStyle: "innerHTML"
   })
 }

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -1,25 +1,10 @@
-import { FrameElement } from "../elements/frame_element"
 import { Bardo } from "./bardo"
-import { urlsAreEqual } from "./url"
 
 export class Renderer {
   #activeElement = null
 
   static renderElement(currentElement, newElement) {
     // Abstract method
-  }
-
-  static shouldRefreshChildFrameWithMorphing(parentFrame, currentFrame, newFrame) {
-    return currentFrame instanceof FrameElement &&
-      // newFrame cannot yet be an instance of FrameElement because custom
-      // elements don't get initialized until they're attached to the DOM, so
-      // test its Element#nodeName instead
-      newFrame instanceof Element && newFrame.nodeName === "TURBO-FRAME" &&
-      currentFrame.shouldReloadWithMorph &&
-      currentFrame.id === newFrame.id &&
-      (!newFrame.getAttribute("src") || urlsAreEqual(currentFrame.src, newFrame.getAttribute("src"))) &&
-      !currentFrame.closest("[data-turbo-permanent]") &&
-      currentFrame.parentElement.closest("turbo-frame[src][refresh=morph]") === parentFrame
   }
 
   constructor(currentSnapshot, newSnapshot, isPreview, willRender = true) {

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -8,11 +8,16 @@ export class Renderer {
     // Abstract method
   }
 
-  static shouldRefreshChildFrameWithMorphing(parentFrame, frame) {
-    return frame instanceof FrameElement &&
-      frame.shouldReloadWithMorph &&
-      !frame.closest("[data-turbo-permanent]") &&
-      frame.parentElement.closest("turbo-frame[src][refresh=morph]") === parentFrame
+  static shouldRefreshChildFrameWithMorphing(parentFrame, currentFrame, newFrame) {
+    return currentFrame instanceof FrameElement &&
+      // newFrame cannot yet be an instance of FrameElement because custom
+      // elements don't get initialized until they're attached to the DOM, so
+      // test its Element#nodeName instead
+      newFrame instanceof Element && newFrame.nodeName === "TURBO-FRAME" &&
+      currentFrame.shouldReloadWithMorph &&
+      currentFrame.id === newFrame.id &&
+      !currentFrame.closest("[data-turbo-permanent]") &&
+      currentFrame.parentElement.closest("turbo-frame[src][refresh=morph]") === parentFrame
   }
 
   constructor(currentSnapshot, newSnapshot, isPreview, willRender = true) {

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -1,5 +1,6 @@
 import { FrameElement } from "../elements/frame_element"
 import { Bardo } from "./bardo"
+import { urlsAreEqual } from "./url"
 
 export class Renderer {
   #activeElement = null
@@ -16,6 +17,7 @@ export class Renderer {
       newFrame instanceof Element && newFrame.nodeName === "TURBO-FRAME" &&
       currentFrame.shouldReloadWithMorph &&
       currentFrame.id === newFrame.id &&
+      (!newFrame.getAttribute("src") || urlsAreEqual(currentFrame.src, newFrame.getAttribute("src"))) &&
       !currentFrame.closest("[data-turbo-permanent]") &&
       currentFrame.parentElement.closest("turbo-frame[src][refresh=morph]") === parentFrame
   }

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -1,3 +1,4 @@
+import { FrameElement } from "../elements/frame_element"
 import { Bardo } from "./bardo"
 
 export class Renderer {
@@ -5,6 +6,13 @@ export class Renderer {
 
   static renderElement(currentElement, newElement) {
     // Abstract method
+  }
+
+  static shouldRefreshChildFrameWithMorphing(parentFrame, frame) {
+    return frame instanceof FrameElement &&
+      frame.shouldReloadWithMorph &&
+      !frame.closest("[data-turbo-permanent]") &&
+      frame.parentElement.closest("turbo-frame[src][refresh=morph]") === parentFrame
   }
 
   constructor(currentSnapshot, newSnapshot, isPreview, willRender = true) {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -17,6 +17,8 @@
           target.closest("turbo-frame")?.setAttribute("refresh", "morph")
         } else if (target.id == "add-src-to-frame") {
           target.closest("turbo-frame")?.setAttribute("src", "/src/tests/fixtures/frames.html")
+        } else if (target.id == "change-frame-id-to-different-nested-child") {
+          target.closest("turbo-frame")?.setAttribute("id", "different-nested-child")
         }
       })
     </script>
@@ -90,6 +92,7 @@
         <h2>Frames: #nested-child</h2>
         <button id="add-refresh-morph-to-frame" type="button">Add [refresh="morph"] to #frame</button>
         <button id="add-src-to-frame" type="button">Add [src="/src/tests/fixtures/frames.html"] to #frame so it can be reloaded</button>
+        <button id="change-frame-id-to-different-nested-child" type="button">Change id to different-nested-child</button>
         <a href="/src/tests/fixtures/frames/frame.html">Load #nested-child</a>
         <a href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
 

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -79,6 +79,8 @@
 
     <turbo-frame id="nested-root" target="frame">
       <h2>Frames: #nested-root</h2>
+      <button id="add-refresh-morph-to-frame" type="button">Add [refresh="morph"] to #frame</button>
+      <button id="add-src-to-frame" type="button">Add [src="/src/tests/fixtures/frames.html"] to #frame so it can be reloaded</button>
       <a id="inner-outer-frame-link" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="nested-child">Inner/Outer frame link</a>
       <form data-turbo-frame="nested-child" method="get" action="/src/tests/fixtures/frames/frame.html">
         <input id="inner-outer-frame-submit" type="submit" value="Inner/Outer form submit">
@@ -86,6 +88,8 @@
 
       <turbo-frame id="nested-child">
         <h2>Frames: #nested-child</h2>
+        <button id="add-refresh-morph-to-frame" type="button">Add [refresh="morph"] to #frame</button>
+        <button id="add-src-to-frame" type="button">Add [src="/src/tests/fixtures/frames.html"] to #frame so it can be reloaded</button>
         <a href="/src/tests/fixtures/frames/frame.html">Load #nested-child</a>
         <a href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
 
@@ -95,6 +99,7 @@
       </turbo-frame>
 
       <turbo-frame id="nested-child-navigate-top" target="_top">
+        <button id="add-src-to-frame" type="button">Add [src="/src/tests/fixtures/frames.html"] to #frame so it can be reloaded</button>
         <form method="get" action="/src/tests/fixtures/one.html">
           <input id="nested-child-navigate-top-submit" type="submit" value="Nested Child form submit">
         </form>

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -306,7 +306,7 @@ test("calling reload on a frame[refresh=morph] morphs the contents", async ({ pa
   expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
 })
 
-test("calling reload on a frame[refresh=morph] reloads descendant frame[refresh=morph] with morphing", async ({ page }) => {
+test("calling reload on a frame[refresh=morph] reloads descendant frame[refresh=morph]s via reload() as well", async ({ page }) => {
   await page.click("#nested-root #add-refresh-morph-to-frame")
   await page.click("#nested-root #add-src-to-frame")
   await page.click("#nested-child #add-refresh-morph-to-frame")
@@ -319,6 +319,21 @@ test("calling reload on a frame[refresh=morph] reloads descendant frame[refresh=
   expect(await nextEventOnTarget(page, "nested-root", "turbo:before-frame-morph")).toBeTruthy()
   expect(await nextEventOnTarget(page, "nested-child", "turbo:before-frame-morph")).toBeTruthy()
   expect(await noNextEventOnTarget(page, "nested-child-navigate-top", "turbo:before-frame-morph")).toBeTruthy()
+})
+
+test("calling reload on a frame[refresh=morph] morphs descendant frame[refresh=morph] normally if the id no longer matches", async ({ page }) => {
+  await page.click("#nested-root #add-refresh-morph-to-frame")
+  await page.click("#nested-root #add-src-to-frame")
+  await page.click("#nested-child #add-refresh-morph-to-frame")
+  await page.click("#nested-child #add-src-to-frame")
+  await page.click("#nested-child #change-frame-id-to-different-nested-child")
+
+  await page.evaluate(() => document.getElementById("nested-root").reload())
+
+  expect(await nextEventOnTarget(page, "nested-root", "turbo:before-frame-morph")).toBeTruthy()
+  expect(await noNextEventOnTarget(page, "different-nested-child", "turbo:before-frame-morph")).toBeTruthy()
+  assert.ok(await hasSelector(page, "#nested-child"))
+  assert.notOk(await hasSelector(page, "#different-nested-child"))
 })
 
 test("calling reload on a frame[refresh=morph] preserves [data-turbo-permanent] elements", async ({ page }) => {

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -306,6 +306,21 @@ test("calling reload on a frame[refresh=morph] morphs the contents", async ({ pa
   expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
 })
 
+test("calling reload on a frame[refresh=morph] reloads descendant frame[refresh=morph] with morphing", async ({ page }) => {
+  await page.click("#nested-root #add-refresh-morph-to-frame")
+  await page.click("#nested-root #add-src-to-frame")
+  await page.click("#nested-child #add-refresh-morph-to-frame")
+  await page.click("#nested-child #add-src-to-frame")
+  await page.click("#nested-child-navigate-top #add-src-to-frame")
+
+  await page.evaluate(() => document.getElementById("nested-root").reload())
+
+  // Only the frames marked with refresh="morph" uses morphing
+  expect(await nextEventOnTarget(page, "nested-root", "turbo:before-frame-morph")).toBeTruthy()
+  expect(await nextEventOnTarget(page, "nested-child", "turbo:before-frame-morph")).toBeTruthy()
+  expect(await noNextEventOnTarget(page, "nested-child-navigate-top", "turbo:before-frame-morph")).toBeTruthy()
+})
+
 test("calling reload on a frame[refresh=morph] preserves [data-turbo-permanent] elements", async ({ page }) => {
   await page.click("#add-src-to-frame")
   await page.click("#add-refresh-morph-to-frame")


### PR DESCRIPTION
Hi folks, here's what seems to me to be the next obvious step after #1192 changed `reload()` to morph a morphing frame.

## Example scenario
Imagine the following page structure: a morphing page with a morphing frame that itself includes another morphing frame, i.e.
```
Morphing Page > Morphing Frame Child > Morphing Frame Grandchild
```

## Status Quo
Refreshing `Morphing Page` already triggers morphing `reload()`s on both the `Morphing Frame Child` and on `Morphing Frame Grandchild`. However, manually triggering `reload()` on `Morphing Frame Child` does NOT trigger a `reload()` on `Morphing Frame Grandchild`, but rather does a full non-morphing render. This seems inconsistent and surprising.

## With this PR
Morphing pages now only trigger `reload()`s on their immediate morphing frame children, and then leaves it up to them to trigger `reload()`s on their own immediate morphing frame children, and so on down. This makes the reload behavior consistent no matter where the reload is initially triggered.

What do you think?