### PR TITLE
Remove unused `getHistoryMethodForAction` function in Visit

### DIFF
--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -386,16 +386,6 @@ export class Visit {
 
   // Private
 
-  getHistoryMethodForAction(action) {
-    switch (action) {
-      case "replace":
-        return history.replaceState
-      case "advance":
-      case "restore":
-        return history.pushState
-    }
-  }
-
   hasPreloadedResponse() {
     return typeof this.response == "object"
   }


### PR DESCRIPTION
It's extracted to util file in #618 but the origin was left behind.

I'd like to run the test locally but playright doesn't play well with alpine so it's not tested 😬 The changes do look relatively straightforward though.