### PR TITLE
Add support for data-turbo-frame="_parent" in nested frames

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -10,7 +10,8 @@ import {
   markAsBusy,
   uuid,
   getHistoryMethodForAction,
-  getVisitAction
+  getVisitAction,
+  findClosestRecursively
 } from "../../util"
 import { FormSubmission } from "../drive/form_submission"
 import { Snapshot } from "../snapshot"
@@ -432,6 +433,12 @@ export class FrameController {
 
   #findFrameElement(element, submitter) {
     const id = getAttribute("data-turbo-frame", submitter, element) || this.element.getAttribute("target")
+    if (id === "_parent") {
+      const parentFrame = findClosestRecursively(this.element.parentElement, "turbo-frame")
+      if (parentFrame) {
+        return parentFrame
+      }
+    }
     return getFrameElementById(id) ?? this.element
   }
 

--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -482,6 +482,13 @@ export class FrameController {
       return false
     }
 
+    if (id === "_parent") {
+      const parentFrame = findClosestRecursively(this.element.parentElement, "turbo-frame")
+      if (!parentFrame || parentFrame.disabled) {
+        return false
+      }
+    }
+
     if (id) {
       const frameElement = getFrameElementById(id)
       if (frameElement) {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -102,6 +102,10 @@
         <form method="get" action="/src/tests/fixtures/one.html" data-turbo-frame="_top">
           <input id="nested-child-navigate-form-top-submit" type="submit" value="Nested Child form submit">
         </form>
+
+        <turbo-frame id="nested-grandchild">
+          <a id="grandchild-link-parent" href="/src/tests/fixtures/frames/frame.html" data-turbo-frame="_parent">Navigate immediate parent only</a>
+        </turbo-frame>
       </turbo-frame>
 
       <turbo-frame id="nested-child-navigate-top" target="_top">
@@ -117,6 +121,10 @@
       <a href="/src/tests/fixtures/one.html" data-turbo-frame="_self">Visit self</a>
     </turbo-frame>
     <a id="outside-navigate-top-link" href="/src/tests/fixtures/one.html">Visit one.html from outside #navigate-top</a>
+
+    <turbo-frame id="top-level-parent">
+      <a href="/src/tests/fixtures/one.html?key=value" data-turbo-frame="_parent">Visit one.html?key=value with _parent</a>
+    </turbo-frame>
 
     <turbo-frame id="missing">
       <a id="missing-frame-link" href="/src/tests/fixtures/frames/frame.html">Missing frame</a>

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -95,7 +95,10 @@
         <button id="change-frame-id-to-different-nested-child" type="button">Change id to different-nested-child</button>
         <a href="/src/tests/fixtures/frames/frame.html">Load #nested-child</a>
         <a href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>
-
+        <a id="link-parent" href="/src/tests/fixtures/frames/parent.html" data-turbo-frame="_parent">Navigate parent</a>
+        <form action="/src/tests/fixtures/frames/parent.html" data-turbo-frame="_parent">
+          <button id="form-submit-parent">Submit to parent</button>
+        </form>
         <form method="get" action="/src/tests/fixtures/one.html" data-turbo-frame="_top">
           <input id="nested-child-navigate-form-top-submit" type="submit" value="Nested Child form submit">
         </form>

--- a/src/tests/fixtures/frames/parent.html
+++ b/src/tests/fixtures/frames/parent.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Nested Root: Parent</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Nested Root: Parent</h1>
+
+    <turbo-frame id="nested-root">
+      <h2>Parent: Loaded</h2>
+    </turbo-frame>
+  </body>
+</html>


### PR DESCRIPTION
## Summary

Implements support for `data-turbo-frame="_parent"` to allow links and forms within nested turbo-frames to target their immediate parent frame without knowing the parent's ID.

## Motivation

This addresses a common use case where:
- Components are rendered within frames but don't know the parent frame's ID
- Nested frames need to update their container without breaking out to `_top`
- Module-based architectures need flexible frame targeting

## Implementation

- Adds `_parent` as a special value alongside existing `_top` and `_self`
- Resolves `_parent` to the immediate parent frame's ID
- Falls back to full page visit when no parent frame exists or it's disabled
- Works for both link clicks and form submissions

## Examples

### Basic nested frame targeting
```html
<turbo-frame id="modal">
  <turbo-frame id="search-results">
    <a href="/items/123" data-turbo-frame="_parent">
      <!-- Search component doesn't need to know parent's ID -->
    </a>
  </turbo-frame>
</turbo-frame>
```

### Multiple nesting levels
```html
<turbo-frame id="outer">
  <turbo-frame id="middle">
    <turbo-frame id="inner">
      <a href="/path" data-turbo-frame="_parent">Updates middle</a>
    </turbo-frame>
  </turbo-frame>
</turbo-frame>
```

## Related Issues

Resolves #1187
References #252