### PR TITLE
Use view transitions for failed form submissions

### DIFF
--- a/src/tests/fixtures/form_view_transition.html
+++ b/src/tests/fixtures/form_view_transition.html
@@ -1,0 +1,21 @@
+<!doctype html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Form with View Transition</title>
+    <meta name="turbo-view-transition" content="true" />
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Form with View Transition</h1>
+    <form id="form-422" action="/__turbo/reject/view-transition" method="post">
+      <input type="hidden" name="status" value="422" />
+      <input id="submit-422" type="submit" value="Submit (422)" />
+    </form>
+    <form id="form-500" action="/__turbo/reject/view-transition" method="post">
+      <input type="hidden" name="status" value="500" />
+      <input id="submit-500" type="submit" value="Submit (500)" />
+    </form>
+  </body>
+</html>

--- a/src/tests/fixtures/form_view_transition_422.html
+++ b/src/tests/fixtures/form_view_transition_422.html
@@ -1,0 +1,12 @@
+<html>
+  <head>
+    <title>Unprocessable Content with View Transition</title>
+    <meta name="turbo-view-transition" content="true" />
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Unprocessable Content</h1>
+    <p>The form submission failed with validation errors.</p>
+  </body>
+</html>

--- a/src/tests/fixtures/form_view_transition_500.html
+++ b/src/tests/fixtures/form_view_transition_500.html
@@ -1,0 +1,14 @@
+<html>
+  <head>
+    <title>Internal Server Error</title>
+    <meta name="turbo-view-transition" content="true" />
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <h1>Internal Server Error</h1>
+
+    <turbo-frame id="frame">
+      <h2>Frame: Internal Server Error</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/functional/form_submission_view_transition_tests.js
+++ b/src/tests/functional/form_submission_view_transition_tests.js
@@ -1,0 +1,31 @@
+import { expect, test } from "@playwright/test"
+import { nextBody } from "../helpers/page"
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/src/tests/fixtures/form_view_transition.html")
+
+  await page.evaluate(`
+    document.startViewTransition = (callback) => {
+      window.startViewTransitionCalled = true
+      callback()
+    }
+  `)
+})
+
+test("form submission with 422 response triggers view transition", async ({ page }) => {
+  await page.click("#submit-422")
+  await nextBody(page)
+
+  await expect(page.locator("h1")).toHaveText("Unprocessable Content")
+  const called = await page.evaluate(`window.startViewTransitionCalled`)
+  await expect(called).toEqual(true)
+})
+
+test("form submission with 500 response triggers view transition", async ({ page }) => {
+  await page.click("#submit-500")
+  await nextBody(page)
+
+  await expect(page.locator("h1")).toHaveText("Internal Server Error")
+  const called = await page.evaluate(`window.startViewTransitionCalled`)
+  await expect(called).toEqual(true)
+})

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -68,6 +68,13 @@ router.post("/reject/morph", (request, response) => {
   response.status(parseInt(status || "422", 10)).sendFile(fixture)
 })
 
+router.post("/reject/view-transition", (request, response) => {
+  const { status } = request.body
+  const fixture = path.join(__dirname, `../../src/tests/fixtures/form_view_transition_${status}.html`)
+
+  response.status(parseInt(status || "422", 10)).sendFile(fixture)
+})
+
 router.post("/reject", (request, response) => {
   const { status } = request.body
   const fixture = path.join(__dirname, `../../src/tests/fixtures/${status}.html`)


### PR DESCRIPTION
View transitions don't work when forms return 422 or 500, because `formSubmissionFailedWithResponse` calls `view.renderPage()` directly.

This change implements `ViewTransitioner` and wraps the existing render and scroll calls with `.renderChange`. Reviewing without whitespace changes (`-w`) is recommended.

The new test is similar to `drive_view_transition_tests.js`, but I had to add a `/reject/view-transition` route to the test server.

New tests pass:

```sh
$ yarn test:browser src/tests/functional/form_submission_view_transition_tests.js
yarn run v1.22.22
$ playwright test src/tests/functional/form_submission_view_transition_tests.js

Running 4 tests using 2 workers

  ✓  1 …n_tests.js:16:5 › form submission with 422 response triggers view transition (1.1s)
  ✓  2 …n_tests.js:16:5 › form submission with 422 response triggers view transition (1.4s)
  ✓  3 …_tests.js:25:5 › form submission with 500 response triggers view transition (726ms)
  ✓  4 …_tests.js:25:5 › form submission with 500 response triggers view transition (603ms)

  4 passed (4.0s)
✨  Done in 4.88s.
```

## Before: No transitions

https://github.com/user-attachments/assets/ce74a63e-cc03-42eb-8e68-40fae17b1c98

## After: With transitions

https://github.com/user-attachments/assets/4b2b312c-5283-47ff-a1cf-d01784c3a3ac