### PR TITLE
Track refreshes per request and URL to support persistent modals with page refreshes

### DIFF
--- a/src/core/drive/limited_map.js
+++ b/src/core/drive/limited_map.js
@@ -1,0 +1,14 @@
+export class LimitedMap extends Map {
+  constructor(maxSize) {
+    super()
+    this.maxSize = maxSize
+  }
+
+  set(key, value) {
+    if (!this.has(key) && this.size >= this.maxSize) {
+      const firstKey = this.keys().next().value
+      this.delete(firstKey)
+    }
+    return super.set(key, value)
+  }
+}

--- a/src/core/drive/recent_requests_tracker.js
+++ b/src/core/drive/recent_requests_tracker.js
@@ -1,0 +1,30 @@
+import { LimitedSet } from "./limited_set"
+import { LimitedMap } from "./limited_map"
+
+export class RecentRequestsTracker {
+  constructor(limit = 20) {
+    this.limit = limit
+    this.refreshedUrls = new LimitedMap(limit)
+  }
+
+  addRequestId(requestId) {
+    if (!this.refreshedUrls.has(requestId)) {
+      this.refreshedUrls.set(requestId, new LimitedSet(this.limit))
+    }
+  }
+
+  get requestIds() {
+    return new Set(this.refreshedUrls.keys())
+  }
+
+  markUrlAsRefreshed(requestId, refreshUrl) {
+    this.addRequestId(requestId)
+
+    this.refreshedUrls.get(requestId).add(refreshUrl)
+  }
+
+  hasRefreshedUrl(requestId, refreshUrl) {
+    const urls = this.refreshedUrls.get(requestId)
+    return urls ? urls.has(refreshUrl) : false
+  }
+}

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -106,9 +106,13 @@ export class Session {
   }
 
   refresh(url, requestId) {
-    const isRecentRequest = requestId && this.recentRequests.has(requestId)
+    const hasAlreadyRefreshedThisUrl = requestId && this.recentRequests.hasRefreshedUrl(requestId, url)
     const isCurrentUrl = url === document.baseURI
-    if (!isRecentRequest && !this.navigator.currentVisit && isCurrentUrl) {
+
+    if (!hasAlreadyRefreshedThisUrl && !this.navigator.currentVisit && isCurrentUrl) {
+      if (requestId) {
+        this.recentRequests.markUrlAsRefreshed(requestId, url)
+      }
       this.visit(url, { action: "replace", shouldCacheSnapshot: false })
     }
   }

--- a/src/http/fetch.js
+++ b/src/http/fetch.js
@@ -1,18 +1,31 @@
 import { uuid } from "../util"
-import { LimitedSet } from "../core/drive/limited_set"
+import { RecentRequestsTracker } from "../core/drive/recent_requests_tracker"
 
-export const recentRequests = new LimitedSet(20)
+export const recentRequests = new RecentRequestsTracker(20)
 
-function fetchWithTurboHeaders(url, options = {}) {
+async function fetchWithTurboHeaders(url, options = {}) {
   const modifiedHeaders = new Headers(options.headers || {})
   const requestUID = uuid()
-  recentRequests.add(requestUID)
+  recentRequests.addRequestId(requestUID)
   modifiedHeaders.append("X-Turbo-Request-Id", requestUID)
 
-  return window.fetch(url, {
+  const response = await window.fetch(url, {
     ...options,
     headers: modifiedHeaders
   })
+
+  // Mark the redirected URL as refreshed for this request ID when it's not
+  // a Turbo frame request (normal navigation or escaping one via
+  // data-turbo-frame="_top"), since it's where the user will be sent to and
+  // thus it's already fresh.
+  //
+  // If it's within a Turbo frame, we don't consider it refreshed because the
+  // content outside the frame will be discarded.
+  if (response.ok && response.redirected && !options?.headers?.["Turbo-Frame"]) {
+    recentRequests.markUrlAsRefreshed(requestUID, response.url)
+  }
+
+  return response
 }
 
 export { fetchWithTurboHeaders as fetch }

--- a/src/tests/fixtures/conversations/index.html
+++ b/src/tests/fixtures/conversations/index.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Conversations Index</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+
+    <style>
+      form {
+        border: 1px solid;
+        margin: 15px;
+        padding: 10px;
+      }
+
+      .modal {
+        position: fixed;
+        top: 3%;
+        left: 50%;
+        transform: translateX(-50%);
+        background: white;
+        border: 1px solid #ccc;
+        box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+        padding: 20px;
+        z-index: 10;
+        max-width: 80vw;
+        width: 100%;
+        height: 60rem;
+        overflow-y: scroll;
+      }
+
+      .forms-container {
+        display: flex;
+        flex-wrap: wrap;
+        gap: 10px;
+      }
+      .forms-container form {
+        flex: 1;
+        min-width: 200px;
+        margin: 5px;
+      }
+    </style>
+
+    <script>
+      let lastRequestId
+
+      document.addEventListener("turbo:load", () => {
+        document.addEventListener("click", (event) => {
+          if (event.target.id === "generate-refresh") {
+            if (!lastRequestId) {
+              // Simulate the server preserving the request ID and sending as
+              // many refreshes as it would send. e.g. for Rails: a manual
+              // broadcast_refresh_later, a manual broadcast_refresh and/or an
+              // automatic one via broadcasts_refreshes.
+
+              const requestIds = Array.from(window.Turbo.session.recentRequests.requestIds)
+              lastRequestId = requestIds[requestIds.length - 1]
+            }
+            const html = `<turbo-stream action="refresh"${
+              lastRequestId ? ` request-id="${lastRequestId}"` : ""
+            }></turbo-stream>`
+            document.body.insertAdjacentHTML("beforeend", html)
+          }
+        })
+      })
+    </script>
+  </head>
+  <body>
+    <h1>Conversations Index</h1>
+
+    <div id="content">
+      <a href="/src/tests/fixtures/conversations/show.html" data-turbo-frame="modal" id="conversation-1">
+        Conversation 1 - Name A
+      </a>
+    </div>
+
+    <!-- Empty turbo-frame representing a slideout/modal that will be populated when clicking a conversation. -->
+    <!-- data-turbo-permanent allows you to keep it open to see its contents change -->
+    <turbo-frame id="modal" data-turbo-permanent></turbo-frame>
+
+    <button id="generate-refresh">Generate Refresh</button>
+
+    <ul>
+      <li>
+        If this page loaded for the first time, clicking the button is like receiving a refresh from the server without
+        a request ID, the first one will be processed and any subsequent refreshes will be discarded.
+      </li>
+      <li>
+        If the page comes from a redirect, such as a form submission that redirects to this page, clicking the button is
+        like receiving a refresh from the server with a request ID, the first one will be processed and any subsequent
+        refreshes will be discarded.
+      </li>
+    </ul>
+  </body>
+</html>

--- a/src/tests/fixtures/conversations/index_updated.html
+++ b/src/tests/fixtures/conversations/index_updated.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Conversations Index - Updated</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    </script>
+  </head>
+  <body>
+    <p class="success-message">
+      Name updated successfully! Page refresh should not happen because we exited the Turbo frame and thus the
+      content is already fresh.
+    </p>
+
+    <h1>Conversations Index</h1>
+
+    <div id="content">Conversation 1 - Name D</div>
+
+    <!-- Empty turbo-frame representing a slideout/modal that will be populated when clicking a conversation. -->
+    <turbo-frame id="modal" data-turbo-permanent></turbo-frame>
+    <button id="generate-refresh">Generate Refresh</button>
+  </body>
+</html>

--- a/src/tests/fixtures/conversations/show.html
+++ b/src/tests/fixtures/conversations/show.html
@@ -1,0 +1,116 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Conversation Show</title>
+  </head>
+  <body>
+    <turbo-frame id="modal">
+      <div class="modal">
+        <h2>Conversation 1 Details</h2>
+        <p>Current Name: A</p>
+
+        <div class="forms-container">
+          <!-- Form to simulate updating the conversation and redirect to conversation show page within modal Turbo frame -->
+          <form
+            id="form-to-update-conversation-and-redirect-to-conversations-show-inside-modal-frame"
+            method="post"
+            action="/__turbo/simple-redirect"
+          >
+            <h3>Update conversation and redirect to conversation show page inside modal Turbo frame</h3>
+            <input type="hidden" name="path" value="/src/tests/fixtures/conversations/show_updated.html" />
+            <button
+              type="submit"
+              id="submit-button-to-update-conversation-and-redirect-to-conversations-show-inside-modal-frame"
+            >
+              Update name to D redirecting to conversation show updated inside modal frame
+            </button>
+            <p>
+              On the next page, a refesh should happen because only the content inside the Turbo frame will be updated
+              and thus, the content outside it is stale. Only one refresh should be processed.
+            </p>
+            <p>
+              This is the recommended approach is you want to update the conversation on both the modal and the
+              conversations index.
+            </p>
+          </form>
+
+          <!-- Form to simulate updating the conversation and redirect to conversation show page outside modal Turbo frame -->
+          <form
+            id="form-to-update-conversation-and-redirect-to-conversations-show-outside-modal-frame"
+            method="post"
+            action="/__turbo/simple-redirect"
+            data-turbo-frame="_top"
+          >
+            <h3>Update conversation and redirect to conversation show page outside modal Turbo frame</h3>
+            <input type="hidden" name="path" value="/src/tests/fixtures/conversations/show_updated.html" />
+            <button
+              type="submit"
+              id="submit-button-to-update-conversation-and-redirect-to-conversations-show-outside-modal-frame"
+            >
+              Update name to D redirecting to conversation show updated outside modal frame
+            </button>
+            <p>
+              On the next page, a refesh should NOT happen because we're exiting the Turbo frame and thus the content is
+              already fresh.
+            </p>
+            <p>This approach would take you to the conversation show page, outside the modal's Turbo frame.</p>
+          </form>
+
+          <!-- Form to simulate updating the conversation and redirect to conversations index inside modal Turbo frame -->
+          <form
+            id="form-to-update-conversation-and-redirect-to-conversations-index-inside-modal-frame"
+            method="post"
+            action="/__turbo/simple-redirect"
+          >
+            <h3>Update conversation and redirect to conversations index inside modal Turbo frame</h3>
+            <input type="hidden" name="path" value="/src/tests/fixtures/conversations/index_updated.html" />
+            <button
+              type="submit"
+              id="submit-button-to-update-conversation-and-redirect-to-conversations-index-inside-modal-frame"
+            >
+              Update name to D redirecting to conversations index updated inside modal frame
+            </button>
+            <p>
+              On the next page, a refresh should happen because, since we're still inside the Turbo frame, the incoming
+              updated conversation's index page only has an empty Turbo frame and since the updated content is outside
+              it, it will be discarded. Only one refresh should be processed.
+            </p>
+            <p>This approach would only update the conversations index, not the modal.</p>
+            <p>
+              It will also "close" the slideout/modal because the incoming HTML has an empty Turbo frame and we're not
+              exiting the Turbo frame, so the slideout/modal content will be replaced by empty HTML.
+            </p>
+          </form>
+
+          <!-- Form to simulate updating the conversation and redirect to conversations index outside modal Turbo frame -->
+          <form
+            id="form-to-update-conversation-and-redirect-to-conversations-index-outside-modal-frame"
+            method="post"
+            action="/__turbo/simple-redirect"
+            data-turbo-frame="_top"
+          >
+            <h3>Update conversation and redirect to conversations index outside modal Turbo frame</h3>
+            <input type="hidden" name="path" value="/src/tests/fixtures/conversations/index_updated.html" />
+            <button
+              type="submit"
+              id="submit-button-to-update-conversation-and-redirect-to-conversations-index-outside-modal-frame"
+            >
+              Update name to D redirecting to conversations index updated outside modal frame
+            </button>
+            <p>
+              On the next page, a refresh should NOT happen, because we exited the Turbo frame and thus the content is
+              already fresh.
+            </p>
+            <p>This approach would only update the conversations index, not the modal.</p>
+            <p>
+              It will not "close" the slideout/modal because we're exiting the Turbo frame, and even though the incoming
+              HTML has an empty Turbo frame, the data-turbo-permanent attribute will prevent its content from being
+              replaced by empty HTML.
+            </p>
+          </form>
+        </div>
+      </div>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/conversations/show_updated.html
+++ b/src/tests/fixtures/conversations/show_updated.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Conversation Show - Updated</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <turbo-frame id="modal">
+      <div class="modal">
+        <h2>Conversation 1 Details</h2>
+        <p>Current Name: D</p>
+        <p class="success-message">
+          Name updated successfully! (If still inside the Turbo frame, page refresh would change Conversations Index's
+          stage to D if we had a database to reflect the change, but only one should be processed. If outside the Turbo
+          frame, the content is already fresh.)
+        </p>
+        <button id="generate-refresh">Generate Refresh</button>
+      </div>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/page_refresh_stream_action.html
+++ b/src/tests/fixtures/page_refresh_stream_action.html
@@ -9,7 +9,7 @@
 <body>
   <form id="refresh" method="post" action="/__turbo/refreshes">
     <button>Refresh</button>
-    <input id="request-id" type="hidden" name="requestId" value="">
+    <input id="request-id-input" type="hidden" name="requestId" value="">
   </form>
 
   <div id="content">

--- a/src/tests/functional/page_refresh_stream_action_tests.js
+++ b/src/tests/functional/page_refresh_stream_action_tests.js
@@ -22,11 +22,13 @@ test("don't refresh the page on self-originated request ids", async ({ page }) =
   assert.match(await textContent(page), /Hello/)
 
   await page.locator("#content").evaluate((content) => content.innerHTML = "")
-  page.evaluate(() => { window.Turbo.session.recentRequests.add("123") })
 
-  await page.locator("#request-id").evaluate((input) => input.value = "123")
-  await page.click("#refresh button")
-  await nextPageRefresh(page)
+  await page.evaluate(() => {
+    const currentUrl = document.baseURI
+    window.Turbo.session.recentRequests.markUrlAsRefreshed("123", currentUrl)
+  })
+
+  await assertPageRefresh(page, "123", {shouldOccur: false})
 
   assert.notMatch(await textContent(page), /Hello/)
 })
@@ -68,6 +70,60 @@ test("debounced refresh of stale URL does not hijack new location navigated to",
   assert.equal(pathname(urlAfterVisit), expectedPath)
 })
 
+test("from conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to conversations Show still inside the Turbo frame should refresh the page because only the content inside the Turbo frame was updated and thus, the content outside it is stale. Only one refresh should be processed.", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/conversations/index.html")
+  await page.click("#conversation-1")
+  await page.click("#submit-button-to-update-conversation-and-redirect-to-conversations-show-inside-modal-frame")
+  const requestIdThatTriggersRefreshes = await getLastRequestId(page)
+
+  await assertPageRefresh(page, requestIdThatTriggersRefreshes, {shouldOccur: true})
+  await assertPageRefresh(page, requestIdThatTriggersRefreshes, {shouldOccur: false})
+  await assertPageRefresh(page, "another-request-id", {shouldOccur: true})
+})
+
+test("from conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to conversations show outside the Turbo frame should not refresh the page because we're exiting the Turbo frame and thus the content is already fresh.", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/conversations/index.html")
+  await page.click("#conversation-1")
+  await page.click("#submit-button-to-update-conversation-and-redirect-to-conversations-show-outside-modal-frame")
+  const requestIdThatTriggersRefreshes = await getLastRequestId(page)
+
+  await assertPageRefresh(page, requestIdThatTriggersRefreshes, {shouldOccur: false})
+  await assertPageRefresh(page, "another-request-id", {shouldOccur: true})
+})
+
+test("from conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to conversations Index still inside the Turbo frame should refresh the page because, since we're still inside the Turbo frame, the incoming updated conversation's index page only has an empty Turbo frame and since the updated content is outside it, it will be discarded. Only one refresh should be processed.", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/conversations/index.html")
+  await page.click("#conversation-1")
+  await page.click("#submit-button-to-update-conversation-and-redirect-to-conversations-index-inside-modal-frame")
+  const requestIdThatTriggersRefreshes = await getLastRequestId(page)
+
+  await assertPageRefresh(page, requestIdThatTriggersRefreshes, {shouldOccur: true})
+  await assertPageRefresh(page, requestIdThatTriggersRefreshes, {shouldOccur: false})
+  await assertPageRefresh(page, "another-request-id", {shouldOccur: true})
+})
+
+test("from conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to conversations Index outside the Turbo frame should not refresh the page because we exited the Turbo frame and thus the content is already fresh.", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/conversations/index.html")
+  await page.click("#conversation-1")
+  await page.click("#submit-button-to-update-conversation-and-redirect-to-conversations-index-outside-modal-frame")
+  const requestIdThatTriggersRefreshes = await getLastRequestId(page)
+
+  await assertPageRefresh(page, requestIdThatTriggersRefreshes, {shouldOccur: false})
+  await assertPageRefresh(page, "another-request-id", {shouldOccur: true})
+})
+
+async function getLastRequestIds(page) {
+  await page.waitForLoadState("networkidle")
+  return page.evaluate(() => {
+    return Array.from(window.Turbo.session.recentRequests.requestIds)
+  })
+}
+
+async function getLastRequestId(page) {
+  const lastRequestIds = await getLastRequestIds(page)
+  return lastRequestIds[lastRequestIds.length - 1]
+}
+
 async function textContent(page) {
   const messages = await page.locator("#content")
   return await messages.textContent()
@@ -82,4 +138,24 @@ async function fetchRequestId(page) {
 
 async function setLongerPageRefreshDebouncePeriod(page, period = 500) {
   return page.evaluate((period) => window.Turbo.session.pageRefreshDebouncePeriod = period, period)
+}
+
+async function assertPageRefresh(page, requestId, {shouldOccur}) {
+  await page.evaluate(() => { window.eventLogs = [] })
+  triggerRefresh(page, requestId)
+  await nextPageRefresh(page)
+
+  const visitLogs = await readEventLogs(page)
+  const visitEvents = visitLogs.filter(([name]) => name == "turbo:visit")
+
+  if (shouldOccur === true) {
+    assert.equal(visitEvents.length, 1, "page refresh should occur")
+  } else {
+    assert.equal(visitEvents.length, 0, "page refresh should not occur")
+  }
+}
+
+function triggerRefresh(page, requestId) {
+  const html = `<turbo-stream action="refresh"${requestId ? ` request-id="${requestId}"` : ''}></turbo-stream>`
+  page.evaluate((html) => document.body.insertAdjacentHTML("beforeend", html), html)
 }

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -23,6 +23,11 @@ router.use((request, response, next) => {
   }
 })
 
+router.post("/simple-redirect", (request, response) => {
+  const { path } = request.body
+  response.redirect(303, path)
+})
+
 router.post("/redirect", (request, response) => {
   const { path, sleep, ...query } = request.body
   const { pathname, query: searchParams } = url.parse(

--- a/src/tests/unit/limited_map_tests.js
+++ b/src/tests/unit/limited_map_tests.js
@@ -1,0 +1,39 @@
+import { assert } from "@open-wc/testing"
+import { LimitedMap } from "../../core/drive/limited_map"
+
+test("add a limited number of elements", () => {
+  const map = new LimitedMap(3)
+  map.set("a", 1)
+  map.set("b", 2)
+  map.set("c", 3)
+  map.set("d", 4)
+
+  assert.equal(map.size, 3)
+
+  assert.notOk(map.has("a"))
+
+  assert.equal(map.get("b"), 2)
+  assert.equal(map.get("c"), 3)
+  assert.equal(map.get("d"), 4)
+})
+
+test("updating existing key does not increase size", () => {
+  const map = new LimitedMap(2)
+  map.set("a", 1)
+  map.set("b", 2)
+  map.set("a", 10)
+
+  assert.equal(map.size, 2)
+  assert.equal(map.get("a"), 10)
+  assert.equal(map.get("b"), 2)
+})
+
+test("maintains insertion order", () => {
+  const map = new LimitedMap(3)
+  map.set("a", 1)
+  map.set("b", 2)
+  map.set("c", 3)
+
+  const keys = Array.from(map.keys())
+  assert.deepEqual(keys, ["a", "b", "c"])
+})

--- a/src/tests/unit/recent_requests_tracker_tests.js
+++ b/src/tests/unit/recent_requests_tracker_tests.js
@@ -1,0 +1,84 @@
+import { assert } from "@open-wc/testing"
+import { RecentRequestsTracker } from "../../core/drive/recent_requests_tracker"
+
+test("markUrlAsRefreshed() marks URL as refreshed", () => {
+  const tracker = new RecentRequestsTracker(10)
+
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page1")
+
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page1"))
+})
+
+test("markUrlAsRefreshed() can track multiple URLs per request ID", () => {
+  const tracker = new RecentRequestsTracker(10)
+
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page1")
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page2")
+
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page1"))
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page2"))
+})
+
+test("markUrlAsRefreshed() can track multiple request IDs for the same URL", () => {
+  const tracker = new RecentRequestsTracker(10)
+
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page1")
+  tracker.markUrlAsRefreshed("request-2", "https://example.com/page1")
+
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page1"))
+  assert.isTrue(tracker.hasRefreshedUrl("request-2", "https://example.com/page1"))
+})
+
+test("cleanup removes old entries for different request IDs", () => {
+  const tracker = new RecentRequestsTracker(2)
+
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page1")
+  tracker.markUrlAsRefreshed("request-2", "https://example.com/page2")
+
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page1"))
+  assert.isTrue(tracker.hasRefreshedUrl("request-2", "https://example.com/page2"))
+
+  tracker.markUrlAsRefreshed("request-3", "https://example.com/page3")
+
+  assert.isFalse(tracker.hasRefreshedUrl("request-1", "https://example.com/page1"))
+  assert.isTrue(tracker.hasRefreshedUrl("request-2", "https://example.com/page2"))
+  assert.isTrue(tracker.hasRefreshedUrl("request-3", "https://example.com/page3"))
+})
+
+test("cleanup removes old entries for the same request ID", () => {
+  const tracker = new RecentRequestsTracker(2)
+
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page1")
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page2")
+
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page1"))
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page2"))
+
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page3")
+
+  assert.isFalse(tracker.hasRefreshedUrl("request-1", "https://example.com/page1"))
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page2"))
+  assert.isTrue(tracker.hasRefreshedUrl("request-1", "https://example.com/page3"))
+})
+
+test("hasRefreshedUrl() returns false for non-existent request ID", () => {
+  const tracker = new RecentRequestsTracker(10)
+
+  assert.isFalse(tracker.hasRefreshedUrl("non-existent", "https://example.com/page1"))
+})
+
+test("hasRefreshedUrl() returns false for non-existent URL", () => {
+  const tracker = new RecentRequestsTracker(10)
+
+  tracker.markUrlAsRefreshed("request-1", "https://example.com/page1")
+
+  assert.isFalse(tracker.hasRefreshedUrl("request-1", "https://example.com/different-page"))
+})
+
+test("addRequestId() adds the request ID without any URL", () => {
+  const tracker = new RecentRequestsTracker(10)
+
+  tracker.addRequestId("request-1")
+
+  assert.isTrue(tracker.requestIds.has("request-1"))
+})


### PR DESCRIPTION
# Description

This PR enables Turbo to handle the common pattern of keeping modals/slideouts open while refreshing the page behind them without extra code needed. When updating content in a persistent modal, any broadcasts from the server will correctly refresh the stale background content, making modern UI patterns work out-of-the-box.

This eliminates the need for manual Turbo Stream updates when building slideouts, dialogs, and inline editors that need to stay open while updating both their own content and the page behind them.

i.e. it makes the happy path, even happier. 

## Details

Turbo is currently focused on modals/slideouts that close when you submit them, because it assumes you'll redirect to the current page, getting the freshest content.

Imagine you have a standard Rails controller action:

```rb
def update
  @conversation.update!(conversation_params)
  redirect_to conversations_path
end
```

And a Turbo frame that gets the conversation content when you click on one:

```html
<a data-turbo-frame="modal" href="/conversations/1">Conversation 1</a>
<turbo-frame id="modal"></turbo-frame>
```

**Redirecting to /conversations with standard body replacement**


https://github.com/user-attachments/assets/666fbc79-14c1-4ffa-904b-5f32cb2e2f2e



**Redirecting to /conversations with page refresh (morph)**

https://github.com/user-attachments/assets/6fccc6ca-f571-4c01-8fd0-7dcb59fd2034

What happens though, if you want to leave the modal/slideout open, and want both the modal and the content behind it to be updated after you submit the form?

If you keep redirecting to the `conversations_path`, the modal will be "closed", because the incoming HTML has an empty Turbo frame, so the modal content will be replaced by empty HTML.

So you instead redirect to the conversation show path:

```rb
def update
  @conversation.update!(conversation_params)
  redirect_to conversation_path(@conversation)
end
```

This will keep the modal "open" and update its contents, but the content behind it will no longer be updated:

https://github.com/user-attachments/assets/e8a2afde-c29f-4753-bcce-0efb318baece

It is at this point that you have to reach out to Turbo streams to manually update the content behind the modal, and to quote @jorgemanrubia's [A happier happy path in Turbo with morphing](https://dev.37signals.com/a-happier-happy-path-in-turbo-with-morphing/):

>"...that's the whole point here: not having to write those". 

>"See, your life gets more complex whenever you add partial updates to the mix. Now you have to care about screen regions, the elements they contain, and how interactions affect them. Good abstractions help, but you can’t shake the additional complexity off. You are just in a more complex realm.
>
>This is why we say that Turbo is progressive: go with the happy [Turbo Drive](https://turbo.hotwired.dev/handbook/drive) path by default — and deviate from it when you need higher fidelity for specific screens or interactions."

With this PR, the controller remains unchanged. Turbo is now smart enough to detect that a page refresh is needed and allows it to be processed if the server sends it, for example, with a model broadcasting page refreshes when updated with:

```rb
class Conversation < ApplicationRecord
  broadcasts_refreshes
end
```

https://github.com/user-attachments/assets/b10c3c43-665b-49d1-9ee1-9c5be28fd192

Note that since the page is refreshed, the refresh would "close" the modal by replacing or morphing the Turbo frame contents with the empty HTML from the conversations page. So we just add `data-turbo-permanent` to the modal:

```html
<turbo-frame id="modal" data-turbo-permanent></turbo-fame>
```

## Inline Rails script reproduction

Apart from the Turbo tests in this PR (which more deeply test things, such as not processing duplicate page refreshes or not processing them when it doesn't have to), I have prepared an inline Rails script that you can save to a file, e.g. `rails.rb` run via:

```rb
ruby rails.rb
```

The tests all pass with this PR.

If you want to run them against Turbo latest release, just comment/uncomment these lines, which will make tests fail:

```diff
// Original
-// import "https://unpkg.com/@hotwired/turbo@8.0.18/dist/turbo.es2017-esm.js"
+import "https://unpkg.com/@hotwired/turbo@8.0.18/dist/turbo.es2017-esm.js"
// PR:
-import "https://cdn.jsdelivr.net/gh/davidalejandroaguilar/turbo@track-refreshes-per-request-and-url-dist/dist/turbo.es2017-esm.js"
+// import "https://cdn.jsdelivr.net/gh/davidalejandroaguilar/turbo@track-refreshes-per-request-and-url-dist/dist/turbo.es2017-esm.js"
```

You can also comment out the tests and uncomment the "playground" test for you to test manually.

The inline Rails script is below:

<details>
  <summary>Inline Rails script</summary>
<p>

```rb
require "bundler/inline"

gemfile(true) do
  source "https://rubygems.org"

  gem "rails"
  gem "propshaft"
  gem "puma"
  gem "sqlite3"
  gem "turbo-rails"
  gem "solid_cable"

  gem "capybara"
  gem "cuprite", require: "capybara/cuprite"
end

ENV["DATABASE_URL"] = "sqlite3::memory:"
ENV["RAILS_ENV"] = "test"

require "active_model/railtie"
require "active_record/railtie"
require "action_controller/railtie"
require "action_view/railtie"
require "active_job/railtie"
require "action_cable/engine"
require "rails/test_unit/railtie"

class App < Rails::Application
  config.load_defaults Rails::VERSION::STRING.to_f

  config.root = __dir__
  config.hosts << "example.org"
  config.eager_load = false
  config.session_store :cookie_store, key: "cookie_store_key"
  config.secret_key_base = "secret_key_base"
  config.consider_all_requests_local = true
  config.action_cable.cable = {
    "adapter" => "solid_cable"
  }
  config.active_job.queue_adapter = :async

  Rails.logger = config.logger = Logger.new($stdout)

  routes.append do
    root to: "conversations#index"
    resources :conversations, only: [:index, :show] do
      member do
        put :update_and_redirect_to_conversation_show
        put :update_and_redirect_to_conversation_index
        put :update_and_redirect_to_root_path
      end
    end
  end
end

Rails.application.initialize!

ActiveRecord::Schema.define do
  create_table :conversations, force: true do |t|
    t.text :name, null: false
  end
end

class Conversation < ActiveRecord::Base
  include Turbo::Broadcastable

  broadcasts_refreshes
end

class ApplicationController < ActionController::Base
  include Rails.application.routes.url_helpers

  def self.shared_head_template
    @shared_head_template ||= ERB.new(<<~HTML)
      <%= csrf_meta_tags %>
      <script type="module">
        // Original:
        // import "https://unpkg.com/@hotwired/turbo@8.0.18/dist/turbo.es2017-esm.js"
        // PR:
        import "https://cdn.jsdelivr.net/gh/davidalejandroaguilar/turbo@track-refreshes-per-request-and-url-dist/dist/turbo.es2017-esm.js"
        import { createConsumer } from "https://unpkg.com/@rails/actioncable@7.2.0/app/assets/javascripts/actioncable.esm.js"

        const consumer = createConsumer("/cable")

        document.addEventListener("DOMContentLoaded", () => {
          document.querySelectorAll("turbo-cable-stream-source").forEach(element => {
            const channel = element.getAttribute("channel")
            const signedStreamName = element.getAttribute("signed-stream-name")

            if (channel && signedStreamName) {
              consumer.subscriptions.create(
                {
                  channel: channel,
                  signed_stream_name: signedStreamName
                },
                {
                  received(data) {
                    Turbo.renderStreamMessage(data)
                  }
                }
              )

              element.setAttribute("connected", "true")
            }
          })
        })
      </script>

      <style>
        form {
          border: 1px solid;
          margin: 15px;
          padding: 10px;
        }

        .modal {
          position: fixed;
          top: 0%;
          left: 50%;
          transform: translateX(-50%);
          background: white;
          border: 1px solid #ccc;
          box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
          padding: 20px;
          z-index: 10;
          max-width: 500px;
          width: 100%;
          height: 50rem;
          overflow-y: scroll;
        }

        .conversation-item {
          margin-bottom: 50rem;
        }
      </style>
    HTML
  end

  helper_method :render_shared_head

  def render_shared_head
    self.class.shared_head_template.result(
      view_context.instance_eval { binding }
    ).html_safe
  end

  class_attribute :index_template, default: <<~'HTML'
    <!DOCTYPE html>
    <html>
      <head>
        <%= render_shared_head %>
      </head>

      <body>
        <h1>Conversations</h1>
        <ul>
          <% @conversations.reverse.each do |conversation| %>
            <%= turbo_stream_from conversation %>
            <li class="conversation-item">
              <%= link_to "Conversation from index #{conversation.name}", conversation_path(conversation), data: {"turbo-frame" => "modal"} %>
            </li>
          <% end %>
        </ul>

        <%= turbo_frame_tag "modal", data: {"turbo-permanent" => true} %>
      </body>
    </html>
  HTML

  class_attribute :show_template, default: <<~HTML
    <!DOCTYPE html>
    <html>
      <head>
        <%= render_shared_head %>
      </head>

      <body>
        <%= turbo_frame_tag "modal" do%>
          <div class="modal">
            <h1>Conversation from show: <%= @conversation.name %></h1>

            <h2>#1 Update conversation and redirect to conversation show inside modal frame</h2>
            <%= form_with model: @conversation, url: update_and_redirect_to_conversation_show_conversation_path(@conversation), method: :put, html: {id: "form-to-update-conversation-and-redirect-to-conversations-show-inside-modal-frame"} do |form| %>
              <%= form.text_field :name %>
              <%= form.submit "Update Conversation" %>

              <p>On the next page, a refesh should happen because only the content inside the Turbo frame will be updated and thus, the content outside it is stale. Only one refresh should be processed.</p>
              <p>This is the recommended approach is you want to update the conversation on both the modal and the conversations index.</p>
            <% end %>

            <h2>#2 Update conversation and redirect to conversation show outside modal frame</h2>
            <%= form_with model: @conversation, url: update_and_redirect_to_conversation_show_conversation_path(@conversation), method: :put, data: {"turbo-frame" => "_top"}, html: {id: "form-to-update-conversation-and-redirect-to-conversations-show-outside-modal-frame"} do |form| %>
              <%= form.text_field :name %>
              <%= form.submit "Update Conversation" %>

              <p>On the next page, a refesh should NOT happen because we're exiting the Turbo frame and thus the content is already fresh.</p>
              <p>This approach would take you to the conversation show page, outside the modal's Turbo frame.</p>
            <% end %>

            <h2>#3 Update conversation and redirect to conversation index inside modal frame</h2>
            <%= form_with model: @conversation, url: update_and_redirect_to_conversation_index_conversation_path(@conversation), method: :put, html: {id: "form-to-update-conversation-and-redirect-to-conversations-index-inside-modal-frame"} do |form| %>
              <%= form.text_field :name %>
              <%= form.submit "Update Conversation" %>

              <p>On the next page, a refresh should happen because, since we're still inside the Turbo frame, the incoming updated conversation's index page only has an empty Turbo frame and since the updated content is outside it, it will be discarded. Only one refresh should be processed.</p>
              <p>This approach would only update the conversations index, not the modal.</p>
              <p>It will also "close" the slideout/modal because the incoming HTML has an empty Turbo frame and we're not exiting the Turbo frame, so the slideout/modal content will be replaced by empty HTML.</p>
            <% end %>

            <h2>#4 Update conversation and redirect to conversation index outside modal frame</h2>
            <%= form_with model: @conversation, url: update_and_redirect_to_conversation_index_conversation_path(@conversation), method: :put, data: {"turbo-frame" => "_top"}, html: {id: "form-to-update-conversation-and-redirect-to-conversations-index-outside-modal-frame"} do |form| %>
              <%= form.text_field :name %>
              <%= form.submit "Update Conversation" %>

              <p>On the next page, a refresh should NOT happen, because we exited the Turbo frame and thus the content is already fresh.</p>
              <p>This approach would only update the conversations index, not the modal.</p>
              <p>It will not "close" the slideout/modal because we're exiting the Turbo frame, and even though the incoming HTML has an empty Turbo frame, the data-turbo-permanent attribute will prevent its content from being replaced by empty HTML.</p>
            <% end %>

            <h2>#5 Update conversation and redirect to root path inside modal frame</h2>
            <%= form_with model: @conversation, url: update_and_redirect_to_root_path_conversation_path(@conversation), method: :put, html: {id: "form-to-update-conversation-and-redirect-to-root-path-inside-modal-frame"} do |form| %>
              <%= form.text_field :name %>
              <%= form.submit "Update Conversation" %>
              <p>This is the same thing as #3</p>
            <% end %>

            <h2>#6 Update conversation and redirect to root path outside modal frame</h2>
            <%= form_with model: @conversation, url: update_and_redirect_to_root_path_conversation_path(@conversation), method: :put, data: {"turbo-frame" => "_top"}, html: {id: "form-to-update-conversation-and-redirect-to-root-path-outside-modal-frame"} do |form| %>
              <%= form.text_field :name %>
              <%= form.submit "Update Conversation" %>
              <p>This is the same thing as #4</p>
            <% end %>
          </div>
        <% end %>
      </body>
    </html>
  HTML
end

class ConversationsController < ApplicationController
  def index
    @conversations = Conversation.all
    render inline: index_template, formats: :html
  end

  def show
    @conversation = Conversation.find(params[:id])
    render inline: show_template, formats: :html
  end

  def update_and_redirect_to_conversation_show
    update_conversation!
    redirect_to conversation_path(@conversation)
    broadcast_extra_refreshes
  end

  def update_and_redirect_to_conversation_index
    update_conversation!
    redirect_to conversations_path
    broadcast_extra_refreshes
  end

  def update_and_redirect_to_root_path
    update_conversation!
    redirect_to root_path
    broadcast_extra_refreshes
  end

  private

  def update_conversation!
    @conversation = Conversation.find(params[:id])
    @conversation.update!(name: params[:conversation][:name])
  end

  def broadcast_extra_refreshes
    # Apart from model's brodcasts_refreshes, we trigger these additional
    # refreshes. Turbo will only process one refresh per request.
    @conversation.broadcast_refresh
    @conversation.broadcast_refresh_later
  end
end

class ApplicationSystemTestCase < ActionDispatch::SystemTestCase
  # driven_by :cuprite, using: :chrome, screen_size: [1400, 1400], options: {js_errors: true}
  driven_by :cuprite, using: :chrome, screen_size: [1400, 1400], options: {js_errors: true, headless: false}
end

Capybara.configure do |config|
  config.server = :puma, {Silent: true}
  config.default_normalize_ws = true
end

require "rails/test_help"

class TurboSystemTest < ApplicationSystemTestCase
  def setup
    3.times do |i|
      Conversation.create(name: "Conversation #{i + 1}")
    end

    visit root_path

    assert_text "Conversations"
    3.times do |i|
      assert_text "Conversation from index Conversation #{i + 1}"
    end

    click_on "Conversation from index Conversation 1"
    assert_text "Conversation from show: Conversation 1"
    assert_current_path root_path
    assert_modal_open
  end

  def teardown
    sleep ARGV.first.to_i
  end

  def assert_modal_closed
    assert_no_selector ".modal"
  end

  def assert_modal_open
    assert_selector ".modal"
  end

  test "example #1: From conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to conversations Show still inside the Turbo frame should refresh the page because only the content inside the Turbo frame was updated and thus, the content outside it is stale. Only one refresh should be processed." do
    within("#form-to-update-conversation-and-redirect-to-conversations-show-inside-modal-frame") do
      fill_in "conversation[name]", with: "Conversation 1 Updated"
      click_on "Update Conversation"
    end

    sleep 0.25
    assert_modal_open
    assert_text "Conversation from show: Conversation 1 Updated"
    assert_text "Conversation from index Conversation 1 Updated"
    assert_current_path root_path
  end

  test "example #2: From conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to conversations show outside the Turbo frame should not refresh the page because we're exiting the Turbo frame and thus the content is already fresh." do
    within("#form-to-update-conversation-and-redirect-to-conversations-show-outside-modal-frame") do
      fill_in "conversation[name]", with: "Conversation 1 Updated"
      click_on "Update Conversation"
    end

    sleep 0.25
    assert_text "Conversation from show: Conversation 1 Updated"
    assert_no_text "Conversation from index Conversation 1 Updated"
    assert_current_path conversation_path(Conversation.find_by(name: "Conversation 1 Updated"))
  end

  test "example #3: From conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to conversations Index still inside the Turbo frame should refresh the page because, since we're still inside the Turbo frame, the incoming updated conversation's index page only has an empty Turbo frame and since the updated content is outside it, it will be discarded. Only one refresh should be processed." do
    within("#form-to-update-conversation-and-redirect-to-conversations-index-inside-modal-frame") do
      fill_in "conversation[name]", with: "Conversation 1 Updated"
      click_on "Update Conversation"
    end

    sleep 0.25
    assert_modal_closed
    assert_no_text "Conversation from show: Conversation 1 Updated"
    assert_text "Conversation from index Conversation 1 Updated"
    assert_current_path root_path
  end

  test "example #4: From conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to conversations Index outside the Turbo frame should not refresh the page because we exited the Turbo frame and thus the content is already fresh." do
    within("#form-to-update-conversation-and-redirect-to-conversations-index-outside-modal-frame") do
      fill_in "conversation[name]", with: "Conversation 1 Updated"
      click_on "Update Conversation"
    end

    sleep 0.25
    assert_modal_open
    assert_text "Conversation from show: Conversation 1"
    assert_text "Conversation from index Conversation 1 Updated"
    assert_current_path conversations_path
  end

  test "example #5: From conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to root path still inside the Turbo frame should refresh the page because, since we're still inside the Turbo frame, the incoming updated conversation's index page only has an empty Turbo frame and since the updated content is outside it, it will be discarded. Only one refresh should be processed." do
    within("#form-to-update-conversation-and-redirect-to-root-path-inside-modal-frame") do
      fill_in "conversation[name]", with: "Conversation 1 Updated"
      click_on "Update Conversation"
    end

    assert_modal_closed
    assert_no_text "Conversation from show: Conversation 1 Updated"
    assert_text "Conversation from index Conversation 1 Updated"
    assert_current_path root_path
  end

  test "example #6: From conversations Index, opening a Turbo frame slideout/modal to conversation Show, submitting a form inside the slideout/modal that redirects to root path outside the Turbo frame should not refresh the page because we exited the Turbo frame and thus the content is already fresh." do
    within("#form-to-update-conversation-and-redirect-to-root-path-outside-modal-frame") do
      fill_in "conversation[name]", with: "Conversation 1 Updated"
      click_on "Update Conversation"
    end

    sleep 0.25
    assert_modal_open
    assert_text "Conversation from show: Conversation 1"
    assert_text "Conversation from index Conversation 1 Updated"
    assert_current_path root_path
  end

  # test "playground" do
  #   sleep 500
  # end
end
```
</p>
</details>

## How it works

Originally, Turbo only kept track of request ids.

**Original approach**

1. Submit a form
2. Generate a `requestUID`
3. Save it on a `recentRequests` variable
4. Attach it as a header to the request
5. Server obtains `requestUID`, Rails sets it in `Turbo.current_request_id`
6. Server redirects you
7. Server triggers broadcasts with the `requestUID` set
8. Turbo receives broadcasts
9. If `requestID` is in recent requests, ignore refresh

This worked for normal form submission that redirected to the same page, since the server just redirected you there, there's no need to process a refresh, you already have the freshest content:

**Scenario A**

1. User is in /conversations
2. Clicks a link to open /conversations/1
3. The content is placed in a `data-turbo-permanent` Turbo frame as a modal/slideout
4. Submits a form
5. Turbo generates `requestUID` "123"
6. The server redirects to /conversations
7. The modal/slideout "closes" (because /conversations has an empty Turbo frame)
8. The content in the /conversations page is fresh.
9. The server broadcasts one or many page refreshes with `requestUID "123"
10. Turbo discards them because it already has them on `recentRequests`

However, in the case of modals/slideouts within a Turbo frame that you want to keep open and update BOTH the modal content and the one behind the modal, this doesn't work:

**Scenario B**

1. User is in /conversations
2. Clicks a link to open /conversations/1
3. The content is placed in a `data-turbo-permanent` Turbo frame as a modal/slideout
4. Submits a form
5. Turbo generates `requestUID` "123"
6. The server redirects to /conversations/1
7. The modal/slideout stays "open" and the deal information within it gets updated and is fresh
8. The content behind it is stale.
9. The server broadcasts one or many page refreshes with `requestUID` "123"
10. Turbo discards them because it already has them on `recentRequests`

In order to fix this, we now keep track of request ids and URLs.

**New approach**

1. Submit a form
2. Generate a `requestUID`
3. Save it on a `recentRequests` variable
4. Attach it as a header to the request.
5. Server obtains `requestUID`, Rails sets it in `Turbo.current_request_id`
6. Server redirects you.
7. Turbo checks if response is a redirect not part of a Turbo frame
8. If so, it marks the URL as refreshed for that `requestID`, this prevents processing refreshes for redirects that the browser will follow and thus content will be fresh.
7. Server triggers broadcasts with the `requestUID` set
8. Turbo receives broadcasts
9. If `requestID` is in recent requests for the current URL, ignore refresh

This fixes the persistent modal scenario:

**Scenario B**

1. User is in /conversations
2. Clicks a link to open /conversations/1
3. The content is placed in a data-turbo-permanent Turbo frame as a modal/slideout
4. Submits a form
5. Turbo generates `requestUID` "123"
6. The server redirects to /conversations/1
7. The modal/slideout stays "open" and the deal information within it gets updated and is fresh
8. The content behind it is stale.
9. The server broadcasts one or many page refreshes with `requestUID` "123"
10. Turbo hasn't processed a refresh for `requestUID` "123" for URL /conversations, so it processes it
11. Any subsequent refreshes for `requestID` "123" and URL /conversations are discarded

The first "normal" scenario mentioned above still works:

**Scenario A**

1. User is in /conversations
2. Clicks a link to open /conversations/1
3. The content is placed in a data-turbo-permanent Turbo frame as a modal/slideout
4. Submits a form
5. Turbo generates `requestUID` "123"
6. The server redirects to /conversations
7. The modal/slideout "closes" (because /conversations has an empty Turbo frame)
8. The content in the /conversations page is fresh.
9. The server broadcasts one or many page refreshes with `requestUID` "123"
10. Turbo discards them because redirect was for /conversations, which the browser already followed and used for fresh content, and thus, `requestUID` "123" for URL /conversations was already marked as refreshed
11. Any subsequent refreshes for `requestID` "123" and URL /conversations are discarded

Some diagrams for those that are more visual:

<details>
<summary>Diagrams</summary>

<p>

[![](https://img.plantuml.biz/plantuml/svg/xLN1Rjf04Btp5LDE845HsXjIgWHILP6IWd2Y7gEnFTWZx5rtTqsKl-_O2mPiYDIgXnvwiZJxPlQzDq_h6-lGk3BFUXzSIZb1aI6h7e1Zbn4ybIRKiCI4O4LhGpQLxy-Ih8CdWz66LGA3XU645MR3dlGLCeuZBb0vw3zRCfEPqQ_oxGDQg0fjaBzZdZ4fLuFgGXiLaDdAi1LoPckKBxHXSXd64Gg_uCqwocjeKwm8Nb_3dZ3S5eKSHQaKvQGY1-Cl_luf16MOiuErDhaSUfQ7qs-aoA0ZCDwFv_kxCwW0jmHE2oWITJlhx37GovWsjhwoIuzcGaeOrp8zyBWb8EVdV8nAOsJ-owxlXUEJXafOTKFCmiF9T5jePUa4qtWqbSroaaWrt9TicvLq7em-gArpOdOvwRQqpPcd56s0ryToMNMzKhgocPDKkDslPI6bYaV0YTAckMwtsK1QqR26soaywbXMFC-q9Gk37zfKQHsUhjexynstd5Ixb4rD8gt44ekEnQDkAYIdGZfZjUcY9rTdL3w8JvMi61sENLKR5sHoL28IrWPp-WlHW_xLfy_ztydLlk5YIivvSRm9RszKspi2GJelg5h6XM2zbu-6qBbWxTyUCQHBgctF7Ti8JGo3zs8rR0TcjbSKE7opi2X8mM1fT9XH_ZyqVnoQMbqtDhOsMOl98mWfPHKt2PAZxEBJz4ybw5JOShMOFNnzdCAieqUaUbKtf6Bvr_u2)](https://editor.plantuml.com/uml/xLN1Rjf04Btp5LDE845HsXjIgWHILP6IWd2Y7gEnFTWZx5rtTqsKl-_O2mPiYDIgXnvwiZJxPlQzDq_h6-lGk3BFUXzSIZb1aI6h7e1Zbn4ybIRKiCI4O4LhGpQLxy-Ih8CdWz66LGA3XU645MR3dlGLCeuZBb0vw3zRCfEPqQ_oxGDQg0fjaBzZdZ4fLuFgGXiLaDdAi1LoPckKBxHXSXd64Gg_uCqwocjeKwm8Nb_3dZ3S5eKSHQaKvQGY1-Cl_luf16MOiuErDhaSUfQ7qs-aoA0ZCDwFv_kxCwW0jmHE2oWITJlhx37GovWsjhwoIuzcGaeOrp8zyBWb8EVdV8nAOsJ-owxlXUEJXafOTKFCmiF9T5jePUa4qtWqbSroaaWrt9TicvLq7em-gArpOdOvwRQqpPcd56s0ryToMNMzKhgocPDKkDslPI6bYaV0YTAckMwtsK1QqR26soaywbXMFC-q9Gk37zfKQHsUhjexynstd5Ixb4rD8gt44ekEnQDkAYIdGZfZjUcY9rTdL3w8JvMi61sENLKR5sHoL28IrWPp-WlHW_xLfy_ztydLlk5YIivvSRm9RszKspi2GJelg5h6XM2zbu-6qBbWxTyUCQHBgctF7Ti8JGo3zs8rR0TcjbSKE7opi2X8mM1fT9XH_ZyqVnoQMbqtDhOsMOl98mWfPHKt2PAZxEBJz4ybw5JOShMOFNnzdCAieqUaUbKtf6Bvr_u2)

</p>

<p>

[![](https://img.plantuml.biz/plantuml/svg/xLR1Jjj04BtdAwQSY0f5jBT8gI0WLKWqHPY88zhOOtkLzQwxEqwQl-zirdRiO42bXrwQIonxtioyDs_Mld0aB5M56dsW70k4KWcfHm0aII4yL7Pfu4va2FUOMdGv__-iq14yM16lfCxWU8wRyMWqdG9Vm6LPMYFY7APJph9mQE7qQyWpWQXQ5f8WDRRWXo7v_katr6W58TXGOd5pFH0LYJK26GwAKLFTZUi6HcZNQ2Tjfnj9UISdv2WIj8m8WLr8X1JoV8ehQpd_KurxaaaFu8dv2edaFeYpkz9eXmFzNkKOhq2c75C7cugSJ1fnKoiAZnEAzlcQaEQX_nqc_Yxi2XRtjo0SvzuD1nElRLy_rFtEPpoU91QE9Zn2cMLyTzdSSeTQCRADxvJU6QAkEG1vHO9s2FsEQxKz7SPhuqqWivnxl4aveD8XZ7BfVCm9o4mRs_OmOX3xBs9722iDNB8w9X4AhfHnwE0u8gaKF1hh7JlkUpECSYxMClFcOskTnKQpMawGvA4-j_6Lain7IRrw7drsFY30BKi8KaCYI9oIltTQeYs4zfoR6V_jhi3H-USlHt-o20tWHLiFQJ5emtxKmN2RCjsnigisdczgbEAhTZbEW3DHaCKFzWNdlcR0jjwGSvjJpFVr9hLhwM9X4pWMolAPiOM2kJAfbjwOGRljx9flrfWl8h5ryAD4pMUasK0gVp7al_dUQxuTkww9Wink9xFnCkzgX07NDlgt1We7ts7cOMoNsDnGPuUsIBtJhrieQ7PdJOoktRkt2ymmbtocDhkclJlhVHiYVQctuAgbyqGqzSe4HX_ViKnxWWqn_efWu0M_iVY3v3S0)](https://editor.plantuml.com/uml/xLR1Jjj04BtdAwQSY0f5jBT8gI0WLKWqHPY88zhOOtkLzQwxEqwQl-zirdRiO42bXrwQIonxtioyDs_Mld0aB5M56dsW70k4KWcfHm0aII4yL7Pfu4va2FUOMdGv__-iq14yM16lfCxWU8wRyMWqdG9Vm6LPMYFY7APJph9mQE7qQyWpWQXQ5f8WDRRWXo7v_katr6W58TXGOd5pFH0LYJK26GwAKLFTZUi6HcZNQ2Tjfnj9UISdv2WIj8m8WLr8X1JoV8ehQpd_KurxaaaFu8dv2edaFeYpkz9eXmFzNkKOhq2c75C7cugSJ1fnKoiAZnEAzlcQaEQX_nqc_Yxi2XRtjo0SvzuD1nElRLy_rFtEPpoU91QE9Zn2cMLyTzdSSeTQCRADxvJU6QAkEG1vHO9s2FsEQxKz7SPhuqqWivnxl4aveD8XZ7BfVCm9o4mRs_OmOX3xBs9722iDNB8w9X4AhfHnwE0u8gaKF1hh7JlkUpECSYxMClFcOskTnKQpMawGvA4-j_6Lain7IRrw7drsFY30BKi8KaCYI9oIltTQeYs4zfoR6V_jhi3H-USlHt-o20tWHLiFQJ5emtxKmN2RCjsnigisdczgbEAhTZbEW3DHaCKFzWNdlcR0jjwGSvjJpFVr9hLhwM9X4pWMolAPiOM2kJAfbjwOGRljx9flrfWl8h5ryAD4pMUasK0gVp7al_dUQxuTkww9Wink9xFnCkzgX07NDlgt1We7ts7cOMoNsDnGPuUsIBtJhrieQ7PdJOoktRkt2ymmbtocDhkclJlhVHiYVQctuAgbyqGqzSe4HX_ViKnxWWqn_efWu0M_iVY3v3S0)

</p>
</details>

Note that this PR aims to NOT break existing behavior nor introduce unwanted additional page refreshes, but only progressively enhance the developer experience in a way that makes sense and it's expected:

e.g. "I'm redirecting to this modal to update it, and my model broadcasts refreshes, why is the page not being refreshed to update the content behind it?"

In order to do so, this PR adds test coverage for many different scenarios. It does so by introducing fixtures under `src/tests/fixtures/conversations/` to be a seamless addition to the "messages" concept we use throughout, as well as making more sense to others, since it's an easier mental model to "open a  modal for a conversation" than to "open modal for a message".