### PR TITLE
Prevent slow turbo frame requests from resetting cookies

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -65,6 +65,7 @@ export class FrameController {
   disconnect() {
     if (this.#connected) {
       this.#connected = false
+      this.#currentFetchRequest?.cancel()
       this.appearanceObserver.stop()
       this.formLinkClickObserver.stop()
       this.linkInterceptor.stop()


### PR DESCRIPTION
This pull request fixes an issue where slow `turbo-frame` requests can inadvertently reset cookies.

For example, let's say we have a form that changes the `session` and a `<turbo-frame>` that loads a slow endpoint:

```html
<form method="post" action="/session">
  <button type="submit">Change Session</button>
</form>

<turbo-frame id="slow" src="/slow"></turbo-frame>
```

Here's a potential flow:

1. Page loads, `<turbo-frame>` starts loading
2. User taps "Change Session"
3. That request completes and the session cookie is updated
4. `<turbo-frame>` request completes later and resets the session cookie to what it was in step 1.

Reproduction: https://github.com/domchristie/turbo_frame_cookies_test

The fix is to cancel the frame's current fetch request when the `<turbo-frame>` disconnects.