### PR TITLE
Update playwright

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # See comments in devcontainer.json for details of setting the playwright tag.
-ARG PLAYWRIGHT_TAG="v1.30.0-focal"
+ARG PLAYWRIGHT_TAG="v1.51.1-focal"
 FROM mcr.microsoft.com/playwright:${PLAYWRIGHT_TAG}
 
 WORKDIR /app

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,5 +1,5 @@
 # See comments in devcontainer.json for details of setting the playwright tag.
-ARG PLAYWRIGHT_TAG="v1.51.1-focal"
+ARG PLAYWRIGHT_TAG="v1.51.1-jammy"
 FROM mcr.microsoft.com/playwright:${PLAYWRIGHT_TAG}
 
 WORKDIR /app

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     //
     // pick '...-arm64' version if running on Apple Silicon.
     "args": {
-      "PLAYWRIGHT_TAG": "v1.51.1-focal"
+      "PLAYWRIGHT_TAG": "v1.51.1-jammy"
     }
   },
   // Add the IDs of extensions you want installed when the container is created.

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -12,7 +12,7 @@
     //
     // pick '...-arm64' version if running on Apple Silicon.
     "args": {
-      "PLAYWRIGHT_TAG": "v1.30.0-focal"
+      "PLAYWRIGHT_TAG": "v1.51.1-focal"
     }
   },
   // Add the IDs of extensions you want installed when the container is created.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     - uses: actions/checkout@v3
     - uses: actions/setup-node@v3
       with:
-        node-version: '16'
+        node-version: '22'
         cache: 'yarn'
     - run: yarn install --frozen-lockfile
     - run: yarn run playwright install --with-deps

--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '18'
+          node-version: '22'
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile

--- a/.github/workflows/dev-builds.yml
+++ b/.github/workflows/dev-builds.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
         with:
-          node-version: '16'
+          node-version: '18'
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "lint": "eslint . --ext .js"
   },
   "engines": {
-    "node": ">= 14"
+    "node": ">= 18"
   }
 }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
   },
   "devDependencies": {
     "@open-wc/testing": "^3.1.7",
-    "@playwright/test": "~1.30.0",
+    "@playwright/test": "~1.51.1",
     "@rollup/plugin-node-resolve": "13.1.3",
     "@web/dev-server-esbuild": "^0.3.3",
     "@web/test-runner": "^0.15.0",

--- a/src/core/view.js
+++ b/src/core/view.js
@@ -14,8 +14,8 @@ export class View {
   scrollToAnchor(anchor) {
     const element = this.snapshot.getElementForAnchor(anchor)
     if (element) {
-      this.scrollToElement(element)
       this.focusElement(element)
+      this.scrollToElement(element)
     } else {
       this.scrollToPosition({ x: 0, y: 0 })
     }

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -11,7 +11,7 @@
     <h1>One</h1>
 
     <!--styles ensure that the element will be scrolled to top when navigated to via an anchored link -->
-    <a name="named-anchor">Named anchor</a>
+    <a name="named-anchor"></a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
     <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/visit.html">Redirection link</a></p>
     <p><a id="page-refresh-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html">Page refresh link</a></p>

--- a/src/tests/fixtures/one.html
+++ b/src/tests/fixtures/one.html
@@ -11,7 +11,7 @@
     <h1>One</h1>
 
     <!--styles ensure that the element will be scrolled to top when navigated to via an anchored link -->
-    <a name="named-anchor"></a>
+    <a name="named-anchor">Named anchor</a>
     <div id="element-id" style="margin-top: 1em; height: 200vh">An element with an ID</div>
     <p><a id="redirection-link" href="/__turbo/redirect?path=/src/tests/fixtures/visit.html">Redirection link</a></p>
     <p><a id="page-refresh-link" data-turbo-action="replace" href="/src/tests/fixtures/page_refresh.html">Page refresh link</a></p>

--- a/src/tests/functional/scroll_restoration_tests.js
+++ b/src/tests/functional/scroll_restoration_tests.js
@@ -2,7 +2,7 @@ import { test } from "@playwright/test"
 import { assert } from "chai"
 import {
   nextBeat,
-  nextBody,
+  reloadPage,
   scrollPosition,
   scrollToSelector
 } from "../helpers/page"
@@ -20,10 +20,7 @@ test("reloading after scrolling", async ({ page }) => {
   const { y: yAfterScrolling } = await scrollPosition(page)
   assert.notEqual(yAfterScrolling, 0)
 
-  await Promise.all([
-    nextBody(page),
-    page.evaluate(() => window.location.reload())
-  ])
+  await reloadPage(page)
   const { y: yAfterReloading } = await scrollPosition(page)
   assert.notEqual(yAfterReloading, 0)
 })

--- a/src/tests/functional/scroll_restoration_tests.js
+++ b/src/tests/functional/scroll_restoration_tests.js
@@ -1,6 +1,11 @@
 import { test } from "@playwright/test"
 import { assert } from "chai"
-import { nextBeat, scrollPosition, scrollToSelector } from "../helpers/page"
+import {
+  nextBeat,
+  nextBody,
+  scrollPosition,
+  scrollToSelector
+} from "../helpers/page"
 
 test("landing on an anchor", async ({ page }) => {
   await page.goto("/src/tests/fixtures/scroll_restoration.html#three")
@@ -15,7 +20,10 @@ test("reloading after scrolling", async ({ page }) => {
   const { y: yAfterScrolling } = await scrollPosition(page)
   assert.notEqual(yAfterScrolling, 0)
 
-  await page.reload()
+  await Promise.all([
+    nextBody(page),
+    page.evaluate(() => window.location.reload())
+  ])
   const { y: yAfterReloading } = await scrollPosition(page)
   assert.notEqual(yAfterReloading, 0)
 })

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -8,6 +8,7 @@ import {
   isScrolledToTop,
   nextAttributeMutationNamed,
   nextBeat,
+  nextBody,
   nextEventNamed,
   noNextAttributeMutationNamed,
   pathname,
@@ -343,7 +344,10 @@ test("Visit direction attribute on a replace visit", async ({ page }) => {
 test("Turbo history state after a reload", async ({ page }) => {
   await page.click("#same-origin-link")
   await nextEventNamed(page, "turbo:load")
-  await page.reload()
+  await Promise.all([
+    nextBody(page),
+    page.evaluate(() => window.location.reload())
+  ])
   assert.equal(
     await page.evaluate(() => window.history.state.turbo.restorationIndex),
     1,

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -47,6 +47,7 @@ test("programmatically visiting a same-origin location", async ({ page }) => {
 test("skip programmatically visiting a cross-origin location falls back to window.location", async ({ page }) => {
   const urlBeforeVisit = page.url()
   await visitLocation(page, "about:blank")
+  await nextBeat()
 
   const urlAfterVisit = page.url()
   assert.notEqual(urlBeforeVisit, urlAfterVisit)

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -8,11 +8,11 @@ import {
   isScrolledToTop,
   nextAttributeMutationNamed,
   nextBeat,
-  nextBody,
   nextEventNamed,
   noNextAttributeMutationNamed,
   pathname,
   readEventLogs,
+  reloadPage,
   resetMutationLogs,
   scrollToSelector,
   visitAction,
@@ -344,10 +344,7 @@ test("Visit direction attribute on a replace visit", async ({ page }) => {
 test("Turbo history state after a reload", async ({ page }) => {
   await page.click("#same-origin-link")
   await nextEventNamed(page, "turbo:load")
-  await Promise.all([
-    nextBody(page),
-    page.evaluate(() => window.location.reload())
-  ])
+  await reloadPage(page)
   assert.equal(
     await page.evaluate(() => window.history.state.turbo.restorationIndex),
     1,

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -90,6 +90,13 @@ export function nextBody(_page, timeout = 500) {
   return sleep(timeout)
 }
 
+export async function reloadPage(page, timeout = 500) {
+  await Promise.all([
+    nextBody(page, timeout),
+    page.evaluate(() => window.location.reload())
+  ])
+}
+
 export async function nextPageRefresh(page, timeout = 500) {
   const pageRefreshDebouncePeriod = await page.evaluate(() => window.Turbo.session.pageRefreshDebouncePeriod)
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -177,13 +177,12 @@
     "@types/sinon-chai" "^3.2.3"
     chai-a11y-axe "^1.3.2"
 
-"@playwright/test@~1.30.0":
-  version "1.30.0"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.30.0.tgz#8c0c4930ff2c7be7b3ec3fd434b2a3b4465ed7cb"
-  integrity sha512-SVxkQw1xvn/Wk/EvBnqWIq6NLo1AppwbYOjNLmyU0R1RoQ3rLEBtmjTnElcnz8VEtn11fptj1ECxK0tgURhajw==
+"@playwright/test@~1.51.1":
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.51.1.tgz#75357d513221a7be0baad75f01e966baf9c41a2e"
+  integrity sha512-nM+kEaTSAoVlXmMPH10017vn3FSiFqr/bh4fKg9vmAdMfd9SDqRZNvPSiAHADc/itWak+qPvMPZQOPwCBW7k7Q==
   dependencies:
-    "@types/node" "*"
-    playwright-core "1.30.0"
+    playwright "1.51.1"
 
 "@rollup/plugin-node-resolve@13.1.3":
   version "13.1.3"
@@ -1715,7 +1714,7 @@ fs.realpath@^1.0.0:
   resolved "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
-fsevents@~2.3.2:
+fsevents@2.3.2, fsevents@~2.3.2:
   version "2.3.2"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
   integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
@@ -2623,6 +2622,20 @@ playwright-core@1.30.0:
   version "1.30.0"
   resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.30.0.tgz#de987cea2e86669e3b85732d230c277771873285"
   integrity sha512-7AnRmTCf+GVYhHbLJsGUtskWTE33SwMZkybJ0v6rqR1boxq2x36U7p1vDRV7HO2IwTZgmycracLxPEJI49wu4g==
+
+playwright-core@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.51.1.tgz#d57f0393e02416f32a47cf82b27533656a8acce1"
+  integrity sha512-/crRMj8+j/Nq5s8QcvegseuyeZPxpQCZb6HNk3Sos3BlZyAknRjoyJPFWkpNn8v0+P3WiwqFF8P+zQo4eqiNuw==
+
+playwright@1.51.1:
+  version "1.51.1"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.51.1.tgz#ae1467ee318083968ad28d6990db59f47a55390f"
+  integrity sha512-kkx+MB2KQRkyxjYPc3a0wLZZoDczmppyGJIvQ43l+aZihkaVvmu/21kiyaHeHjiFxjxNNFnUncKmcGIyOojsaw==
+  dependencies:
+    playwright-core "1.51.1"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 playwright@^1.22.2:
   version "1.30.0"


### PR DESCRIPTION
Updates playwright version to 1.51.1 and sets the same version in devcontainer and Docker configs.

I had to fix some tests:

- Fix tests that used `page.reload()` that was broken due to a known bug in playwright. See https://github.com/microsoft/playwright/issues/28264 for details.
- Fixed a test related to named anchor navigation, when an element is too small (0 pixels in the case of a naked anchor), `scrollingIntoView` would put the scroll position in a place where the element is not completely visible, so focusing it would re-scroll to the middle of it, messing up the `scrollIntoView` position.  I solved it by shifting the order of both method calls, first `focusElement` and finally `scrollToElement`. 


