### PR TITLE
Refactor `renderElement` static methods to instance methods

### DIFF
--- a/src/core/drive/error_renderer.js
+++ b/src/core/drive/error_renderer.js
@@ -2,7 +2,7 @@ import { activateScriptElement } from "../../util"
 import { Renderer } from "../renderer"
 
 export class ErrorRenderer extends Renderer {
-  static renderElement(currentElement, newElement) {
+  renderElement(currentElement, newElement) {
     const { documentElement, body } = document
 
     documentElement.replaceChild(newElement, body)

--- a/src/core/drive/morphing_page_renderer.js
+++ b/src/core/drive/morphing_page_renderer.js
@@ -4,7 +4,7 @@ import { dispatch } from "../../util"
 import { morphElements } from "../morphing"
 
 export class MorphingPageRenderer extends PageRenderer {
-  static renderElement(currentElement, newElement) {
+  renderElement(currentElement, newElement) {
     morphElements(currentElement, newElement, {
       callbacks: {
         beforeNodeMorphed: element => !canRefreshFrame(element)

--- a/src/core/drive/page_renderer.js
+++ b/src/core/drive/page_renderer.js
@@ -2,7 +2,7 @@ import { activateScriptElement, waitForLoad } from "../../util"
 import { Renderer } from "../renderer"
 
 export class PageRenderer extends Renderer {
-  static renderElement(currentElement, newElement) {
+  renderElement(currentElement, newElement) {
     if (document.body && newElement instanceof HTMLBodyElement) {
       document.body.replaceWith(newElement)
     } else {

--- a/src/core/frames/frame_renderer.js
+++ b/src/core/frames/frame_renderer.js
@@ -2,7 +2,7 @@ import { activateScriptElement, nextRepaint } from "../../util"
 import { Renderer } from "../renderer"
 
 export class FrameRenderer extends Renderer {
-  static renderElement(currentElement, newElement) {
+  renderElement(currentElement, newElement) {
     const destinationRange = document.createRange()
     destinationRange.selectNodeContents(currentElement)
     destinationRange.deleteContents()
@@ -15,8 +15,8 @@ export class FrameRenderer extends Renderer {
     }
   }
 
-  constructor(delegate, currentSnapshot, newSnapshot, renderElement, isPreview, willRender = true) {
-    super(currentSnapshot, newSnapshot, renderElement, isPreview, willRender)
+  constructor(delegate, currentSnapshot, newSnapshot, isPreview, willRender = true) {
+    super(currentSnapshot, newSnapshot, isPreview, willRender)
     this.delegate = delegate
   }
 

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -3,7 +3,7 @@ import { morphChildren } from "../morphing"
 import { dispatch } from "../../util"
 
 export class MorphingFrameRenderer extends FrameRenderer {
-  static renderElement(currentElement, newElement) {
+  renderElement(currentElement, newElement) {
     dispatch("turbo:before-frame-morph", {
       target: currentElement,
       detail: { currentElement, newElement }

--- a/src/core/renderer.js
+++ b/src/core/renderer.js
@@ -3,7 +3,7 @@ import { Bardo } from "./bardo"
 export class Renderer {
   #activeElement = null
 
-  static renderElement(currentElement, newElement) {
+  renderElement(currentElement, newElement) {
     // Abstract method
   }
 
@@ -12,7 +12,6 @@ export class Renderer {
     this.newSnapshot = newSnapshot
     this.isPreview = isPreview
     this.willRender = willRender
-    this.renderElement = this.constructor.renderElement
     this.promise = new Promise((resolve, reject) => (this.resolvingFunctions = { resolve, reject }))
   }
 

--- a/src/elements/stream_element.js
+++ b/src/elements/stream_element.js
@@ -26,7 +26,7 @@ import { nextRepaint } from "../util"
  *   </turbo-stream>
  */
 export class StreamElement extends HTMLElement {
-  static async renderElement(newElement) {
+  async renderElement(newElement) {
     await newElement.performAction()
   }
 
@@ -164,7 +164,7 @@ export class StreamElement extends HTMLElement {
     return new CustomEvent("turbo:before-stream-render", {
       bubbles: true,
       cancelable: true,
-      detail: { newStream: this, render: StreamElement.renderElement }
+      detail: { newStream: this, render: this.renderElement }
     })
   }
 


### PR DESCRIPTION
Now that https://github.com/hotwired/turbo/pull/1028 has landed, this seems like an obvious win. Any reason not to do this?