### PR TITLE
Respect prefers-reduced-motion

### DIFF
--- a/src/core/drive/page_snapshot.js
+++ b/src/core/drive/page_snapshot.js
@@ -71,7 +71,7 @@ export class PageSnapshot extends Snapshot {
   }
 
   get prefersViewTransitions() {
-    return this.headSnapshot.getMetaValue("view-transition") === "same-origin"
+    return this.headSnapshot.getMetaValue("view-transition") === "same-origin" && !window?.matchMedia("(prefers-reduced-motion: reduce)")?.matches
   }
 
   get shouldMorphPage() {

--- a/src/core/drive/page_snapshot.js
+++ b/src/core/drive/page_snapshot.js
@@ -71,7 +71,7 @@ export class PageSnapshot extends Snapshot {
   }
 
   get prefersViewTransitions() {
-    return this.headSnapshot.getMetaValue("view-transition") === "same-origin" && !window?.matchMedia("(prefers-reduced-motion: reduce)")?.matches
+    return this.headSnapshot.getMetaValue("view-transition") === "same-origin" && !window.matchMedia("(prefers-reduced-motion: reduce)").matches
   }
 
   get shouldMorphPage() {

--- a/src/tests/functional/drive_view_transition_tests.js
+++ b/src/tests/functional/drive_view_transition_tests.js
@@ -21,6 +21,15 @@ test("navigating triggers the view transition", async ({ page }) => {
   assert.isTrue(called)
 })
 
+test("navigating does not trigger a view transition when prefers reduced motion is reduce", async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' })
+  await page.locator("#go-right").click()
+  await nextBody(page)
+
+  const called = await page.evaluate(`window.startViewTransitionCalled`)
+  assert.isUndefined(called)
+})
+
 test("navigating does not trigger a view transition when meta tag not present", async ({ page }) => {
   await page.locator("#go-other").click()
   await nextBody(page)


### PR DESCRIPTION
Closes: https://github.com/hotwired/turbo/issues/1408

This PR checks wether the user has requested reduced motion via their OS/browser and disables view-transitions if that is the case, see: https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion

The way it is currently made it will assume [no-preference](https://developer.mozilla.org/en-US/docs/Web/CSS/@media/prefers-reduced-motion#no-preference) by default in case a browser does not support the media query, matchMedia, or does not have window available