### PR TITLE
rename unprocessable entity to unprocessable content to match Rack

### DIFF
--- a/src/tests/fixtures/422.html
+++ b/src/tests/fixtures/422.html
@@ -1,13 +1,13 @@
 <html>
   <head>
-    <title>Unprocessable Entity</title>
+    <title>Unprocessable Content</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
   <body>
-    <h1>Unprocessable Entity</h1>
+    <h1>Unprocessable Content</h1>
 
     <turbo-frame id="frame">
-      <h2>Frame: Unprocessable Entity</h2>
+      <h2>Frame: Unprocessable Content</h2>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/422_morph.html
+++ b/src/tests/fixtures/422_morph.html
@@ -3,14 +3,14 @@
     <meta name="turbo-refresh-method" content="morph">
     <meta name="turbo-refresh-scroll" content="preserve">
 
-    <title>Unprocessable Entity</title>
+    <title>Unprocessable Content</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
   <body>
-    <h1>Unprocessable Entity</h1>
+    <h1>Unprocessable Content</h1>
 
     <turbo-frame id="frame">
-      <h2>Frame: Unprocessable Entity</h2>
+      <h2>Frame: Unprocessable Content</h2>
     </turbo-frame>
   </body>
 </html>

--- a/src/tests/fixtures/422_tall.html
+++ b/src/tests/fixtures/422_tall.html
@@ -1,13 +1,13 @@
 <html>
   <head>
-    <title>Unprocessable Entity</title>
+    <title>Unprocessable Content</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
   </head>
   <body>
     <main style="height: 1000vh">
-      <h1>Unprocessable Entity</h1>
+      <h1>Unprocessable Content</h1>
       <turbo-frame id="frame">
-        <h2>Frame: Unprocessable Entity</h2>
+        <h2>Frame: Unprocessable Content</h2>
       </turbo-frame>
     </main>
   </body>

--- a/src/tests/fixtures/form.html
+++ b/src/tests/fixtures/form.html
@@ -138,11 +138,11 @@
     </div>
     <hr>
     <div id="reject">
-      <form class="unprocessable_entity" action="/__turbo/reject" method="post" style="margin-top:100vh">
+      <form class="unprocessable_content" action="/__turbo/reject" method="post" style="margin-top:100vh">
         <input type="hidden" name="status" value="422">
         <input type="submit">
       </form>
-      <form class="unprocessable_entity_with_tall_form" action="/__turbo/reject/tall" method="post">
+      <form class="unprocessable_content_with_tall_form" action="/__turbo/reject/tall" method="post">
         <input type="hidden" name="status" value="422">
         <input type="submit" style="margin-top:1000vh">
       </form>
@@ -263,7 +263,7 @@
         <input type="hidden" name="status" value="204">
         <input type="submit" style="">
       </form>
-      <form class="unprocessable_entity" action="/__turbo/reject" method="post">
+      <form class="unprocessable_content" action="/__turbo/reject" method="post">
         <input type="hidden" name="status" value="422">
         <input type="submit">
       </form>

--- a/src/tests/fixtures/page_refresh.html
+++ b/src/tests/fixtures/page_refresh.html
@@ -132,7 +132,7 @@
     <button id="add-new-assets">Add new assets</button>
 
     <div id="reject">
-      <form class="unprocessable_entity" action="/__turbo/reject/morph" method="post" style="margin-top:100vh">
+      <form class="unprocessable_content" action="/__turbo/reject/morph" method="post" style="margin-top:100vh">
         <input type="hidden" name="status" value="422">
         <input type="submit">
       </form>

--- a/src/tests/functional/form_submission_tests.js
+++ b/src/tests/functional/form_submission_tests.js
@@ -576,22 +576,22 @@ test("input named action with action attribute", async ({ page }) => {
   assert.equal(getSearchParam(page.url(), "query"), "1")
 })
 
-test("invalid form submission with unprocessable entity status", async ({ page }) => {
-  await page.click("#reject form.unprocessable_entity input[type=submit]")
+test("invalid form submission with unprocessable content status", async ({ page }) => {
+  await page.click("#reject form.unprocessable_content input[type=submit]")
   await nextBody(page)
 
   const title = await page.locator("h1")
-  assert.equal(await title.textContent(), "Unprocessable Entity", "renders the response HTML")
+  assert.equal(await title.textContent(), "Unprocessable Content", "renders the response HTML")
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
 
 test("invalid form submission with long form", async ({ page }) => {
-  await scrollToSelector(page, "#reject form.unprocessable_entity_with_tall_form input[type=submit]")
-  await page.click("#reject form.unprocessable_entity_with_tall_form input[type=submit]")
+  await scrollToSelector(page, "#reject form.unprocessable_content_with_tall_form input[type=submit]")
+  await page.click("#reject form.unprocessable_content_with_tall_form input[type=submit]")
   await nextBody(page)
 
   const title = await page.locator("h1")
-  assert.equal(await title.textContent(), "Unprocessable Entity", "renders the response HTML")
+  assert.equal(await title.textContent(), "Unprocessable Content", "renders the response HTML")
   assert(await isScrolledToTop(page), "page is scrolled to the top")
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
@@ -891,8 +891,8 @@ test("frame form submission within a frame submits the Turbo-Frame header", asyn
   assert.ok(fetchOptions.headers["Turbo-Frame"], "submits with the Turbo-Frame header")
 })
 
-test("invalid frame form submission with unprocessable entity status", async ({ page }) => {
-  await page.click("#frame form.unprocessable_entity input[type=submit]")
+test("invalid frame form submission with unprocessable content status", async ({ page }) => {
+  await page.click("#frame form.unprocessable_content input[type=submit]")
 
   assert.ok(await formSubmitStarted(page), "fires turbo:submit-start")
   await nextEventNamed(page, "turbo:before-fetch-request")
@@ -906,7 +906,7 @@ test("invalid frame form submission with unprocessable entity status", async ({ 
 
   const title = await page.locator("#frame h2")
   assert.ok(await hasSelector(page, "#reject form"), "only replaces frame")
-  assert.equal(await title.textContent(), "Frame: Unprocessable Entity")
+  assert.equal(await title.textContent(), "Frame: Unprocessable Content")
 })
 
 test("invalid frame form submission with internal server error status", async ({ page }) => {

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -331,15 +331,15 @@ test("it preserves data-turbo-permanent elements that don't match when their ids
   await expect(page.locator("#preserve-me")).toHaveText("Preserve me, I have a family!")
 })
 
-test("renders unprocessable entity responses with morphing", async ({ page }) => {
+test("renders unprocessable content responses with morphing", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 
-  await page.click("#reject form.unprocessable_entity input[type=submit]")
+  await page.click("#reject form.unprocessable_content input[type=submit]")
   await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
   await nextBody(page)
 
   const title = await page.locator("h1")
-  assert.equal(await title.textContent(), "Unprocessable Entity", "renders the response HTML")
+  assert.equal(await title.textContent(), "Unprocessable Content", "renders the response HTML")
   assert.notOk(await hasSelector(page, "#frame form.reject"), "replaces entire page")
 })
 


### PR DESCRIPTION
This is an alternative to https://github.com/hotwired/turbo/pull/1277 which looks abandoned.