### PR TITLE
Fix navigating to the turbo-root does not use Turbo Drive

### DIFF
--- a/src/core/url.js
+++ b/src/core/url.js
@@ -55,9 +55,5 @@ function getLastPathComponent(url) {
 }
 
 function getPrefix(url) {
-  return addTrailingSlash(url.origin + url.pathname)
-}
-
-function addTrailingSlash(value) {
-  return value.endsWith("/") ? value : value + "/"
+  url.origin + url.pathname
 }

--- a/src/core/url.js
+++ b/src/core/url.js
@@ -25,7 +25,7 @@ export function getExtension(url) {
 }
 
 export function isPrefixedBy(baseURL, url) {
-  const prefix = getPrefix(url) || '/'
+  const prefix = getPrefix(url) || "/"
   return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
 }
 

--- a/src/core/url.js
+++ b/src/core/url.js
@@ -25,8 +25,8 @@ export function getExtension(url) {
 }
 
 export function isPrefixedBy(baseURL, url) {
-  const prefix = getPrefix(url) || "/"
-  return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
+  const prefix = addTrailingSlash(url.origin + url.pathname)
+  return addTrailingSlash(baseURL.href) === prefix || baseURL.href.startsWith(prefix)
 }
 
 export function locationIsVisitable(location, rootLocation) {
@@ -54,6 +54,6 @@ function getLastPathComponent(url) {
   return getPathComponents(url).slice(-1)[0]
 }
 
-function getPrefix(url) {
-  url.origin + url.pathname
+function addTrailingSlash(value) {
+  return value.endsWith("/") ? value : value + "/"
 }

--- a/src/core/url.js
+++ b/src/core/url.js
@@ -25,7 +25,7 @@ export function getExtension(url) {
 }
 
 export function isPrefixedBy(baseURL, url) {
-  const prefix = getPrefix(url)
+  const prefix = getPrefix(url) || '/'
   return baseURL.href === expandURL(prefix).href || baseURL.href.startsWith(prefix)
 }
 

--- a/src/tests/fixtures/root/index.html
+++ b/src/tests/fixtures/root/index.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
-<html id="html">
+<html>
   <head>
     <meta charset="utf-8">
-    <title>Turbo</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
     <meta name="turbo-root" content="/src/tests/fixtures/root">
   </head>
   <body>
     <section>
-      <h1>Root</h1>
-      <p><a id="link-page-inside" href="/src/tests/fixtures/root/page.html">Link to page inside root</a></p>
-      <p><a id="link-page-outside" href="/src/tests/fixtures/one.html">Link to page outside root</a></p>
+      <p><a id="link-page-inside" href="/src/tests/fixtures/root/page.html">Link to page inside the root</a></p>
+      <p><a id="link-page-outside" href="/src/tests/fixtures/one.html">Link to page outside the root</a></p>
+      <p><a id="link-page-outside-prefix" href="/src/tests/fixtures/rootlet.html">Link to page outside the root having the root as a prefix</a></p>
     </section>
-    <div id="messages"></div>
   </body>
 </html>

--- a/src/tests/fixtures/root/index.html
+++ b/src/tests/fixtures/root/index.html
@@ -1,0 +1,18 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="turbo-root" content="/src/tests/fixtures/root">
+  </head>
+  <body>
+    <section>
+      <h1>Root</h1>
+      <p><a id="link-page-inside" href="/src/tests/fixtures/root/page.html">Link to page inside root</a></p>
+      <p><a id="link-page-outside" href="/src/tests/fixtures/one.html">Link to page outside root</a></p>
+    </section>
+    <div id="messages"></div>
+  </body>
+</html>

--- a/src/tests/fixtures/root/page.html
+++ b/src/tests/fixtures/root/page.html
@@ -1,17 +1,14 @@
 <!DOCTYPE html>
-<html id="html">
+<html>
   <head>
     <meta charset="utf-8">
-    <title>Turbo</title>
     <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
     <script src="/src/tests/fixtures/test.js"></script>
     <meta name="turbo-root" content="/src/tests/fixtures/root">
   </head>
   <body>
     <section>
-      <h1>Root</h1>
       <p><a id="link-root" href="/src/tests/fixtures/root">Link to root</a></p>
     </section>
-    <div id="messages"></div>
   </body>
 </html>

--- a/src/tests/fixtures/root/page.html
+++ b/src/tests/fixtures/root/page.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <meta name="turbo-root" content="/src/tests/fixtures/root">
+  </head>
+  <body>
+    <section>
+      <h1>Root</h1>
+      <p><a id="link-root" href="/src/tests/fixtures/root">Link to root</a></p>
+    </section>
+    <div id="messages"></div>
+  </body>
+</html>

--- a/src/tests/functional/root_test.js
+++ b/src/tests/functional/root_test.js
@@ -1,0 +1,27 @@
+import { test } from "@playwright/test"
+import { assert } from "chai"
+import { nextBody, pathname, visitAction } from "../helpers/page"
+
+test("test visiting a location inside the root", async ({ page }) => {
+  page.goto("/src/tests/fixtures/root/index.html")
+  page.click("#link-page-inside")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/root/page.html")
+  assert.notEqual(await visitAction(page), "load")
+})
+
+test("test visiting the root itself", async ({ page }) => {
+  page.goto("/src/tests/fixtures/root/page.html")
+  page.click("#link-root")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/root/")
+  assert.notEqual(await visitAction(page), "load")
+})
+
+test("test visiting a location outside the root", async ({ page }) => {
+  page.goto("/src/tests/fixtures/root/index.html")
+  page.click("#link-page-outside")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "load")
+})

--- a/src/tests/functional/root_test.js
+++ b/src/tests/functional/root_test.js
@@ -2,7 +2,7 @@ import { test } from "@playwright/test"
 import { assert } from "chai"
 import { nextBody, pathname, visitAction } from "../helpers/page"
 
-test("test visiting a location inside the root", async ({ page }) => {
+test("visiting a location inside the root", async ({ page }) => {
   page.goto("/src/tests/fixtures/root/index.html")
   page.click("#link-page-inside")
   await nextBody(page)
@@ -10,7 +10,7 @@ test("test visiting a location inside the root", async ({ page }) => {
   assert.notEqual(await visitAction(page), "load")
 })
 
-test("test visiting the root itself", async ({ page }) => {
+test("visiting the root itself", async ({ page }) => {
   page.goto("/src/tests/fixtures/root/page.html")
   page.click("#link-root")
   await nextBody(page)
@@ -18,7 +18,7 @@ test("test visiting the root itself", async ({ page }) => {
   assert.notEqual(await visitAction(page), "load")
 })
 
-test("test visiting a location outside the root", async ({ page }) => {
+test("visiting a location outside the root", async ({ page }) => {
   page.goto("/src/tests/fixtures/root/index.html")
   page.click("#link-page-outside")
   await nextBody(page)

--- a/src/tests/functional/root_tests.js
+++ b/src/tests/functional/root_tests.js
@@ -25,3 +25,11 @@ test("visiting a location outside the root", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "load")
 })
+
+test("visiting a location outside the root having the root as a prefix", async ({ page }) => {
+  page.goto("/src/tests/fixtures/root/index.html")
+  page.click("#link-page-outside-prefix")
+  await nextBody(page)
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/rootlet.html")
+  assert.equal(await visitAction(page), "load")
+})


### PR DESCRIPTION
Supersedes #1341, fixes #912

This is based on the work of @tobyzerner (#913), @leofeyer (#1341) and @packagethief (https://github.com/hotwired/turbo/pull/1341#issuecomment-3161810530) - I just added another test and made minor adjustments.

The original issue fixed by this PR, was Turbo not using Drive when navigating to the "turbo-root" itself.