### PR TITLE
Bump actions/upload-artifact to v4 to get CI green again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,7 @@ jobs:
     - name: Firefox Test
       run: yarn test:browser --project=firefox
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       with:
         name: turbo-dist
         path: dist/*


### PR DESCRIPTION
All PRs are currently red because GitHub has intentionally broken `actions/upload-artifact@v3` to force an upgrade to v4.

From any recent CI run:
> Error: This request has been automatically failed because it uses a deprecated version of `actions/upload-artifact: v3`. Learn more: https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/

Below are the breaking changes for v4, none of which seem to apply to Turbo, so a simple bump should do.
https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes