### PR TITLE
Allow setting turbo-suppress-warning on body element

### DIFF
--- a/src/script_warning.js
+++ b/src/script_warning.js
@@ -1,12 +1,15 @@
 import { unindent } from "./util"
 ;(() => {
   let element = document.currentScript
+  let suppressWarningAttribute = 'data-turbo-suppress-warning'
   if (!element) return
-  if (element.hasAttribute("data-turbo-suppress-warning")) return
+  if (element.hasAttribute(suppressWarningAttribute)) return
 
   element = element.parentElement
   while (element) {
     if (element == document.body) {
+      if (element.hasAttribute(suppressWarningAttribute)) return
+
       return console.warn(
         unindent`
         You are loading Turbo from a <script> element inside the <body> element. This is probably not what you meant to do!
@@ -16,8 +19,8 @@ import { unindent } from "./util"
         For more information, see: https://turbo.hotwired.dev/handbook/building#working-with-script-elements
 
         ——
-        Suppress this warning by adding a "data-turbo-suppress-warning" attribute to: %s
-      `,
+        Suppress this warning by adding a "${suppressWarningAttribute}" attribute to the script tag loading this code or the body element:
+        ` + "\n" +
         element.outerHTML
       )
     }


### PR DESCRIPTION
The warning previously made it look like placing the data-turbo-suppress-warning attribute on the body element would suppress it, but in fact, only the script tag was being checked for this attribute.

Now, data-turbo-suppress-warning on the body element will also suppress the warning.

The script tag check is kept unchanged to avoid breaking existing code.

The warning message has been updated to mention both possibilities (script tag and body tag) as valid places for
data-turbo-suppress-warning.

Before:
<img width="675" height="255" alt="Screenshot from 2025-08-05 10-39-45" src="https://github.com/user-attachments/assets/dc506dfa-2953-4ebb-8715-128c2b69d17d" />

_Notice the data-turbo-suppress-warning attribute already present on the body tag, while the message suggests adding it_

After:
<img width="706" height="286" alt="Screenshot from 2025-08-05 12-45-18" src="https://github.com/user-attachments/assets/be76114d-7165-4dad-b442-cfbcad3dcc7f" />

_The body tag no longer has the data-turbo-suppress-warning attribute, because the warning would no longer appear if it had it_