### PR TITLE
Enable frame morphing for data-turbo-frame links and forms if the URL doesn't change

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -91,10 +91,9 @@ export class FrameController {
   }
 
   sourceURLReloaded() {
-    const { refresh, src } = this.element
+    const { src } = this.element
 
-    this.#shouldMorphFrame = src && refresh === "morph"
-
+    this.#shouldMorphFrame = this.element.shouldReloadWithMorph
     this.element.removeAttribute("complete")
     this.element.src = null
     this.element.src = src
@@ -234,6 +233,9 @@ export class FrameController {
     const frame = this.#findFrameElement(formSubmission.formElement, formSubmission.submitter)
 
     frame.delegate.proposeVisitIfNavigatedWithAction(frame, getVisitAction(formSubmission.submitter, formSubmission.formElement, frame))
+    if (frame.src === response.response.url && frame.shouldReloadWithMorph) {
+      frame.delegate.#shouldMorphFrame = true
+    }
     frame.delegate.loadResponse(response)
 
     if (!formSubmission.isSafe) {
@@ -343,6 +345,9 @@ export class FrameController {
     frame.delegate.proposeVisitIfNavigatedWithAction(frame, getVisitAction(submitter, element, frame))
 
     this.#withCurrentNavigationElement(element, () => {
+      if (frame.src === url && frame.shouldReloadWithMorph) {
+        frame.delegate.#shouldMorphFrame = true
+      }
       frame.src = url
     })
   }

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -267,7 +267,7 @@ test("following a link to a page with a matching frame does not dispatch a turbo
   )
 })
 
-test("following a link within a frame which has a target set navigates the target frame without morphing even when frame[refresh=morph]", async ({ page }) => {
+test("following a link within a frame which has a target set navigates the target frame without morphing even when frame[refresh=morph] if the url changes", async ({ page }) => {
   await page.click("#add-refresh-morph-to-frame")
   await page.click("#hello a")
   await nextBeat()
@@ -277,7 +277,7 @@ test("following a link within a frame which has a target set navigates the targe
   await expect(page.locator("#frame h2")).toHaveText("Frame: Loaded")
 })
 
-test("navigating from within replaces the contents even with turbo-frame[refresh=morph]", async ({ page }) => {
+test("navigating from within replaces the contents even with turbo-frame[refresh=morph] if the url changes", async ({ page }) => {
   await page.click("#add-refresh-morph-to-frame")
   await page.click("#link-frame")
   await nextBeat()
@@ -285,6 +285,38 @@ test("navigating from within replaces the contents even with turbo-frame[refresh
   expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-render")).toBeTruthy()
   expect(await noNextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
   await expect(page.locator("#frame h2")).toHaveText("Frame: Loaded")
+})
+
+test("following a link that targets a frame with refresh morph morphs the page if the url doesn't change", async ({ page }) => {
+  await page.click("#add-refresh-morph-to-frame")
+  await page.click("#outside-frame-form")
+  await nextBeat()
+
+  expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-render")).toBeTruthy()
+  expect(await noNextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
+
+  await page.click("#outside-frame-form")
+  await nextBeat()
+
+  expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
+  expect(await noNextEventOnTarget(page, "frame", "turbo:before-frame-render")).toBeTruthy()
+})
+
+test("submitting a form that targets a frame with refresh morph morphs the page if the url doesn't change", async ({ page }) => {
+  test.setTimeout(3000)
+  expect(await noNextEventOnTarget(page, "frame", "turbo:before-frame-render")).toBeTruthy()
+  await page.click("#add-refresh-morph-to-frame")
+  await page.click("#button-frame-action-advance")
+  await nextBeat()
+
+  expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-render")).toBeTruthy()
+  expect(await noNextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
+
+  await page.click("#button-frame-action-advance")
+  await nextBeat()
+
+  expect(await nextEventOnTarget(page, "frame", "turbo:before-frame-morph")).toBeTruthy()
+  expect(await noNextEventOnTarget(page, "frame", "turbo:before-frame-render")).toBeTruthy()
 })
 
 test("calling reload on a frame replaces the contents", async ({ page }) => {


### PR DESCRIPTION
Hi folks, this PR is aimed at enabling another specific use-case for morphing `turbo-frame[refresh=morph]` that isn't currently supported.

## Status quo:
Right now, if one clicks a link or submits a form that contains `data-turbo-frame`, that target frame is replaced without morphing, even if `refresh=morph`. This makes sense if the frame is navigating to an entirely new URL, because its not a "refresh" operation at all.

## Motivating use-case:
However, I propose that in some common idiomatic situations these operations are indeed refreshes, and therefore should be morphed. Imagine a turbo-frame with a list of blog posts, and an external new post form, which targets the blog post list. I submit for your consideration that in this situation, submitting the form is indeed refreshing the frame.

```html
<turbo-frame id="posts" src="/posts" refresh="morph">
  <ul>
    <li><a href="/posts/3">Post 3</a></li>
    <li><a href="/posts/2">Post 2</a></li>
    <li><a href="/posts/1">Post 1</a></li>
  </ul>
</turbo-frame>

<form action="/posts" data-turbo-frame="posts">
  <input name="title">
  <input type="submit">
</form>
```

## Proposed solution
If a morphing frame's URL changes from the result of a link click or form submission, keep the current behavior and render it with the normal replacement rendering. If the URL does NOT change, however, consider it a refresh and use morphing.

## Final notes
Please let me know if this PR is an idea worth considering for merging, and if so I'll do a bit more work here. I think it could use some more tests to fully nail down all the permutations it implies, and also an extract method refactoring... setting the `FrameController`'s private `#shouldMorphFrame` property from the outside reeks of Feature Envy, and I'm surprised its even legal JavaScript!

Thanks for your time, and continued work on Turbo!