### PR TITLE
Support Directional View Transitions

### DIFF
--- a/src/core/drive/history.js
+++ b/src/core/drive/history.js
@@ -87,13 +87,8 @@ export class History {
         this.location = new URL(window.location.href)
         const { restorationIdentifier, restorationIndex } = turbo
         this.restorationIdentifier = restorationIdentifier
-        const direction = this.restorationVisitDirection(restorationIdentifier, restorationIndex)
-
-        this.delegate.historyPoppedToLocationWithRestorationIdentifierAndDirection(
-          this.location,
-          restorationIdentifier,
-          direction
-        )
+        const direction = restorationIndex > this.currentIndex ? "forward" : "back"
+        this.delegate.historyPoppedToLocationWithRestorationIdentifierAndDirection(this.location, restorationIdentifier, direction)
         this.currentIndex = restorationIndex
       }
     }
@@ -113,17 +108,5 @@ export class History {
 
   pageIsLoaded() {
     return this.pageLoaded || document.readyState == "complete"
-  }
-
-  restorationVisitDirection(restorationIdentifier, restorationIndex) {
-    const historyDirection = restorationIndex > this.currentIndex ? "forward" : "back"
-    const originalVisitDirection =
-      this.restorationData[restorationIdentifier]?.direction === "back" ? "back" : "forward"
-
-    return historyDirection === "forward" ? originalVisitDirection : this.oppositeDirection(originalVisitDirection)
-  }
-
-  oppositeDirection(direction) {
-    return direction === "forward" ? "back" : "forward"
   }
 }

--- a/src/core/drive/history.js
+++ b/src/core/drive/history.js
@@ -87,8 +87,13 @@ export class History {
         this.location = new URL(window.location.href)
         const { restorationIdentifier, restorationIndex } = turbo
         this.restorationIdentifier = restorationIdentifier
-        const direction = restorationIndex > this.currentIndex ? "forward" : "back"
-        this.delegate.historyPoppedToLocationWithRestorationIdentifierAndDirection(this.location, restorationIdentifier, direction)
+        const direction = this.restorationVisitDirection(restorationIdentifier, restorationIndex)
+
+        this.delegate.historyPoppedToLocationWithRestorationIdentifierAndDirection(
+          this.location,
+          restorationIdentifier,
+          direction
+        )
         this.currentIndex = restorationIndex
       }
     }
@@ -108,5 +113,17 @@ export class History {
 
   pageIsLoaded() {
     return this.pageLoaded || document.readyState == "complete"
+  }
+
+  restorationVisitDirection(restorationIdentifier, restorationIndex) {
+    const historyDirection = restorationIndex > this.currentIndex ? "forward" : "back"
+    const originalVisitDirection =
+      this.restorationData[restorationIdentifier]?.direction === "back" ? "back" : "forward"
+
+    return historyDirection === "forward" ? originalVisitDirection : this.oppositeDirection(originalVisitDirection)
+  }
+
+  oppositeDirection(direction) {
+    return direction === "forward" ? "back" : "forward"
   }
 }

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -92,6 +92,7 @@ export class Visit {
     this.shouldCacheSnapshot = shouldCacheSnapshot
     this.acceptsStreamResponse = acceptsStreamResponse
     this.direction = direction || Direction[action]
+    this.viewTransitionDirection = this.calculateViewTransitionDirection()
   }
 
   get adapter() {
@@ -428,6 +429,16 @@ export class Visit {
     if (this.frame) {
       cancelAnimationFrame(this.frame)
       delete this.frame
+    }
+  }
+
+  calculateViewTransitionDirection() {
+    const originalVisitDirection = this.restorationData.direction === "back" ? "back" : "forward"
+
+    if (this.direction === "forward") {
+      return originalVisitDirection
+    } else {
+      return originalVisitDirection === "forward" ? "back" : "forward"
     }
   }
 }

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -34,6 +34,8 @@ export function registerAdapter(adapter) {
  * @param options Options to apply
  * @param options.action Type of history navigation to apply ("restore",
  * "replace" or "advance")
+ * @param options.direction Logical direction of the navigation, applies to
+ * view transitions ("forward", "back")
  * @param options.historyChanged Specifies whether the browser history has
  * already been changed for this visit or not
  * @param options.referrer Specifies the referrer of this visit such that

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -250,8 +250,9 @@ export class Session {
   followedLinkToLocation(link, location) {
     const action = this.getActionForLink(link)
     const acceptsStreamResponse = link.hasAttribute("data-turbo-stream")
+    const direction = link.getAttribute("data-turbo-visit-direction")
 
-    this.visit(location.href, { action, acceptsStreamResponse })
+    this.visit(location.href, { action, acceptsStreamResponse, direction })
   }
 
   // Navigator delegate

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -275,7 +275,7 @@ export class Session {
   visitStarted(visit) {
     if (!visit.acceptsStreamResponse) {
       markAsBusy(document.documentElement)
-      this.view.markVisitDirection(visit.direction)
+      this.view.markVisitDirection(visit.viewTransitionDirection)
     }
     extendURLWithDeprecatedProperties(visit.location)
     if (!visit.silent) {

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -95,6 +95,10 @@ export class Session {
   visit(location, options = {}) {
     const frameElement = options.frame ? document.getElementById(options.frame) : null
 
+    if (["forward", "back"].includes(options.direction)) {
+      this.history.updateRestorationData({ direction: options.direction })
+    }
+
     if (frameElement instanceof FrameElement) {
       const action = options.action || getVisitAction(frameElement)
 


### PR DESCRIPTION
Addresses https://github.com/hotwired/turbo/issues/1374

This adds support for setting the direction of visit's view transition, and applies the logical direction when navigating stack history.

### Example
Annotate an anchor tag with its logical direction, which will be applied to the view transition.

```html
<!-- /cars/1/offers.html -->

<!-- equivalent to: Turbo.visit("/cars/1", { direction: "back" }) -->
<a href="/cars/1" `data-turbo-visit-direction="back"` />
```

After visiting the above link, subsequently using the browser's back button will apply a _forward_ view transition. The end result is that the original as well as subsequent back/forward button visits will perform a view transition using the intuitive direction of the navigation.

### TODO
- [ ] more testing
- [ ] write tests?

