### PR TITLE
Functional Tests: Replace chai with Playwright Assertions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /dist
 /node_modules
+/test-results
 *.log
 package-lock.json

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -204,6 +204,20 @@ export function pathname(url) {
   return pathname
 }
 
+export function withPathname(value) {
+  return ({ pathname }) => pathname === value
+}
+
+export function withSearch(value) {
+  return ({ search }) => search === value
+}
+
+export function withSearchParam(name, value) {
+  return ({ searchParams }) => Array.isArray(value) ?
+    JSON.stringify(searchParams.getAll(name)) === JSON.stringify(value) :
+    searchParams.get(name) === value
+}
+
 export async function pathnameForIFrame(page, name) {
   const locator = await page.locator(`[name="${name}"]`)
   const location = await locator.evaluate((iframe) => iframe.contentWindow?.location)


### PR DESCRIPTION
This commit starts to eradicate all `assert` usage from the browser test suite, starting with the `src/tests/functional/form_submission_tests.js` file.

Utilize Playwright's built-in [assertions][] so that functional test assertions are consistent. The `chai`-based assertions provide similar coverage, but not much is gained for the suite by having two competing styles of assertion.

The majority of this diff replaces `assert.equal` with `expect(...).toEqual()`. In some cases, text comparison is replaced with Playwright's [toHaveText][], since that assertion bakes in synchronization and waiting support, and has the ability to compare contents in a way that ignores spacing differences.

There are other patterns throughout the test suite that could be improved by adhering more closely to Playwright idioms. Future commits can improve upon those tests.

Related
---

A reduction in functional test suite execution time was an unexpected benefit. Since the suite relies less on manual timing interventions like `nextEventNamed` and `nextBeat`, it relies more on Playwright's built-in synchronization and timing mechanisms.

```sh
  # BEFORE
git checkout main
yarn test:browser --project=chrome src/tests/functional/form_submission_tests.js

  # ...

  111 passed (35.0s)
✨  Done in 35.44s.
```

```sh
  # AFTER
git checkout test-playwright-expect
yarn test:browser --project=chrome src/tests/functional/form_submission_tests.js

  # ...

  110 passed (18.3s)
✨  Done in 18.81s.
```

[assertions]: https://playwright.dev/docs/test-assertions
[toHaveText]: https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-text