### PR TITLE
Propagate turbo:submit-end events from data-turbo-method links

### DIFF
--- a/src/observers/form_link_click_observer.js
+++ b/src/observers/form_link_click_observer.js
@@ -65,7 +65,7 @@ export class FormLinkClickObserver {
     this.delegate.submittedFormLinkToLocation(link, location, form)
 
     document.body.appendChild(form)
-    form.addEventListener("turbo:submit-end", () => form.remove(), { once: true })
+    form.addEventListener("turbo:submit-end", () => requestAnimationFrame(() => form.remove()), { once: true })
     requestAnimationFrame(() => form.requestSubmit())
   }
 }


### PR DESCRIPTION
Clicking a `data-turbo-method` link submits an ephemeral form. The form is removed synchronously in a `turbo:submit-end` handler, blocking propagation to parent elements.

This causes issues for ancestors that act on turbo:submit-end, like closing a dialog on redirect responses.

To fix, defer form removal to allow the event to fully propagate.