### PR TITLE
Remove catch in extractForeignFrameElement

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -450,9 +450,6 @@ export class FrameController {
         await element.loaded
         return await this.extractForeignFrameElement(element)
       }
-    } catch (error) {
-      console.error(error)
-      return new FrameElement()
     }
 
     return null


### PR DESCRIPTION
This catches the error thrown in activateElement:
 `Matching <turbo-frame id={id} element has a source URL which references itself`

Then an empty FrameElement is returned, it ends up calling FrameRenderer.renderElement. when calling currentElement.appendChild, the browser calls connectedCallback on our empty element (presumably nothing is actually being appended). The error that actually gets thrown from all this is
  `undefined is not an object (evaluating 'this.delegate.connect')`
coming from the constructor of FrameElement.

So this catch just obscures the original error and takes a lot of digging to find the true cause.