### PR TITLE
Ensure response content is loaded before requestFinish is called.

### DIFF
--- a/src/http/fetch_request.js
+++ b/src/http/fetch_request.js
@@ -154,11 +154,16 @@ export class FetchRequest {
     })
     if (event.defaultPrevented) {
       this.delegate.requestPreventedHandlingResponse(this, fetchResponse)
-    } else if (fetchResponse.succeeded) {
-      this.delegate.requestSucceededWithResponse(this, fetchResponse)
     } else {
-      this.delegate.requestFailedWithResponse(this, fetchResponse)
+      await fetchResponse.responseHTML
+
+      if (fetchResponse.succeeded) {
+        this.delegate.requestSucceededWithResponse(this, fetchResponse)
+      } else {
+        this.delegate.requestFailedWithResponse(this, fetchResponse)
+      }
     }
+
     return fetchResponse
   }
 

--- a/src/tests/helpers/mock_fetch.js
+++ b/src/tests/helpers/mock_fetch.js
@@ -1,0 +1,34 @@
+const nativeFetch = window.fetch
+
+async function mockFetch(url, options) {
+  return await mockFetch._mockResponse || nativeFetch(url, options)
+}
+mockFetch.mockResponse = function(response) {
+  this._mockResponse = response
+}
+
+class MockFetchResponse {
+  constructor({ url, ok, headers, status, redirected, data }) {
+    this.url = url
+    this.ok = ok || true
+    this.headers = headers || new Headers({
+      "Content-Type": "text/html"
+    })
+    this.status = status || 200
+    this.redirected = redirected || false
+    this.data = data || (() => "Hello, world!")
+  }
+
+  async text() {
+    await Promise.resolve()
+    return this.data()
+  }
+
+  clone() {
+    return new MockFetchResponse(this)
+  }
+}
+
+window.fetch = mockFetch
+
+export { mockFetch as fetch, MockFetchResponse }

--- a/src/tests/unit/fetch_request_tests.js
+++ b/src/tests/unit/fetch_request_tests.js
@@ -1,0 +1,53 @@
+import { assert } from "@open-wc/testing"
+import { fetch, MockFetchResponse } from "../helpers/mock_fetch"
+import { FetchRequest } from "../../http/fetch_request"
+
+// A mock for the FetchRequest delegate that records the order of method calls
+class LoggingFetchRequestDelegate {
+  constructor(log) {
+    [
+      "prepareRequest",
+      "requestStarted",
+      "requestSucceededWithResponse",
+      "requestFailedWithResponse",
+      "requestPreventedHandlingResponse",
+      "requestErrored",
+      "requestFinished"
+    ].forEach(method => {
+      this[method] = (request, ...args) => {
+        log.push(method)
+      }
+    })
+  }
+}
+
+let eventLog, delegate, request
+
+setup(() => {
+  eventLog = []
+  delegate = new LoggingFetchRequestDelegate(eventLog)
+  request = new FetchRequest(delegate, "GET", new URL("http://example.com"))
+})
+
+test("fetch response body is recieved before the FetchRequest declares it is finished", async () => {
+  fetch.mockResponse(new MockFetchResponse({
+    data: () => {
+      eventLog.push("recieveData")
+      return "Hello, world!"
+    }
+  }))
+
+  await request.perform()
+
+  assert.deepEqual(eventLog, [
+    "prepareRequest",
+    "requestStarted",
+    "recieveData",
+    "requestSucceededWithResponse",
+    "requestFinished"
+  ])
+})
+
+teardown(() => {
+  fetch.mockResponse(null)
+})


### PR DESCRIPTION
Previously the response content was loaded asynchronously within the FetchRequest delegate. Consequently, the requestFinished callback was called prior this finishing. The requestFinished callback triggers the toggling of the busy attribute on `<html>/<turbo-frame>/<form>`, the triggering of the afterSubmit callback which toggles the disabled state of form submitters, and the the turbo:submit-end event.

For clients with high latency, this could result in janky behaviour when the busy/disabled state is removed a noticeable time before the response is loaded and rendered.

This change removes this delay by ensuring the response is loaded and available prior to notifying the delegate and continuing execution of the Turbo behaviour.