### PR TITLE
Reproduce redirect to file download fails in turbo frame

### DIFF
--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -111,6 +111,10 @@
       <a id="missing-frame-link" href="/src/tests/fixtures/frames/frame.html">Missing frame</a>
       <a id="missing-page-link" href="/missing.html">Missing page</a>
       <a id="unvisitable-page-link" href="/src/tests/fixtures/frames/unvisitable.html">Unvisitable page</a>
+      <a id="non-html" href="/src/tests/fixtures/svg.svg">Non-HTML</a>
+      <a id="unknown-non-html" href="/__turbo/file.unknown_svg">Unknown non-HTML</a>
+      <a id="redirect-to-non-html" href="__turbo/redirect?path=/src/tests/fixtures/svg.svg">Redirect to non-HTML</a>
+      <a id="redirect-to-unknown-non-html" href="__turbo/redirect?path=/__turbo/file.unknown_svg">Redirect to unknown non-HTML</a>
     </turbo-frame>
 
     <turbo-frame id="body-script" target="body-script">


### PR DESCRIPTION
Reproduce https://github.com/hotwired/turbo/issues/1253 in tests

Interestingly, "following a link to a non html file changes page src" has different behaviour across chrome and firefox
Also, "following a link to an unknown non html file changes page src" is not directly related to reproducing this issue but it's a disparity between turbo drive and turbo frame behaviour.