### PR TITLE
Make sure full page reloads use the response URL after a redirect

### DIFF
--- a/src/core/native/browser_adapter.js
+++ b/src/core/native/browser_adapter.js
@@ -36,6 +36,10 @@ export class BrowserAdapter {
 
   visitRequestCompleted(visit) {
     visit.loadResponse()
+
+    if(visit.response.redirected) {
+      this.location = visit.redirectedToLocation
+    }
   }
 
   visitRequestFailedWithStatusCode(visit, statusCode) {

--- a/src/core/native/browser_adapter.js
+++ b/src/core/native/browser_adapter.js
@@ -20,6 +20,8 @@ export class BrowserAdapter {
 
   visitStarted(visit) {
     this.location = visit.location
+    this.redirectedToLocation = null
+
     visit.loadCachedSnapshot()
     visit.issueRequest()
     visit.goToSamePageAnchor()
@@ -37,8 +39,8 @@ export class BrowserAdapter {
   visitRequestCompleted(visit) {
     visit.loadResponse()
 
-    if(visit.response.redirected) {
-      this.location = visit.redirectedToLocation
+    if (visit.response.redirected) {
+      this.redirectedToLocation = visit.redirectedToLocation
     }
   }
 
@@ -129,7 +131,7 @@ export class BrowserAdapter {
   reload(reason) {
     dispatch("turbo:reload", { detail: reason })
 
-    window.location.href = this.location?.toString() || window.location.href
+    window.location.href = (this.redirectedToLocation || this.location)?.toString() || window.location.href
   }
 
   get navigator() {

--- a/src/tests/fixtures/link_redirect.html
+++ b/src/tests/fixtures/link_redirect.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/dist/turbo.es2017-umd.js"></script>
+    <meta data-turbo-track="reload" content="A">
+  </head>
+  <body>
+    <a id="indirect" href="/__turbo/redirect?path=/src/tests/fixtures/link_redirect_target.html">Indirect link</a>
+  </body>
+</html>

--- a/src/tests/fixtures/link_redirect_target.html
+++ b/src/tests/fixtures/link_redirect_target.html
@@ -1,0 +1,7 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <script src="/dist/turbo.es2017-umd.js"></script>
+    <meta data-turbo-track="reload" content="B">
+  </head>
+</html>

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -119,6 +119,27 @@ test("page refreshes cause a reload when assets change", async ({ page }) => {
   await expect(page.locator("#new-stylesheet")).toHaveCount(0)
 })
 
+test("reloading when assets change uses the response URL of a prior redirect", async ({page}) => {
+  const destinations = []
+
+  page.on("request", (request) => {
+    const path = new URL(request.url()).pathname
+
+    if (path === "/__turbo/redirect") {
+      destinations.push("redirect")
+    } else if (path === "/src/tests/fixtures/link_redirect_target.html") {
+      destinations.push("target")
+    }
+  })
+
+  await page.goto("/src/tests/fixtures/link_redirect.html")
+  await page.click("#indirect")
+
+  await page.waitForURL("/src/tests/fixtures/link_redirect_target.html")
+
+  assert.sameMembers(destinations, ["redirect", "target", "target"], "redirects once")
+})
+
 test("renders a page refresh with morphing when the paths are the same but search params are different", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 


### PR DESCRIPTION
Fixes https://github.com/hotwired/turbo/issues/1391

With this change, we store the effective location (`visit.redirectedToLocation`)  in `visitRequestCompleted` when the fetch was redirected. This makes sure the redirect is not executed again in case of a forced reload (which might lead to problems, see #1391).

