### PR TITLE
Fix: preserve removed turbo-frames with refresh=morph on page refreshes

### DIFF
--- a/src/core/morphing.js
+++ b/src/core/morphing.js
@@ -35,14 +35,16 @@ export function morphChildren(currentElement, newElement, options = {}) {
 
 export function shouldRefreshFrameWithMorphing(currentFrame, newFrame) {
   return currentFrame instanceof FrameElement &&
-    // newFrame cannot yet be an instance of FrameElement because custom
-    // elements don't get initialized until they're attached to the DOM, so
-    // test its Element#nodeName instead
-    newFrame instanceof Element && newFrame.nodeName === "TURBO-FRAME" &&
-    currentFrame.shouldReloadWithMorph &&
-    currentFrame.id === newFrame.id &&
-    (!newFrame.getAttribute("src") || urlsAreEqual(currentFrame.src, newFrame.getAttribute("src"))) &&
+    currentFrame.shouldReloadWithMorph && (!newFrame || areFramesCompatibleForRefreshing(currentFrame, newFrame)) &&
     !currentFrame.closest("[data-turbo-permanent]")
+}
+
+function areFramesCompatibleForRefreshing(currentFrame, newFrame) {
+  // newFrame cannot yet be an instance of FrameElement because custom
+  // elements don't get initialized until they're attached to the DOM, so
+  // test its Element#nodeName instead
+  return newFrame instanceof Element && newFrame.nodeName === "TURBO-FRAME" && currentFrame.id === newFrame.id &&
+  (!newFrame.getAttribute("src") || urlsAreEqual(currentFrame.src, newFrame.getAttribute("src")))
 }
 
 export function closestFrameReloadableWithMorphing(node) {

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -321,21 +321,6 @@ test("calling reload on a frame[refresh=morph] reloads descendant frame[refresh=
   expect(await noNextEventOnTarget(page, "nested-child-navigate-top", "turbo:before-frame-morph")).toBeTruthy()
 })
 
-test("calling reload on a frame[refresh=morph] morphs descendant frame[refresh=morph] normally if the id no longer matches", async ({ page }) => {
-  await page.click("#nested-root #add-refresh-morph-to-frame")
-  await page.click("#nested-root #add-src-to-frame")
-  await page.click("#nested-child #add-refresh-morph-to-frame")
-  await page.click("#nested-child #add-src-to-frame")
-  await page.click("#nested-child #change-frame-id-to-different-nested-child")
-
-  await page.evaluate(() => document.getElementById("nested-root").reload())
-
-  expect(await nextEventOnTarget(page, "nested-root", "turbo:before-frame-morph")).toBeTruthy()
-  expect(await noNextEventOnTarget(page, "different-nested-child", "turbo:before-frame-morph")).toBeTruthy()
-  assert.ok(await hasSelector(page, "#nested-child"))
-  assert.notOk(await hasSelector(page, "#different-nested-child"))
-})
-
 test("calling reload on a frame[refresh=morph] preserves [data-turbo-permanent] elements", async ({ page }) => {
   await page.click("#add-src-to-frame")
   await page.click("#add-refresh-morph-to-frame")

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -253,6 +253,21 @@ test("navigated frames without refresh attribute are reset after morphing", asyn
   )
 })
 
+test("frames with refresh='morph' are preserved when missing from new content", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh.html")
+
+  await page.evaluate(() => {
+    const frame = document.getElementById("refresh-morph")
+    frame.id = "missing-frame" // Change ID so to simulate a removed frame
+  })
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+  await nextBeat()
+
+  assert.ok(await hasSelector(page, "#missing-frame"), "the frame is preserved")
+})
+
 test("it preserves the scroll position when the turbo-refresh-scroll meta tag is 'preserve'", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 


### PR DESCRIPTION
This was a regression introduced in https://github.com/hotwired/turbo/commit/e6e6997e4636ac87fa9bd17cc838b8fc0eeb213b