### PR TITLE
Add 2 second timeouts to infinitely-looping assertions

### DIFF
--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -322,6 +322,7 @@ test("waits for some time, but renders if CSS takes too much to load", async ({ 
   })
 
   await page.click("#additional-assets-link")
+  await sleep(3000)
   await nextEventNamed(page, "turbo:render")
 
   assert.equal(await page.textContent("h1"), "Additional assets")

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -96,9 +96,15 @@ export async function nextPageRefresh(page, timeout = 500) {
   return sleep(pageRefreshDebouncePeriod + timeout)
 }
 
+const timeout = 2000
+
 export async function nextEventNamed(page, eventName, expectedDetail = {}) {
   let record
+  const startTime = new Date()
   while (!record) {
+    if (new Date() - startTime > timeout) {
+      throw new Error(`Event ${eventName} with ${JSON.stringify(expectedDetail)} wasn't dispatched within ${timeout}ms`)
+    }
     const records = await readEventLogs(page, 1)
     record = records.find(([name, detail]) => {
       return name == eventName && Object.entries(expectedDetail).every(([key, value]) => detail[key] === value)
@@ -109,7 +115,11 @@ export async function nextEventNamed(page, eventName, expectedDetail = {}) {
 
 export async function nextEventOnTarget(page, elementId, eventName) {
   let record
+  const startTime = new Date()
   while (!record) {
+    if (new Date() - startTime > timeout) {
+      throw new Error(`Element ${elementId} didn't dispatch event ${eventName} within ${timeout}ms`)
+    }
     const records = await readEventLogs(page, 1)
     record = records.find(([name, _, id]) => name == eventName && id == elementId)
   }
@@ -130,7 +140,11 @@ export async function listenForEventOnTarget(page, elementId, eventName) {
 
 export async function nextBodyMutation(page) {
   let record
+  const startTime = new Date()
   while (!record) {
+    if (new Date() - startTime > timeout) {
+      throw new Error(`body mutation didn't occur within ${timeout}ms`)
+    }
     [record] = await readBodyMutationLogs(page, 1)
   }
   return record[0]
@@ -143,7 +157,11 @@ export async function noNextBodyMutation(page) {
 
 export async function nextAttributeMutationNamed(page, elementId, attributeName) {
   let record
+  const startTime = new Date()
   while (!record) {
+    if (new Date() - startTime > timeout) {
+      throw new Error(`Element ${elementId}'s ${attributeName} attribute mutation didn't occur within ${timeout}ms`)
+    }
     const records = await readMutationLogs(page, 1)
     record = records.find(([name, id]) => name == attributeName && id == elementId)
   }


### PR DESCRIPTION
Following up upon https://github.com/hotwired/turbo/pull/1317 , this time without adding a timeout parameter!

With this commit, I'm seeing the minimum wait for a failure result drop from 0:60 to 0:15 when one of these assertions is failing.