### PR TITLE
Update html[dir] attribute during navigation

### DIFF
--- a/src/core/drive/page_renderer.js
+++ b/src/core/drive/page_renderer.js
@@ -30,6 +30,7 @@ export class PageRenderer extends Renderer {
 
   async prepareToRender() {
     this.#setLanguage()
+    this.#setDirection()
     await this.mergeHead()
   }
 
@@ -66,6 +67,17 @@ export class PageRenderer extends Renderer {
       documentElement.setAttribute("lang", lang)
     } else {
       documentElement.removeAttribute("lang")
+    }
+  }
+
+  #setDirection() {
+    const { documentElement } = this.currentSnapshot
+    const { dir } = this.newSnapshot
+
+    if (dir) {
+      documentElement.setAttribute("dir", dir)
+    } else {
+      documentElement.removeAttribute("dir")
     }
   }
 

--- a/src/core/drive/page_snapshot.js
+++ b/src/core/drive/page_snapshot.js
@@ -45,6 +45,10 @@ export class PageSnapshot extends Snapshot {
     return this.documentElement.getAttribute("lang")
   }
 
+  get dir() {
+    return this.documentElement.getAttribute("dir")
+  }
+
   get headElement() {
     return this.headSnapshot.element
   }

--- a/src/tests/fixtures/dir_rtl.html
+++ b/src/tests/fixtures/dir_rtl.html
@@ -1,0 +1,12 @@
+<!doctype html>
+<html dir="rtl">
+    <head>
+        <meta charset="utf-8" />
+        <title>Turbo</title>
+        <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+        <script src="/src/tests/fixtures/test.js"></script>
+    </head>
+    <body>
+        <h1>html[dir="rtl"]</h1>
+    </body>
+</html>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -47,6 +47,7 @@
       <p><a id="delayed-link" href="/__turbo/delayed_response">Delayed link</a></p>
       <p><a id="redirect-link" href="/__turbo/redirect">Redirect link</a></p>
       <p><a id="es_locale_link" href="/src/tests/fixtures/es_locale.html">Change html[lang]</a></p>
+      <p><a id="dir-rtl" href="/src/tests/fixtures/dir_rtl.html">Change html[dir]</a></p>
       <form>
         <input type="text" id="text-input">
         <input type="radio" id="radio-input">

--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -212,6 +212,13 @@ test("changes the html[lang] attribute", async ({ page }) => {
   assert.equal(await page.getAttribute("html", "lang"), "es")
 })
 
+test("changes the html[dir] attribute", async ({ page }) => {
+  await page.click("#dir-rtl")
+  await nextEventNamed(page, "turbo:load")
+
+  assert.equal(await page.getAttribute("html", "dir"), "rtl")
+})
+
 test("accumulates script elements in head", async ({ page }) => {
   const assetElements = () => page.$$('script')
   const originalElements = await assetElements()


### PR DESCRIPTION
  This PR adds support for updating the `html[dir]` attribute during navigation, similar to how the `html[lang]` attribute is currently handled. See #1035.

This is important for languages that are written from the right to the left (like Arabic).