### PR TITLE
Pin Ubuntu to deal with older playwright failing to install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
We should upgrade playwright but then I ran into some dependency issues that `npx playwright install-deps` wouldn't fix. Not willing to spend time on this now.