### PR TITLE
Improve prefetch/navigation performance

### DIFF
--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -78,7 +78,7 @@ export class LinkPrefetchObserver {
           target
         )
 
-        fetchRequest.fetchOptions.priority = 'low'
+        fetchRequest.fetchOptions.priority = "low"
 
         prefetchCache.setLater(location.toString(), fetchRequest, this.#cacheTtl)
       }

--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -78,6 +78,8 @@ export class LinkPrefetchObserver {
           target
         )
 
+        fetchRequest.fetchOptions.priority = 'low'
+
         prefetchCache.setLater(location.toString(), fetchRequest, this.#cacheTtl)
       }
     }

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -26,6 +26,7 @@ test("it prefetches the page", async ({ page }) => {
 
   expect(url).toEqual(await link.evaluate(a => a.href))
   expect(fetchOptions.headers["X-Sec-Purpose"]).toEqual("prefetch")
+  expect(fetchOptions.priority).toEqual("low")
 
   await link.hover()
   await noNextEventOnTarget(page, "anchor_for_prefetch", "turbo:before-fetch-request")


### PR DESCRIPTION
Fixes https://github.com/hotwired/turbo/issues/1372

With this change, prefetch requests will be made with the fetch priority set to `low`. This makes sure, that regular requests (default `high`) will be prioritized by the browser. Otherwise - on slow connections or servers - pending prefetches may pile up and block other fetches until fully processed.