### PR TITLE
Fix UUID generation to include all hex digits

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -98,7 +98,7 @@ export function uuid() {
       } else if (i == 19) {
         return (Math.floor(Math.random() * 4) + 8).toString(16)
       } else {
-        return Math.floor(Math.random() * 15).toString(16)
+        return Math.floor(Math.random() * 16).toString(16)
       }
     })
     .join("")


### PR DESCRIPTION
Changed Math.random() * 15 to * 16 to properly generate 0-f range instead of missing the 'f' digit.