### PR TITLE
Revert fetch to call window.fetch directly again

### DIFF
--- a/src/http/fetch.js
+++ b/src/http/fetch.js
@@ -3,15 +3,13 @@ import { LimitedSet } from "../core/drive/limited_set"
 
 export const recentRequests = new LimitedSet(20)
 
-const nativeFetch = window.fetch
-
 function fetchWithTurboHeaders(url, options = {}) {
   const modifiedHeaders = new Headers(options.headers || {})
   const requestUID = uuid()
   recentRequests.add(requestUID)
   modifiedHeaders.append("X-Turbo-Request-Id", requestUID)
 
-  return nativeFetch(url, {
+  return window.fetch(url, {
     ...options,
     headers: modifiedHeaders
   })


### PR DESCRIPTION
This reverts the change made in #1077 in order to restore compatibility with other JS libraries that depend on modifying `window.fetch`.

Related issue: #1371

## Why

(copied from #1371)

If another library is instantiated after Turbo and modifies `window.fetch`, `Turbo.fetch` ignores any modified behavior because Turbo still references the original `window.fetch` at the time of its own instantiation.

Concretely, this means that users have to write a hack in Rails applications to wait to import Turbo until everything else is imported and instantiated. For example, with Datadog RUM, this is the required workaround (without this revert):

```js
import { datadogRum } from "@datadog/browser-rum";

function importTurbo(counter = 0) {
  if (datadogRum.getInternalContent() || counter > 100) {
    import("@hotwired/turbo-rails");
  } else {
    setTimeout(() => {
      importTurbo(counter + 1);
    }, 30);
  }
}

datadogRum.init({...});
importTurbo();
```