### PR TITLE
[WIP] Stream Versioning

### DIFF
--- a/src/core/streams/stream_actions.js
+++ b/src/core/streams/stream_actions.js
@@ -1,5 +1,24 @@
 import { session } from "../"
 import { morphElements, morphChildren } from "../morphing"
+import { attributeToNumber } from "../../util"
+
+export function versionCheck(streamElement, targetElement) {
+  const targetVersion = attributeToNumber(targetElement.getAttribute("data-turbo-version"))
+  const streamVersion = streamElement.version
+
+  const streamVersionPresent = streamVersion != null
+  const targetVersionPresent = targetVersion != null
+
+  if (!streamVersionPresent && targetVersionPresent) {
+    return false // Don't allow an unversioned element to replace a versioned element
+  } else if (streamVersionPresent && !targetVersionPresent) {
+    return true // Do allow a versioned element to replace an unversioned element
+  } else if (streamVersionPresent && targetVersionPresent) {
+    return streamVersion > targetVersion
+  } else {
+    return true
+  }
+}
 
 export const StreamActions = {
   after() {
@@ -28,6 +47,11 @@ export const StreamActions = {
     const method = this.getAttribute("method")
 
     this.targetElements.forEach((targetElement) => {
+      if (!versionCheck(this, targetElement)) {
+        console.debug("Skipping replace action because the version is not greater than the target element's version.")
+        return
+      }
+
       if (method === "morph") {
         morphElements(targetElement, this.templateContent)
       } else {
@@ -40,6 +64,11 @@ export const StreamActions = {
     const method = this.getAttribute("method")
 
     this.targetElements.forEach((targetElement) => {
+      if (!versionCheck(this, targetElement)) {
+        console.debug("Skipping replace action because the version is not greater than the target element's version.")
+        return
+      }
+
       if (method === "morph") {
         morphChildren(targetElement, this.templateContent)
       } else {

--- a/src/elements/stream_element.js
+++ b/src/elements/stream_element.js
@@ -1,5 +1,5 @@
 import { StreamActions } from "../core/streams/stream_actions"
-import { nextRepaint } from "../util"
+import { attributeToNumber, nextRepaint } from "../util"
 
 // <turbo-stream action=replace target=id><template>...
 
@@ -143,6 +143,10 @@ export class StreamElement extends HTMLElement {
    */
   get targets() {
     return this.getAttribute("targets")
+  }
+
+  get version() {
+    return attributeToNumber(this.getAttribute("version"))
   }
 
   /**

--- a/src/tests/unit/stream_element_tests.js
+++ b/src/tests/unit/stream_element_tests.js
@@ -134,8 +134,117 @@ test("action=replace", async () => {
   assert.isNull(element.parentElement)
 })
 
+test("action=replace with greater version", async () => {
+  subject.fixtureHTML = `<div><div id="hello" data-turbo-version="1">Hello Turbo</div></div>`
+  
+  const element = createStreamElement("replace", "hello", createTemplateElement(`<h1 id="hello" data-turbo-version="2">Goodbye Turbo</h1>`), { version: "2" })
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.ok(subject.find("div#hello"))
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Goodbye Turbo")
+  assert.notOk(subject.find("div#hello"))
+  assert.ok(subject.find("h1#hello"))
+  assert.isNull(element.parentElement)
+})
+
+test("action=replace with older version", async () => {
+  subject.fixtureHTML = `<div><div id="hello" data-turbo-version="2">Hello Turbo</div></div>`
+
+  const element = createStreamElement("replace", "hello", createTemplateElement(`<h1 id="hello" data-turbo-version="1">Goodbye Turbo</h1>`), { version: "1" })
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.ok(subject.find("div#hello"))
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.ok(subject.find("div#hello"))
+})
+
+test("action=replace with no version", async () => {
+  subject.fixtureHTML = `<div><div id="hello" data-turbo-version="1">Hello Turbo</div></div>`
+
+  const element = createStreamElement("replace", "hello", createTemplateElement(`<h1 id="hello">Goodbye Turbo</h1>`))
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.ok(subject.find("div#hello"))
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.notOk(subject.find("h1#hello"))
+  assert.isNull(element.parentElement)
+})
+
+test("action=replace with a version", async () => {
+  const element = createStreamElement("replace", "hello", createTemplateElement(`<h1 id="hello" data-turbo-version="1">Goodbye Turbo</h1>`), { version: "1" })
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.ok(subject.find("div#hello"))
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Goodbye Turbo")
+  assert.notOk(subject.find("div#hello"))
+  assert.ok(subject.find("h1#hello"))
+  assert.isNull(element.parentElement)
+})
+
 test("action=update", async () => {
   const element = createStreamElement("update", "hello", createTemplateElement("Goodbye Turbo"))
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Goodbye Turbo")
+  assert.isNull(element.parentElement)
+})
+
+test("action=update with greater version", async () => {
+  subject.fixtureHTML = `<div><div id="hello" data-turbo-version="1">Hello Turbo</div></div>`
+
+  const element = createStreamElement("update", "hello", createTemplateElement(`<h1 id="hello" data-turbo-version="2">Goodbye Turbo</h1>`), { version: "2" })
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Goodbye Turbo")
+  assert.isNull(element.parentElement)
+})
+
+test("action=update with older version", async () => {
+  subject.fixtureHTML = `<div><div id="hello" data-turbo-version="2">Hello Turbo</div></div>`
+
+  const element = createStreamElement("update", "hello", createTemplateElement(`<h1 id="hello" data-turbo-version="1">Goodbye Turbo</h1>`), { version: "1" })
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.isNull(element.parentElement)
+})
+
+test("action=update with no version", async () => {
+  subject.fixtureHTML = `<div><div id="hello" data-turbo-version="1">Hello Turbo</div></div>`
+
+  const element = createStreamElement("update", "hello", createTemplateElement(`<h1 id="hello">Goodbye Turbo</h1>`))
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+
+  subject.append(element)
+  await nextAnimationFrame()
+
+  assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
+  assert.isNull(element.parentElement)
+})
+
+test("action=update with a version", async () => {
+  const element = createStreamElement("update", "hello", createTemplateElement(`<h1 id="hello" data-turbo-version="1">Goodbye Turbo</h1>`), { version: "1" })
   assert.equal(subject.find("#hello")?.textContent, "Hello Turbo")
 
   subject.append(element)

--- a/src/util.js
+++ b/src/util.js
@@ -254,3 +254,11 @@ export function debounce(fn, delay) {
     timeoutId = setTimeout(callback, delay)
   }
 }
+
+export function isNumeric(n) {
+  return !isNaN(parseFloat(n)) && isFinite(n)
+}
+
+export function attributeToNumber(value) {
+  return isNumeric(value) ? Number(value) : null
+}


### PR DESCRIPTION
This still needs some additional more tests and docs prior to merging but I wanted to open this for comment on the general approach.

This is a proposed solution for #906

This PR introduces the concept of versioning for Turbo stream `update` and `replace` actions, see the above issue for more background.

Functionality:

* Add the attribute `data-steam-version` on stream target element. 
* Add the attribute `version` on the `turbo-stream` element. 
* During `update` and `replace`: If versions are present, they are parsed as numeric values and compared, actions are rejected unless the new version is greater than the existing version. 

The current API presented here does not attempt to automatically manage the versions within template content, i.e. an update looks like this:

```html
<turbo-stream action="update" target="item" version="1">
  <template>
    <div id="item" data-turbo-version="1"></div>
  </template>
</turbo-stream>
```

Versioning information ends up duplicated both in the `turbo-stream` and the template content. 

In theory we could search the template content for the target selector and propagate the version down from the `turbo-stream` element. But I think this is "too smart" and likely to have edge cases. I suspect most usage of `turbo` is via higher level libraries, like `turbo-rails`, and I think those layers should be able to mask the duplication given more domain knowledge.

Let me know what ya think and I'll wrap this up. 