### PR TITLE
Make progress bar's styling customizable via CSS properties

### DIFF
--- a/src/core/drive/progress_bar.js
+++ b/src/core/drive/progress_bar.js
@@ -8,13 +8,15 @@ export class ProgressBar {
   static get defaultCSS() {
     return unindent`
       .turbo-progress-bar {
-        position: fixed;
-        display: block;
-        top: 0;
-        left: 0;
-        height: 3px;
-        background: #0076ff;
-        z-index: 2147483647;
+        position: var(--progress-bar-position, fixed);
+        display: var(--progress-bar-display, block);
+        top: var(--progress-bar-top, 0);
+        left: var(--progress-bar-left, 0);
+        height: var(--progress-bar-height, 3px);
+        background-color: var(--progress-bar-backgroundc-color, #0076ff);
+        border-radius: var(--progress-bar-border-radius, 0);
+        box-shadow: var(--progress-bar-box-shadow, none);
+        z-index: var(--progress-bar-z-index, 2147483647);
         transition:
           width ${ProgressBar.animationDuration}ms ease-out,
           opacity ${ProgressBar.animationDuration / 2}ms ${ProgressBar.animationDuration / 2}ms ease-in;


### PR DESCRIPTION
Add CSS custom properties to control the progress bar's appearance, and added border-radius and box-shadow. All properties default to the original values to maintain backwards compatibility.

Custom properties are better than overrides (`.turbo-progress-bar { background: red; }`) since it's the standard way to make components customizable, plus you get runtime changes (via JS) and theming (`:root[data-theme="dark"] { --progress-bar-background-color: gray; }`) for free.

Example:
```css
:root {
  /* An indigo-colored, floating progress bar with rounded corners and a shadow */
  --progress-bar-top: 1rem;
  --progress-bar-height: 4px;
  --progress-bar-background-color: rgb(99, 102, 241);
  --progress-bar-border-radius: 2px;
  --progress-bar-box-shadow: 0 1px 2px rgba(99, 102, 241, .1);
}
```