### PR TITLE
Rendering Functional Tests: Replace chai with Playwright

### DIFF
--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -2,9 +2,6 @@ import { expect, test } from "@playwright/test"
 import { assert } from "chai"
 import {
   clickWithoutScrolling,
-  getSearchParam,
-  hash,
-  hasSelector,
   isScrolledToSelector,
   nextAttributeMutationNamed,
   nextBeat,
@@ -14,12 +11,12 @@ import {
   pathname,
   pathnameForIFrame,
   readEventLogs,
-  search,
-  selectorHasFocus,
   visitAction,
-  waitUntilSelector,
-  waitUntilNoSelector,
-  willChangeBody
+  willChangeBody,
+  withHash,
+  withPathname,
+  withSearch,
+  withSearchParam
 } from "../helpers/page"
 
 test.beforeEach(async ({ page }) => {
@@ -31,52 +28,51 @@ test("navigating renders a progress bar until the next turbo:load", async ({ pag
   await page.evaluate(() => window.Turbo.setProgressBarDelay(0))
   await page.click("#delayed-link")
 
-  await waitUntilSelector(page, ".turbo-progress-bar")
-  assert.ok(await hasSelector(page, ".turbo-progress-bar"), "displays progress bar")
+  await expect(page.locator(".turbo-progress-bar"), "displays progress bar").toBeAttached()
 
   await nextEventNamed(page, "turbo:render")
-  assert.ok(await hasSelector(page, ".turbo-progress-bar"), "displays progress bar")
+  await expect(page.locator(".turbo-progress-bar"), "displays progress bar").toBeAttached()
 
   await nextEventNamed(page, "turbo:load")
-  await waitUntilNoSelector(page, ".turbo-progress-bar")
-
-  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "hides progress bar")
+  await expect(page.locator(".turbo-progress-bar"), "hides progress bar").not.toBeAttached()
 })
 
 test("navigating does not render a progress bar before expiring the delay", async ({ page }) => {
   await page.evaluate(() => window.Turbo.setProgressBarDelay(1000))
   await page.click("#same-origin-unannotated-link")
 
-  assert.notOk(await hasSelector(page, ".turbo-progress-bar"), "does not show progress bar before delay")
+  await expect(page.locator(".turbo-progress-bar"), "does not show progress bar before delay").not.toBeAttached()
 })
 
 test("navigating hides the progress bar on failure", async ({ page }) => {
   await page.evaluate(() => window.Turbo.setProgressBarDelay(0))
   await page.click("#delayed-failure-link")
 
-  await waitUntilSelector(page, ".turbo-progress-bar")
-  await waitUntilNoSelector(page, ".turbo-progress-bar")
+  await expect(page.locator(".turbo-progress-bar")).toBeAttached()
+  await expect(page.locator(".turbo-progress-bar")).not.toBeAttached()
 })
 
 test("after loading the page", async ({ page }) => {
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(await visitAction(page), "load")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("following a same-origin unannotated link", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "advance")
-  assert.equal(
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("advance")
+  expect(
     await nextAttributeMutationNamed(page, "html", "aria-busy"),
-    "true",
     "sets [aria-busy] on the document element"
+  ).toEqual(
+    "true"
   )
-  assert.equal(
+  expect(
     await nextAttributeMutationNamed(page, "html", "aria-busy"),
-    null,
     "removes [aria-busy] from the document element"
+  ).toEqual(
+    null
   )
 })
 
@@ -87,60 +83,60 @@ test("following a same-origin unannotated custom element link", async ({ page })
     const link = shadowRoot?.querySelector("a")
     link?.click()
   })
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(search(page.url()), "")
-  assert.equal(await visitAction(page), "advance")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  await expect(page).toHaveURL(withSearch(""))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("drive enabled; click an element in the shadow DOM wrapped by a link in the light DOM", async ({ page }) => {
   await page.click("#shadow-dom-drive-enabled span")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "advance")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("drive disabled; click an element in the shadow DOM within data-turbo='false'", async ({ page }) => {
   await page.click("#shadow-dom-drive-disabled span")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "load")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("drive enabled; click an element in the slot", async ({ page }) => {
   await page.click("#element-in-slot")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "advance")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("drive disabled; click an element in the slot within data-turbo='false'", async ({ page }) => {
   await page.click("#element-in-slot-disabled")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "load")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("drive disabled; click an element in the nested slot within data-turbo='false'", async ({ page }) => {
   await page.click("#element-in-nested-slot-disabled")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "load")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("following a same-origin unannotated link with search params", async ({ page }) => {
   await page.click("#same-origin-unannotated-link-search-params")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(search(page.url()), "?key=value")
-  assert.equal(await visitAction(page), "advance")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  await expect(page).toHaveURL(withSearch("?key=value"))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("following a same-origin unannotated form[method=GET]", async ({ page }) => {
   await page.click("#same-origin-unannotated-form button")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "advance")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("following a same-origin data-turbo-method=get link", async ({ page }) => {
@@ -149,46 +145,45 @@ test("following a same-origin data-turbo-method=get link", async ({ page }) => {
   await nextEventNamed(page, "turbo:submit-end")
   await nextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(getSearchParam(page.url(), "a"), "one")
-  assert.equal(getSearchParam(page.url(), "b"), "two")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  await expect(page).toHaveURL(withSearchParam("a", "one"))
+  await expect(page).toHaveURL(withSearchParam("b", "two"))
 })
 
 test("following a same-origin data-turbo-action=replace link", async ({ page }) => {
   await page.click("#same-origin-replace-link")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "replace")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("replace")
 })
 
 test("following a same-origin GET form[data-turbo-action=replace]", async ({ page }) => {
   await page.click("#same-origin-replace-form-get button")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "replace")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("replace")
 })
 
 test("following a same-origin GET form button[data-turbo-action=replace]", async ({ page }) => {
   await page.click("#same-origin-replace-form-submitter-get button")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "replace")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("replace")
 })
 
 test("following a same-origin POST form[data-turbo-action=replace]", async ({ page }) => {
   await page.click("#same-origin-replace-form-post button")
-  await nextBody(page)
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "replace")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("replace")
 })
 
 test("following a same-origin POST form button[data-turbo-action=replace]", async ({ page }) => {
   await page.click("#same-origin-replace-form-submitter-post button")
   await nextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "replace")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("replace")
 })
 
 test("following a POST form clears cache", async ({ page }) => {
@@ -201,87 +196,85 @@ test("following a POST form clears cache", async ({ page }) => {
   await nextBeat() // 301 redirect response
   await nextBeat() // 200 response
   await page.goBack()
-  assert.notOk(await hasSelector(page, "some-cached-element"))
+  await expect(page.locator("some-cached-element")).not.toBeAttached()
 })
 
 test("following a same-origin POST link with data-turbo-action=replace", async ({ page }) => {
   await page.click("#same-origin-replace-post-link")
-  await nextBody(page)
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "replace")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("replace")
 })
 
 test("following a same-origin data-turbo=false link", async ({ page }) => {
   await page.click("#same-origin-false-link")
   await page.waitForEvent("load")
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "load")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("following a same-origin unannotated link inside a data-turbo=false container", async ({ page }) => {
   await page.click("#same-origin-unannotated-link-inside-false-container")
   await page.waitForEvent("load")
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "load")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("following a same-origin data-turbo=true link inside a data-turbo=false container", async ({ page }) => {
   await page.click("#same-origin-true-link-inside-false-container")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "advance")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("following a same-origin anchored link", async ({ page }) => {
   await page.click("#same-origin-anchored-link")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(hash(page.url()), "#element-id")
-  assert.equal(await visitAction(page), "advance")
-  assert(await isScrolledToSelector(page, "#element-id"))
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  await expect(page).toHaveURL(withHash("#element-id"))
+  expect(await visitAction(page)).toEqual("advance")
+  expect(await isScrolledToSelector(page, "#element-id")).toEqual(true)
 })
 
 test("following a same-origin link to a named anchor", async ({ page }) => {
   await page.click("#same-origin-anchored-link-named")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(hash(page.url()), "#named-anchor")
-  assert.equal(await visitAction(page), "advance")
-  assert(await isScrolledToSelector(page, "[name=named-anchor]"))
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  await expect(page).toHaveURL(withHash("#named-anchor"))
+  expect(await visitAction(page)).toEqual("advance")
+  expect(await isScrolledToSelector(page, "[name=named-anchor]")).toEqual(true)
 })
 
 test("following a cross-origin unannotated link", async ({ page }) => {
   await page.click("#cross-origin-unannotated-link")
-  await nextBody(page)
-  assert.equal(page.url(), "about:blank")
-  assert.equal(await visitAction(page), "load")
+
+  await expect(page).toHaveURL("about:blank")
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("following a same-origin [target] link", async ({ page }) => {
   const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#same-origin-targeted-link")])
 
-  assert.equal(pathname(popup.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(popup), "load")
+  expect(pathname(popup.url())).toEqual("/src/tests/fixtures/one.html")
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("following a _self [target] link", async ({ page }) => {
   await page.click("#self-targeted-link")
-  await nextBody(page)
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "advance")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("following a same-origin [download] link", async ({ page }) => {
-  assert.notOk(
+  expect(
     await willChangeBody(page, async () => {
       await page.click("#same-origin-download-link")
       await nextBeat()
     })
-  )
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(await visitAction(page), "load")
+  ).toEqual(false)
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("following a same-origin link inside an SVG element", async ({ page }) => {
@@ -289,9 +282,8 @@ test("following a same-origin link inside an SVG element", async ({ page }) => {
   await link.focus()
   await page.keyboard.press("Enter")
 
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "advance")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("following a cross-origin link inside an SVG element", async ({ page }) => {
@@ -299,58 +291,55 @@ test("following a cross-origin link inside an SVG element", async ({ page }) => 
   await link.focus()
   await page.keyboard.press("Enter")
 
-  await nextBody(page)
-  assert.equal(page.url(), "about:blank")
-  assert.equal(await visitAction(page), "load")
+  await expect(page).toHaveURL("about:blank")
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("clicking the back button", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
-  await nextBody(page)
+  await nextEventNamed(page, "turbo:load")
   await page.goBack()
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(await visitAction(page), "restore")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  expect(await visitAction(page)).toEqual("restore")
 })
 
 test("clicking the forward button", async ({ page }) => {
   await page.click("#same-origin-unannotated-link")
-  await nextBody(page)
+  await nextEventNamed(page, "turbo:load")
   await page.goBack()
   await page.goForward()
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "restore")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("restore")
 })
 
 test("form submissions that redirect to a different location have a default advance action", async ({ page }) => {
   await page.click("#redirect-submit")
-  await nextBody(page)
-  assert.equal(await visitAction(page), "advance")
+  await nextEventNamed(page, "turbo:load")
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("form submissions that redirect to the current location have a default replace action", async ({ page }) => {
   await page.click("#refresh-submit")
-  await nextBody(page)
-  assert.equal(await visitAction(page), "replace")
+  await nextEventNamed(page, "turbo:load")
+  expect(await visitAction(page)).toEqual("replace")
 })
 
 test("link targeting a disabled turbo-frame navigates the page", async ({ page }) => {
   await page.click("#link-to-disabled-frame")
-  await nextBody(page)
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/frames/hello.html")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/frames/hello.html"))
 })
 
 test("skip link with hash-only path scrolls to the anchor without a visit", async ({ page }) => {
   assert.notOk(
     await willChangeBody(page, async () => {
       await page.click('a[href="#main"]')
-      await nextBeat()
     })
   )
 
-  assert.ok(await isScrolledToSelector(page, "#main"), "scrolled to #main")
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(hash(page.url()), "#main")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  await expect(page).toHaveURL(withHash("#main"))
+  expect(await isScrolledToSelector(page, "#main"), "scrolled to #main").toEqual(true)
 })
 
 test("skip link with hash-only path moves focus and changes tab order", async ({ page }) => {
@@ -358,18 +347,18 @@ test("skip link with hash-only path moves focus and changes tab order", async ({
   await nextBeat()
   await page.press("#main", "Tab")
 
-  assert.notOk(await selectorHasFocus(page, "#ignored-link"), "skips interactive elements before #main")
-  assert.ok(await selectorHasFocus(page, "#main *:focus"), "moves focus inside #main")
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(hash(page.url()), "#main")
+  await expect(page.locator("#ignored-link"), "skips interactive elements before #main").not.toBeFocused()
+  await expect(page.locator("#main *:focus"), "moves focus inside #main").toBeFocused()
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  await expect(page).toHaveURL(withHash("#main"))
 })
 
 test("same-page anchored replace link assumes the intention was a refresh", async ({ page }) => {
   await page.click("#refresh-link")
-  await nextBody(page)
-  assert.ok(await isScrolledToSelector(page, "#main"), "scrolled to #main")
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(hash(page.url()), "#main")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  await expect(page).toHaveURL(withHash("#main"))
+  expect(await isScrolledToSelector(page, "#main"), "scrolled to #main").toEqual(true)
 })
 
 test("navigating back to anchored URL", async ({ page }) => {
@@ -383,25 +372,25 @@ test("navigating back to anchored URL", async ({ page }) => {
   await page.goBack()
   await nextBody(page)
 
-  assert.ok(await isScrolledToSelector(page, "#main"), "scrolled to #main")
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(hash(page.url()), "#main")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  await expect(page).toHaveURL(withHash("#main"))
+  expect(await isScrolledToSelector(page, "#main"), "scrolled to #main").toEqual(true)
 })
 
 test("following a redirection", async ({ page }) => {
   await page.click("#redirection-link")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
-  assert.equal(await visitAction(page), "replace")
-  await waitUntilNoSelector(page, ".turbo-progress-bar")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
+  expect(await visitAction(page)).toEqual("replace")
+  await expect(page.locator(".turbo-progress-bar")).not.toBeAttached()
 })
 
 test("clicking the back button after redirection", async ({ page }) => {
   await page.click("#redirection-link")
   await nextBody(page)
   await page.goBack()
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(await visitAction(page), "restore")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  expect(await visitAction(page)).toEqual("restore")
 })
 
 test("same-page anchor visits do not trigger visit events", async ({ page }) => {
@@ -417,19 +406,20 @@ test("same-page anchor visits do not trigger visit events", async ({ page }) => 
   for (const eventName in events) {
     await page.goto("/src/tests/fixtures/navigation.html")
     await page.click('a[href="#main"]')
-    assert.ok(await noNextEventNamed(page, eventName), `same-page links do not trigger ${eventName} events`)
+    expect(await noNextEventNamed(page, eventName), `same-page links do not trigger ${eventName} events`).toEqual(true)
   }
 })
 
 test("correct referrer header", async ({ page }) => {
   page.click("#headers-link")
-  await nextBody(page)
+  await nextEventNamed(page, "turbo:load")
   const pre = await page.textContent("pre")
   const headers = await JSON.parse(pre || "")
-  assert.equal(
+  expect(
     headers.referer,
-    "http://localhost:9000/src/tests/fixtures/navigation.html",
     `referer header is correctly set`
+  ).toEqual(
+    "http://localhost:9000/src/tests/fixtures/navigation.html"
   )
 })
 
@@ -439,8 +429,8 @@ test("double-clicking on a link", async ({ page }) => {
 
   await nextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/__turbo/delayed_response")
-  assert.equal(await visitAction(page), "advance")
+  await expect(page).toHaveURL(withPathname("/__turbo/delayed_response"))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("does not fire turbo:load twice after following a redirect", async ({ page }) => {
@@ -448,7 +438,7 @@ test("does not fire turbo:load twice after following a redirect", async ({ page 
 
   await nextBeat() // 301 redirect response
 
-  assert.ok(await noNextEventNamed(page, "turbo:load"))
+  expect(await noNextEventNamed(page, "turbo:load")).toEqual(true)
 
   await nextBeat() // 200 response
   await nextBody(page)
@@ -460,14 +450,13 @@ test("navigating back whilst a visit is in-flight", async ({ page }) => {
   await nextEventNamed(page, "turbo:before-render")
   await page.goBack()
 
-  assert.ok(
+  expect(
     await nextEventNamed(page, "turbo:visit"),
     "navigating back whilst a visit is in-flight starts a non-silent Visit"
-  )
+  ).toBeTruthy()
 
-  await nextBody(page)
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(await visitAction(page), "restore")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  expect(await visitAction(page)).toEqual("restore")
 })
 
 test("ignores links with a [target] attribute that target an iframe with a matching [name]", async ({ page }) => {
@@ -475,8 +464,8 @@ test("ignores links with a [target] attribute that target an iframe with a match
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  expect(await pathnameForIFrame(page, "iframe")).toEqual("/src/tests/fixtures/one.html")
 })
 
 test("ignores links with a [target] attribute that targets an iframe with [name='']", async ({ page }) => {
@@ -484,13 +473,13 @@ test("ignores links with a [target] attribute that targets an iframe with [name=
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
 })
 
 test("ignores forms with a [target=_blank] attribute", async ({ page }) => {
   const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#form-target-blank button")])
 
-  expect(pathname(popup.url())).toContain("/src/tests/fixtures/one.html")
+  await expect(popup).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
 })
 
 test("ignores forms with a [target] attribute that targets an iframe with a matching [name]", async ({ page }) => {
@@ -498,14 +487,14 @@ test("ignores forms with a [target] attribute that targets an iframe with a matc
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  expect(await pathnameForIFrame(page, "iframe")).toEqual("/src/tests/fixtures/one.html")
 })
 
 test("ignores forms with a button[formtarget=_blank] attribute", async ({ page }) => {
   const [popup] = await Promise.all([page.waitForEvent("popup"), page.click("#button-formtarget-blank")])
 
-  expect(pathname(popup.url())).toContain("/src/tests/fixtures/one.html")
+  await expect(popup).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
 })
 
 test("ignores forms with a button[formtarget] attribute that targets an iframe with [name='']", async ({ page }) => {
@@ -513,7 +502,7 @@ test("ignores forms with a button[formtarget] attribute that targets an iframe w
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
 })
 
 test("ignores forms with a button[formtarget] attribute that targets an iframe with a matching [name]", async ({
@@ -523,8 +512,8 @@ test("ignores forms with a button[formtarget] attribute that targets an iframe w
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/navigation.html")
-  assert.equal(await pathnameForIFrame(page, "iframe"), "/src/tests/fixtures/one.html")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/navigation.html"))
+  expect(await pathnameForIFrame(page, "iframe")).toEqual("/src/tests/fixtures/one.html")
 })
 
 test("ignores forms with a [target] attribute that target an iframe with [name='']", async ({ page }) => {
@@ -532,5 +521,5 @@ test("ignores forms with a [target] attribute that target an iframe with [name='
   await nextBeat()
   await noNextEventNamed(page, "turbo:load")
 
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/one.html")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
 })

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -204,6 +204,10 @@ export function pathname(url) {
   return pathname
 }
 
+export function withHash(value) {
+  return ({ hash }) => hash === value
+}
+
 export function withPathname(value) {
   return ({ pathname }) => pathname === value
 }


### PR DESCRIPTION
Follow-up to https://github.com/hotwired/turbo/pull/1454

This commit continues to migrate from `assert` usage toward Playwright's `expect`. This commit focuses on the
`src/tests/functional/navigation_tests.js` file.

Utilize Playwright's built-in [assertions][] so that functional test assertions are consistent. The `chai`-based assertions provide similar coverage, but not much is gained for the suite by having two competing styles of assertion.

The majority of this diff replaces `assert.equal` with `expect(...).toEqual()`. In some cases, text comparison is replaced with Playwright's [toHaveText][], since that assertion bakes in synchronization and waiting support, and has the ability to compare contents in a way that ignores spacing differences.

```sh
  # BEFORE
git checkout main
yarn test:browser --project=chrome src/tests/functional/navigation_tests.js

  # ...

  55 passed (32.6s)
✨  Done in 33.10s.
```

```sh
  # AFTER
$ playwright test --project=chrome src/tests/functional/navigation_tests.js

Running 37 tests using 1 worker

  # …

  55 passed (17.6s)
✨  Done in 18.06s.
```

[assertions]: https://playwright.dev/docs/test-assertions
[toHaveText]: https://playwright.dev/docs/api/class-locatorassertions#locator-assertions-to-have-text