### PR TITLE
Build: Remove circular dependency

### DIFF
--- a/src/core/url.js
+++ b/src/core/url.js
@@ -33,6 +33,10 @@ export function locationIsVisitable(location, rootLocation) {
   return isPrefixedBy(location, rootLocation) && !config.drive.unvisitableExtensions.has(getExtension(location))
 }
 
+export function getLocationForLink(link) {
+  return expandURL(link.getAttribute("href") || "")
+}
+
 export function getRequestURL(url) {
   const anchor = getAnchor(url)
   return anchor != null ? url.href.slice(0, -(anchor.length + 1)) : url.href

--- a/src/observers/link_click_observer.js
+++ b/src/observers/link_click_observer.js
@@ -1,4 +1,5 @@
-import { doesNotTargetIFrame, findLinkFromClickTarget, getLocationForLink } from "../util"
+import { getLocationForLink } from "../core/url"
+import { doesNotTargetIFrame, findLinkFromClickTarget } from "../util"
 
 export class LinkClickObserver {
   started = false

--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -1,6 +1,6 @@
+import { getLocationForLink } from "../core/url"
 import {
   dispatch,
-  getLocationForLink,
   getMetaContent,
   findClosestRecursively
 } from "../util"

--- a/src/util.js
+++ b/src/util.js
@@ -1,5 +1,3 @@
-import { expandURL } from "./core/url"
-
 export function activateScriptElement(element) {
   if (element.getAttribute("data-turbo-eval") == "false") {
     return element
@@ -254,10 +252,6 @@ export function findLinkFromClickTarget(target) {
   if (link.hasAttribute("target") && link.target !== "_self") return null
 
   return link
-}
-
-export function getLocationForLink(link) {
-  return expandURL(link.getAttribute("href") || "")
 }
 
 export function debounce(fn, delay) {


### PR DESCRIPTION
Prior to this commit, the `util` module depended on the `expandURL` function (from the `core/url` module) for the sake of implementing its `getLocationForLink` function.

Since the `core/url` module depended on `core/config` (which itself transitively depended on the `util` module), it initiated a circular dependency chain mentioned in `yarn build` output:

```sh
yarn build

(!) Circular dependency
src/core/url.js -> src/core/config/index.js -> src/core/config/forms.js -> src/util.js -> src/core/url.js
```

This commit moves the `getLocationForLink` function out of `util` and into `core/url`. It also changes `import` call sites throughout the package to reflect the new location.

After this change, the build output no longer mentioned the circular chain:

```
❯ yarn build
yarn run v1.22.22
$ rollup -c

src/index.js → dist/turbo.es2017-umd.js, dist/turbo.es2017-esm.js...
created dist/turbo.es2017-umd.js, dist/turbo.es2017-esm.js in 177ms
✨  Done in 0.42s.
```