### PR TITLE
Don't ignore the browser's default for `a[href]` links

### DIFF
--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -42,6 +42,7 @@
       <p><a id="same-origin-anchored-link-named" href="/src/tests/fixtures/one.html#named-anchor">Same-origin link to named anchor</a></p>
       <p><a id="cross-origin-unannotated-link" href="about:blank">Cross-origin unannotated link</a></p>
       <p><a id="same-origin-targeted-link" href="/src/tests/fixtures/one.html" target="_blank">Same-origin targeted link</a></p>
+      <p><a id="self-targeted-link" href="/src/tests/fixtures/one.html" target="_self">Explicit browser default target link</a></p>
       <p><a id="same-origin-download-link" href="/intentionally_missing_fake_download.html" download="x.html">Same-origin download link</a></p>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -266,10 +266,11 @@ test("following a same-origin [target] link", async ({ page }) => {
 })
 
 test("following a _self [target] link", async ({ page }) => {
-  const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#self-targeted-link")])
+  await page.click("#self-targeted-link")
+  await nextBody(page)
 
-  assert.equal(pathname(popup.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(popup), "load")
+  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(page), "advance")
 })
 
 test("following a same-origin [download] link", async ({ page }) => {
@@ -284,14 +285,20 @@ test("following a same-origin [download] link", async ({ page }) => {
 })
 
 test("following a same-origin link inside an SVG element", async ({ page }) => {
-  await page.click("#same-origin-link-inside-svg-element", { force: true })
+  const link = page.locator("#same-origin-link-inside-svg-element")
+  await link.focus()
+  await page.keyboard.press("Enter")
+
   await nextBody(page)
   assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
   assert.equal(await visitAction(page), "advance")
 })
 
 test("following a cross-origin link inside an SVG element", async ({ page }) => {
-  await page.click("#cross-origin-link-inside-svg-element", { force: true })
+  const link = page.locator("#cross-origin-link-inside-svg-element")
+  await link.focus()
+  await page.keyboard.press("Enter")
+
   await nextBody(page)
   assert.equal(page.url(), "about:blank")
   assert.equal(await visitAction(page), "load")

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -265,6 +265,13 @@ test("following a same-origin [target] link", async ({ page }) => {
   assert.equal(await visitAction(popup), "load")
 })
 
+test("following a _self [target] link", async ({ page }) => {
+  const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#self-targeted-link")])
+
+  assert.equal(pathname(popup.url()), "/src/tests/fixtures/one.html")
+  assert.equal(await visitAction(popup), "load")
+})
+
 test("following a same-origin [download] link", async ({ page }) => {
   assert.notOk(
     await willChangeBody(page, async () => {
@@ -494,9 +501,7 @@ test("ignores forms with a button[formtarget=_blank] attribute", async ({ page }
   expect(pathname(popup.url())).toContain("/src/tests/fixtures/one.html")
 })
 
-test("ignores forms with a button[formtarget] attribute that targets an iframe with [name='']", async ({
-  page
-}) => {
+test("ignores forms with a button[formtarget] attribute that targets an iframe with [name='']", async ({ page }) => {
   await page.click("#form-target-empty-name-iframe button")
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")

--- a/src/util.js
+++ b/src/util.js
@@ -247,7 +247,7 @@ export function doesNotTargetIFrame(name) {
 }
 
 export function findLinkFromClickTarget(target) {
-  return findClosestRecursively(target, "a[href]:not([target^=_]):not([download])")
+  return findClosestRecursively(target, 'a[href]:not([download]):not([target^=_]:not([target="_self"]))')
 }
 
 export function getLocationForLink(link) {

--- a/src/util.js
+++ b/src/util.js
@@ -247,7 +247,13 @@ export function doesNotTargetIFrame(name) {
 }
 
 export function findLinkFromClickTarget(target) {
-  return findClosestRecursively(target, 'a[href]:not([download]):not([target^=_]:not([target="_self"]))')
+  const link = findClosestRecursively(target, "a[href], a[xlink\\:href]")
+
+  if (!link) return null
+  if (link.hasAttribute("download")) return null
+  if (link.hasAttribute("target") && link.target !== "_self") return null
+
+  return link
 }
 
 export function getLocationForLink(link) {


### PR DESCRIPTION
Currently, Turbo ignores any link with a target attribute set. However, this means that Turbo ignores the default `target="_self"`.

Some design systems and/or web components set the target to "_self" even though it's technically not required. Because they set this target, Turbo ignores a link it shouldn't be ignoring.

This commit ensures we're including the `target="_self"` on a link element when looking up a link from a click target.

The new Polaris web components are a good example of web components that explicitly set the `target="_self"` even though it's not needed according to the browser specs. 

- The browser specifications on the default target: https://developer.mozilla.org/en-US/docs/Web/HTML/Reference/Elements/a#target
- Conversation with Shopify team: https://community.shopify.dev/t/pass-all-data-attributes-to-the-shadow-root-elements/19029/15