### PR TITLE
Clone cached DOM for previews to prevent any mutation leakage

### DIFF
--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -19,6 +19,8 @@ export class PageView extends View {
     const shouldMorphPage = this.isPageRefresh(visit) && this.snapshot.shouldMorphPage
     const rendererClass = shouldMorphPage ? MorphingPageRenderer : PageRenderer
 
+    if (isPreview) snapshot = snapshot.clone()
+
     const renderer = new rendererClass(this.snapshot, snapshot, isPreview, willRender)
 
     if (!renderer.shouldRender) {


### PR DESCRIPTION
My quick stab at a solution for #1385

Not sure what is the best way to test this. I couldn't see where the "preview" behaviour was being tested at the moment. Happy to be pointed in the right direction.