### PR TITLE
Better testing timeouts for less painful development

### DIFF
--- a/playwright.config.js
+++ b/playwright.config.js
@@ -7,7 +7,7 @@ const config = {
       use: {
         ...devices["Desktop Chrome"],
         contextOptions: {
-          timeout: 60000
+          timeout: 10000
         },
         hasTouch: true
       }
@@ -17,20 +17,21 @@ const config = {
       use: {
         ...devices["Desktop Firefox"],
         contextOptions: {
-          timeout: 60000
+          timeout: 10000
         },
         hasTouch: true
       }
     }
   ],
-  browserStartTimeout: 60000,
+  timeout: 10000,
+  browserStartTimeout: 10000,
   retries: 2,
   testDir: "./src/tests/",
   testMatch: /(functional|integration)\/.*_tests\.js/,
   webServer: {
     command: "yarn start",
     url: "http://localhost:9000/src/tests/fixtures/test.js",
-    timeout: 120 * 1000,
+    timeout: 10000,
     // eslint-disable-next-line no-undef
     reuseExistingServer: !process.env.CI
   },


### PR DESCRIPTION
## Background
* Many tests assert that certain browser events occurred using a helper named `nextEventNamed`. To deal with asynchronicity, this helper waits until  the specified event occurs. If the event never occurs, it loops forever until the the default Playwright test timeout is reached.
* The default Playwright test timeout is 30 seconds.
* Playwright is configured to retry failing tests for a max of 3 total runs.
* Playwright is configured to run tests on both Chromium and Firefox.

## Pain
When developing Turbo and running tests frequently, if even one of these event assertion fails, we're looking at a _minimum of 3 minutes_ before the test run completes! And that's the best-case scenario of running only one individual test... often we're running many, and if one test fails, often other tests are failing too.
 
## Proposed resolution
Configure Playwright's global default to 10 seconds. This still seems high to me, to be honest, but I figured it was best to be conservative. If we're okay with lowering it further to perhaps 5 or even 3 seconds, I'm happy to do this. Note that if one or two tests truly need a longer timeout, they can be set individually with a simple `test.setTimeout(ms)` call at the beginning of the test.

## Additional notes
While I was in the Playwright config file, I lowered some other seemingly excessive timeouts, also to 10 seconds. I figure if Chrome or Firefox doesn't start up within 10 seconds, its probably not going to start in 60 seconds either. The tiny node fixture testing server had a 2 minute startup timeout!