### PR TITLE
rootMargin for turbo-frame

### DIFF
--- a/src/observers/appearance_observer.js
+++ b/src/observers/appearance_observer.js
@@ -4,12 +4,17 @@ export class AppearanceObserver {
   constructor(delegate, element) {
     this.delegate = delegate
     this.element = element
-    this.intersectionObserver = new IntersectionObserver(this.intersect)
   }
 
   start() {
     if (!this.started) {
       this.started = true
+
+      if (!this.intersectionObserver) {
+        const rootMargin = this.element.getAttribute("data-turbo-lazy-root-margin") || "0px"
+        this.intersectionObserver = new IntersectionObserver(this.intersect, { rootMargin })
+      }
+
       this.intersectionObserver.observe(this.element)
     }
   }

--- a/src/tests/fixtures/frame_navigation_lazy.html
+++ b/src/tests/fixtures/frame_navigation_lazy.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <link rel="icon" href="data:image/x-icon;base64,AA">
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <div id="container">
+      <h1>Frame lazy test</h1>
+
+      <div style="height: calc(100vh*2);"></div>
+      <div id="load-frame-trigger"></div>
+      <div style="height: 100px;"></div>
+
+      <turbo-frame id="eager-loaded-frame" src="/src/tests/fixtures/frames/frame_for_eager.html" loading="lazy"
+                 data-turbo-lazy-root-margin="100px">
+        <h2 style="margin: 0">Eager-loaded frame: Not Loaded</h2>
+      </turbo-frame>
+    </div>
+  </body>
+</html>

--- a/src/tests/functional/frame_navigation_tests.js
+++ b/src/tests/functional/frame_navigation_tests.js
@@ -63,6 +63,17 @@ test("lazy-loaded frame promotes navigation", async ({ page }) => {
   assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/frame_for_eager.html")
 })
 
+test("lazy-loading frame with root margin", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation_lazy.html")
+
+  assert.equal(await page.textContent("#eager-loaded-frame h2"), "Eager-loaded frame: Not Loaded")
+
+  await page.locator("#load-frame-trigger").evaluate(el => el.scrollIntoView(false))
+  await nextEventOnTarget(page, "eager-loaded-frame", "turbo:frame-load")
+
+  assert.equal(await page.textContent("#eager-loaded-frame h2"), "Eager-loaded frame: Loaded")
+})
+
 test("promoted frame navigation updates the URL before rendering", async ({ page }) => {
   await page.goto("/src/tests/fixtures/tabs.html")
 


### PR DESCRIPTION
This PR introduces the `data-turbo-lazy-root-margin` attribute for `turbo-frame`.
The value is passed to the `IntersectionObserver` in `AppearanceObserver` as the `rootMargin` option.

The purpose of this option is to trigger lazy frame loading slightly before the user scrolls to the element. This improves user experience by making the site feel more responsive.

Currently, we are using a custom Stimulus controller with its own IntersectionObserver to achieve the same effect.