### PR TITLE
Verify with the browser adapter before initiating link prefetching

### DIFF
--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -117,6 +117,17 @@ export class Navigator {
     }
   }
 
+  // Link prefetching
+
+  linkPrefetchingIsEnabledForLocation(location) {
+    // Not all adapters implement linkPrefetchingIsEnabledForLocation
+    if (typeof this.adapter.linkPrefetchingIsEnabledForLocation === "function") {
+      return this.adapter.linkPrefetchingIsEnabledForLocation(location)
+    }
+
+    return true
+  }
+
   // Visit delegate
 
   visitStarted(visit) {

--- a/src/core/native/browser_adapter.js
+++ b/src/core/native/browser_adapter.js
@@ -72,6 +72,12 @@ export class BrowserAdapter {
 
   visitRendered(_visit) {}
 
+  // Link prefetching
+
+  linkPrefetchingIsEnabledForLocation(location) {
+    return true
+  }
+
   // Form Submission Delegate
 
   formSubmissionStarted(_formSubmission) {

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -232,7 +232,8 @@ export class Session {
   canPrefetchRequestToLocation(link, location) {
     return (
       this.elementIsNavigatable(link) &&
-        locationIsVisitable(location, this.snapshot.rootLocation)
+      locationIsVisitable(location, this.snapshot.rootLocation) &&
+      this.navigator.linkPrefetchingIsEnabledForLocation(location)
     )
   }
 

--- a/src/tests/unit/native_adapter_support_tests.js
+++ b/src/tests/unit/native_adapter_support_tests.js
@@ -11,6 +11,7 @@ class NativeAdapterSupportTest {
   finishedVisitRequests = []
   startedFormSubmissions = []
   finishedFormSubmissions = []
+  linkPrefetchRequests = []
 
   // Adapter interface
 
@@ -53,6 +54,10 @@ class NativeAdapterSupportTest {
   }
 
   pageInvalidated() {}
+
+  linkPrefetchingIsEnabledForLocation(location) {
+    this.linkPrefetchRequests.push(location)
+  }
 }
 
 let adapter
@@ -203,4 +208,14 @@ test("visit follows redirect and proposes replace visit to adapter", async () =>
   const [visit] = adapter.proposedVisits
   assert.equal(visit.location, redirectedLocation)
   assert.equal(visit.options.action, "replace")
+})
+
+test ("link prefetch requests verify with adapter", async () => {
+  const locatable = window.location.toString()
+
+  Turbo.navigator.linkPrefetchingIsEnabledForLocation(locatable)
+  assert.equal(adapter.linkPrefetchRequests.length, 1)
+
+  const [location] = adapter.linkPrefetchRequests
+  assert.equal(location, locatable)
 })


### PR DESCRIPTION
This resolves an issue found in the Hotwire Native iOS library. See: https://github.com/hotwired/hotwire-native-ios/issues/12

Link prefetching is being triggered on link taps on iOS, which has unintended consequences in the Hotwire Native iOS library. This causes double `GET` requests when crossing the `default` and `modal` context session boundaries, which use separate `WKWebView` instances.

Additionally, some urls correspond to natively implemented screens, not webviews, so link prefetching is undesirable for these cases, too.

This change allows the Hotwire Native libraries to have control of the link prefetching behavior. We will disable link prefetching in the native libraries where link hovering is not available.

Here are the corresponding Hotwire Native iOS and Hotwire Native Android PRs:
- https://github.com/hotwired/hotwire-native-ios/pull/62
- https://github.com/hotwired/hotwire-native-android/pull/78