### PR TITLE
Mention the correct element "data-turbo-suppress-warning" is expected on

### DIFF
--- a/src/script_warning.js
+++ b/src/script_warning.js
@@ -1,6 +1,6 @@
 import { unindent } from "./util"
 ;(() => {
-  let scriptElement = document.currentScript
+  const scriptElement = document.currentScript
   if (!scriptElement) return
   if (scriptElement.hasAttribute("data-turbo-suppress-warning")) return
 


### PR DESCRIPTION
The previous error message made it look like adding "data-turbo-suppress-warning" to the body element would supress the warning, while the code checked for this data attribute on the script tag that loaded turbo.

I would prefer to allow this data attribute to be placed on the body element (PR for this can be found here: https://github.com/hotwired/turbo/pull/1423), but if that's not an option - maybe worth at least updating the warning.

Before:
<img width="675" height="255" alt="Screenshot from 2025-08-05 10-39-45" src="https://github.com/user-attachments/assets/dc506dfa-2953-4ebb-8715-128c2b69d17d" />

_Notice the data-turbo-suppress-warning attribute already present on the body tag, while the message suggests adding it_

After:
<img width="680" height="216" alt="Screenshot from 2025-08-05 11-45-52" src="https://github.com/user-attachments/assets/64788837-79e1-4594-b36b-05fa571f4b69" />
