### PR TITLE
Proposal: Add `[headless]` attribute to `<turbo-frame>`

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -110,6 +110,15 @@ export class FrameController {
     }
   }
 
+  headlessChanged() {
+    // No action needed on attribute change. This method is required because
+    // "headless" is in FrameElement.observedAttributes, which triggers
+    // attributeChangedCallback, which calls this delegate method.
+    //
+    // The headless attribute is evaluated while extractForeignFrameElement
+    // processes the response.
+  }
+
   async #loadSourceURL() {
     if (this.enabled && this.isActive && !this.complete && this.sourceURL) {
       this.element.loaded = this.#visit(expandURL(this.sourceURL))
@@ -440,6 +449,14 @@ export class FrameController {
     const id = CSS.escape(this.id)
 
     try {
+      // If headless mode is enabled, wrap the entire response body in a synthetic frame
+      if (this.element.headless) {
+        const syntheticFrame = document.createElement("turbo-frame")
+        syntheticFrame.setAttribute("id", this.id)
+        syntheticFrame.append(...container.cloneNode(true).childNodes)
+        return syntheticFrame
+      }
+
       element = activateElement(container.querySelector(`turbo-frame#${id}`), this.sourceURL)
       if (element) {
         return element

--- a/src/elements/frame_element.js
+++ b/src/elements/frame_element.js
@@ -25,7 +25,7 @@ export class FrameElement extends HTMLElement {
   loaded = Promise.resolve()
 
   static get observedAttributes() {
-    return ["disabled", "loading", "src"]
+    return ["disabled", "loading", "src", "headless"]
   }
 
   constructor() {
@@ -52,6 +52,8 @@ export class FrameElement extends HTMLElement {
       this.delegate.sourceURLChanged()
     } else if (name == "disabled") {
       this.delegate.disabledChanged()
+    } else if (name == "headless") {
+      this.delegate.headlessChanged()
     }
   }
 
@@ -154,6 +156,30 @@ export class FrameElement extends HTMLElement {
       this.setAttribute("autoscroll", "")
     } else {
       this.removeAttribute("autoscroll")
+    }
+  }
+
+  /**
+   * Gets the headless state of the frame.
+   *
+   * If true, the frame will accept any response content without requiring
+   * a matching turbo-frame element in the response.
+   */
+  get headless() {
+    return this.hasAttribute("headless")
+  }
+
+  /**
+   * Sets the headless state of the frame.
+   *
+   * If true, the frame will accept any response content without requiring
+   * a matching turbo-frame element in the response.
+   */
+  set headless(value) {
+    if (value) {
+      this.setAttribute("headless", "")
+    } else {
+      this.removeAttribute("headless")
     }
   }
 

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -153,5 +153,14 @@
     <a id="below-the-fold-link-frame-action" data-turbo-action="advance" data-turbo-frame="frame" href="/src/tests/fixtures/frames/frame.html">Navigate #frame</a>
 
     <a id="link-to-eager-loaded-frame" href="/__turbo/redirect?path=/src/tests/fixtures/page_with_eager_frame.html">Eager-loaded frame after GET redirect</a>
+
+    <turbo-frame id="headless" headless>
+      <h2>Frames: #headless</h2>
+      <p>This is a headless frame that accepts any response</p>
+      <a id="link-headless" href="/src/tests/fixtures/frames/headless_response.html">Load headless response</a>
+      <a id="link-headless-with-scripts" href="/src/tests/fixtures/frames/headless_response_with_scripts.html">Load headless with scripts</a>
+    </turbo-frame>
+
+    <a id="outside-headless-link" href="/src/tests/fixtures/frames/headless_response.html" data-turbo-frame="headless">Navigate headless from outside</a>
   </body>
 </html>

--- a/src/tests/fixtures/frames/headless_response.html
+++ b/src/tests/fixtures/frames/headless_response.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Headless Response</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Plain Response Without Frame</h1>
+    <p id="headless-content">This content has no turbo-frame wrapper</p>
+    <div id="additional-data">Additional data that should be captured</div>
+  </body>
+</html>

--- a/src/tests/fixtures/frames/headless_response_with_scripts.html
+++ b/src/tests/fixtures/frames/headless_response_with_scripts.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Headless Response With Scripts</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Response With Script</h1>
+    <p id="headless-script-content">Content with inline script</p>
+    <script type="text/javascript">
+      document.getElementById("headless-script-content").setAttribute("data-script-executed", "true")
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
Turbo Frames are _amazing_, and provide a beautiful set of options to help an engineer be fruitful and productive in creating highly-interactive web applications.

For me, a common use-case is to have an endpoint (say a `#new` or `#edit`) that is ultimately returning the body of a modal, or another endpoint that's returning content that I need for say, specific tabs on the page.

[Campfire is also following this approach](https://github.com/basecamp/once-campfire/blob/5c0526eaf7f83d129472a520fa673bfcb9c2f397/app/views/messages/boosts/new.html.erb#L1-L26).

In the above instances, I'm not so much worried about creating a progressive enhancement version of the page, ala: a `posts/new` that renders some dom that won't be included in the population of the current frame. So then - it becomes a bit of a necessary evil to make sure that my response is wrapped in a matching frame, just so that it renders as expected.

Additionally - in working with engineers less experienced with Hotwire - it's been a common gotcha to forget to return content wrapped in a frame, or to mistype/mismatch the frame's ID.

As it so happens, I was chatting last week with an engineer who has regularly stumbled over this issue - and he just randomly asked: "Why don't turbo frame's let me shove the entire response into the frame, instead of requiring me to have the matching ID?" -- and thus, the idea for this change was born 😄

## Current Functionality
Current Page
```html
<a href="/posts/new" data-turbo-frame="modal">New Post</a>

<turbo-frame id="modal">
</turbo-frame>
```
Response
```html
<turbo-frame id="modal">
  <h2>Create a Post</h2>
  <form>
    <!-- etc -->
  </form>
</turbo-frame>
```

## Proposed (Headless) Functionality
Current page
```html

<a href="/posts/new" data-turbo-frame="modal">New Post</a>

<turbo-frame id="modal" headless>
</turbo-frame>
```
Response (no matching frame)
```html
<h2>Create a Post</h2>
<form>
  <!-- etc -->
</form>
```

---

Some folks might ask - "why not use an iFrame?", and that's a fair question! Turbo Frames are significantly more powerful than iFrames (morphing, lazy loading, event-emission, etc).

Let me know y'all's thoughts!

Thanks for this amazing project!

---

This PR aims to introduce a `[headless]` attribute for `<turbo-frame>` elements that accepts response content without requiring a matching `<turbo-frame id="...">` wrapper in the response.

This addresses a common point of confusion where developers need their frame to display content from endpoints that don't return properly wrapped frame responses. With `[headless]`, the entire response body is inserted into the frame, eliminating the need for response templates to include matching frame wrappers.

Implementation details:

First, add the `[headless]` attribute to `FrameElement`'s `observedAttributes` array and implement corresponding getter/setter methods following the pattern established by other boolean frame attributes like `[disabled]` and `[autoscroll]`.

Next, extend `extractForeignFrameElement` to check for the headless attribute. When present, create a synthetic `<turbo-frame>` element and populate it with the entire response body content using `container.cloneNode(true).childNodes`. This synthetic frame then flows through the standard frame rendering pipeline, ensuring consistent behavior with regular frame updates including script execution and event dispatching.

The implementation deliberately skips the `activateElement` pipeline for synthetic frames since they are created via `document.createElement` and already belong to the current document, avoiding the need for `document.importNode` or self-reference checking.

Test coverage includes:

* Accepting responses without matching frame IDs
* Skipping `turbo:frame-missing` event dispatch
* Executing scripts from response bodies
* Replacing all previous frame content with response body content

This feature maintains backward compatibility—existing frames continue to require matching IDs unless explicitly marked with `[headless]`.