### PR TITLE
Playwright: replace `assert` with `expect`

### DIFF
--- a/src/tests/functional/async_script_tests.js
+++ b/src/tests/functional/async_script_tests.js
@@ -1,5 +1,4 @@
-import { test } from "@playwright/test"
-import { assert } from "chai"
+import { expect, test } from "@playwright/test"
 import { readEventLogs, visitAction } from "../helpers/page"
 
 test.beforeEach(async ({ page }) => {
@@ -10,11 +9,11 @@ test.beforeEach(async ({ page }) => {
 test("does not emit turbo:load when loaded asynchronously after DOMContentLoaded", async ({ page }) => {
   const events = await readEventLogs(page)
 
-  assert.deepEqual(events, [])
+  expect(events).toEqual([])
 })
 
 test("following a link when loaded asynchronously after DOMContentLoaded", async ({ page }) => {
   await page.click("#async-link")
 
-  assert.equal(await visitAction(page), "advance")
+  expect(await visitAction(page)).toEqual("advance")
 })

--- a/src/tests/functional/cache_observer_tests.js
+++ b/src/tests/functional/cache_observer_tests.js
@@ -1,24 +1,21 @@
-import { test } from "@playwright/test"
-import { assert } from "chai"
-import { hasSelector, nextBody } from "../helpers/page"
+import { expect, test } from "@playwright/test"
+import { nextEventNamed } from "../helpers/page"
 
 test("removes temporary elements", async ({ page }) => {
   await page.goto("/src/tests/fixtures/cache_observer.html")
 
-  assert.equal(await page.textContent("#temporary"), "data-turbo-temporary")
+  await expect(page.locator("#temporary")).toHaveText("data-turbo-temporary")
 
   await page.click("#link")
-  await nextBody(page)
+  await nextEventNamed(page, "turbo:load")
   await page.goBack()
-  await nextBody(page)
 
-  assert.notOk(await hasSelector(page, "#temporary"))
+  await expect(page.locator("#temporary")).not.toBeAttached()
 })
 
 test("following a redirect renders [data-turbo-temporary] elements before the cache removes", async ({ page }) => {
   await page.goto("/src/tests/fixtures/navigation.html")
   await page.click("#redirect-to-cache-observer")
-  await nextBody(page)
 
-  assert.equal(await page.textContent("#temporary"), "data-turbo-temporary")
+  await expect(page.locator("#temporary")).toHaveText("data-turbo-temporary")
 })

--- a/src/tests/functional/drive_disabled_tests.js
+++ b/src/tests/functional/drive_disabled_tests.js
@@ -1,13 +1,11 @@
-import { test } from "@playwright/test"
-import { assert } from "chai"
+import { expect, test } from "@playwright/test"
 import {
   getFromLocalStorage,
-  nextBody,
   nextEventOnTarget,
-  pathname,
-  searchParams,
   setLocalStorageFromEvent,
-  visitAction
+  visitAction,
+  withPathname,
+  withSearchParam
 } from "../helpers/page"
 
 const path = "/src/tests/fixtures/drive_disabled.html"
@@ -18,30 +16,27 @@ test.beforeEach(async ({ page }) => {
 
 test("drive disabled by default; click normal link", async ({ page }) => {
   await page.click("#drive_disabled")
-  await nextBody(page)
 
-  assert.equal(pathname(page.url()), path)
-  assert.equal(await visitAction(page), "load")
+  await expect(page).toHaveURL(withPathname(path))
+  expect(await visitAction(page)).toEqual("load")
 })
 
 test("drive disabled by default; click link inside data-turbo='true'", async ({ page }) => {
   await page.click("#drive_enabled")
-  await nextBody(page)
 
-  assert.equal(pathname(page.url()), path)
-  assert.equal(await visitAction(page), "advance")
+  await expect(page).toHaveURL(withPathname(path))
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("drive disabled by default; submit form inside data-turbo='true'", async ({ page }) => {
   await setLocalStorageFromEvent(page, "turbo:submit-start", "formSubmitted", "true")
 
   await page.click("#no_submitter_drive_enabled a#requestSubmit")
-  await nextBody(page)
 
-  assert.ok(await getFromLocalStorage(page, "formSubmitted"))
-  assert.equal(pathname(page.url()), "/src/tests/fixtures/form.html")
-  assert.equal(await visitAction(page), "advance")
-  assert.equal(await searchParams(page.url()).get("greeting"), "Hello from a redirect")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/form.html"))
+  await expect(page).toHaveURL(withSearchParam("greeting", "Hello from a redirect"))
+  expect(await getFromLocalStorage(page, "formSubmitted")).toBeTruthy()
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("drive disabled by default; links within <turbo-frame> navigate with Turbo", async ({ page }) => {

--- a/src/tests/functional/drive_tests.js
+++ b/src/tests/functional/drive_tests.js
@@ -1,6 +1,5 @@
-import { test } from "@playwright/test"
-import { assert } from "chai"
-import { nextBody, pathname, visitAction } from "../helpers/page"
+import { expect, test } from "@playwright/test"
+import { visitAction, withPathname } from "../helpers/page"
 
 const path = "/src/tests/fixtures/drive.html"
 
@@ -10,8 +9,8 @@ test.beforeEach(async ({ page }) => {
 
 test("drive enabled by default; click normal link", async ({ page }) => {
   await page.click("#drive_enabled")
-  await nextBody(page)
-  assert.equal(pathname(page.url()), path)
+
+  await expect(page).toHaveURL(withPathname(path))
 })
 
 test("drive to external link", async ({ page }) => {
@@ -20,16 +19,14 @@ test("drive to external link", async ({ page }) => {
   })
 
   await page.click("#drive_enabled_external")
-  await nextBody(page)
 
-  assert.equal(await page.evaluate(() => window.location.href), "https://example.com/")
-  assert.equal(await page.textContent("body"), "Hello from the outside world")
+  await expect(page).toHaveURL("https://example.com/")
+  await expect(page.locator("body")).toHaveText("Hello from the outside world")
 })
 
 test("drive enabled by default; click link inside data-turbo='false'", async ({ page }) => {
   await page.click("#drive_disabled")
-  await nextBody(page)
 
-  assert.equal(pathname(page.url()), path)
-  assert.equal(await visitAction(page), "load")
+  await expect(page).toHaveURL(withPathname(path))
+  expect(await visitAction(page)).toEqual("load")
 })

--- a/src/tests/functional/drive_view_transition_legacy_tests.js
+++ b/src/tests/functional/drive_view_transition_legacy_tests.js
@@ -1,5 +1,4 @@
-import { test } from "@playwright/test"
-import { assert } from "chai"
+import { expect, test } from "@playwright/test"
 import { nextBody } from "../helpers/page"
 
 test.beforeEach(async ({ page }) => {
@@ -17,14 +16,12 @@ test("navigating triggers the view transition", async ({ page }) => {
   await page.locator("#go-right").click()
   await nextBody(page)
 
-  const called = await page.evaluate(`window.startViewTransitionCalled`)
-  assert.isTrue(called)
+  expect(await page.evaluate(`window.startViewTransitionCalled`)).toEqual(true)
 })
 
 test("navigating does not trigger a view transition when meta tag not present", async ({ page }) => {
   await page.locator("#go-other").click()
   await nextBody(page)
 
-  const called = await page.evaluate(`window.startViewTransitionCalled`)
-  assert.isUndefined(called)
+  expect(await page.evaluate(`window.startViewTransitionCalled`)).toEqual(undefined)
 })

--- a/src/tests/functional/import_tests.js
+++ b/src/tests/functional/import_tests.js
@@ -1,5 +1,4 @@
-import { test } from "@playwright/test"
-import { assert } from "chai"
+import { expect, test } from "@playwright/test"
 
 test("window variable with ESM", async ({ page }) => {
   await page.goto("/src/tests/fixtures/esm.html")
@@ -39,5 +38,5 @@ async function assertTypeOf(page, propertyName, propertyType) {
     return typeof object
   }, propertyName)
 
-  assert.equal(type, propertyType, `Expected ${propertyName} to be ${propertyType}`)
+  expect(type, `Expected ${propertyName} to be ${propertyType}`).toEqual(propertyType)
 }

--- a/src/tests/functional/pausable_rendering_tests.js
+++ b/src/tests/functional/pausable_rendering_tests.js
@@ -1,6 +1,4 @@
-import { test } from "@playwright/test"
-import { assert } from "chai"
-import { nextBeat } from "../helpers/page"
+import { expect, test } from "@playwright/test"
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/src/tests/fixtures/pausable_rendering.html")
@@ -8,43 +6,41 @@ test.beforeEach(async ({ page }) => {
 
 test("pauses and resumes rendering", async ({ page }) => {
   page.on("dialog", (dialog) => {
-    assert.strictEqual(dialog.message(), "Continue rendering?")
+    expect(dialog.message()).toEqual("Continue rendering?")
     dialog.accept()
   })
 
   await page.click("#link")
-  await nextBeat()
 
-  assert.equal(await page.textContent("h1"), "One")
+  await expect(page.locator("h1")).toHaveText("One")
 })
 
 test("aborts rendering", async ({ page }) => {
   const [firstDialog] = await Promise.all([page.waitForEvent("dialog"), page.click("#link")])
 
-  assert.strictEqual(firstDialog.message(), "Continue rendering?")
+  expect(firstDialog.message()).toEqual("Continue rendering?")
 
   firstDialog.dismiss()
 
-  assert.equal(await page.textContent("h1"), "Pausable Rendering")
+  await expect(page.locator("h1")).toHaveText("Pausable Rendering")
 })
 
 test("pauses and resumes rendering a Frame", async ({ page }) => {
   page.on("dialog", (dialog) => {
-    assert.strictEqual(dialog.message(), "Continue rendering?")
+    expect(dialog.message()).toEqual("Continue rendering?")
     dialog.accept()
   })
 
   await page.click("#frame-link")
-  await nextBeat()
 
-  assert.equal(await page.textContent("#hello h2"), "Hello from a frame")
+  await expect(page.locator("#hello h2")).toHaveText("Hello from a frame")
 })
 
 test("aborts rendering a Frame", async ({ page }) => {
   page.on("dialog", (dialog) => {
-    assert.strictEqual(dialog.message(), "Continue rendering?")
+    expect(dialog.message()).toEqual("Continue rendering?")
     dialog.dismiss()
   })
 
-  assert.equal(await page.textContent("#hello h2"), "Pausable Frame Rendering")
+  await expect(page.locator("#hello h2")).toHaveText("Pausable Frame Rendering")
 })

--- a/src/tests/functional/preloader_tests.js
+++ b/src/tests/functional/preloader_tests.js
@@ -1,5 +1,4 @@
-import { test } from "@playwright/test"
-import { assert } from "chai"
+import { expect, test } from "@playwright/test"
 import { nextEventOnTarget } from "../helpers/page"
 
 test("preloads snapshot on initial load", async ({ page }) => {
@@ -9,7 +8,7 @@ test("preloads snapshot on initial load", async ({ page }) => {
   const preloadLink = await page.locator("#preload_anchor")
   const href = await preloadLink.evaluate((link) => link.href)
 
-  assert.ok(await urlInSnapshotCache(page, href))
+  expect(await urlInSnapshotCache(page, href)).toEqual(true)
 })
 
 test("preloading dispatch turbo:before-fetch-{request,response} events", async ({ page }) => {
@@ -21,9 +20,9 @@ test("preloading dispatch turbo:before-fetch-{request,response} events", async (
   const { url, fetchOptions } = await nextEventOnTarget(page, "preload_anchor", "turbo:before-fetch-request")
   const { fetchResponse } = await nextEventOnTarget(page, "preload_anchor", "turbo:before-fetch-response")
 
-  assert.equal(href, url, "dispatches request during preloading")
-  assert.equal(fetchOptions.headers.Accept, "text/html, application/xhtml+xml")
-  assert.equal(fetchResponse.response.url, href)
+  expect(href, "dispatches request during preloading").toEqual(url)
+  expect(fetchOptions.headers.Accept).toEqual("text/html, application/xhtml+xml")
+  expect(fetchResponse.response.url).toEqual(href)
 })
 
 test("preloads snapshot on page visit", async ({ page }) => {
@@ -34,7 +33,7 @@ test("preloads snapshot on page visit", async ({ page }) => {
   const preloadLink = await page.locator("#preload_anchor")
   const href = await preloadLink.evaluate((link) => link.href)
 
-  assert.ok(await urlInSnapshotCache(page, href))
+  expect(await urlInSnapshotCache(page, href)).toEqual(true)
 })
 
 test("preloads anchor from frame that will drive the page", async ({ page }) => {
@@ -44,7 +43,7 @@ test("preloads anchor from frame that will drive the page", async ({ page }) => 
   const preloadLink = await page.locator("#menu a[data-turbo-frame=_top]")
   const href = await preloadLink.evaluate((link) => link.href)
 
-  assert.ok(await urlInSnapshotCache(page, href))
+  expect(await urlInSnapshotCache(page, href)).toEqual(true)
 })
 
 test("does not preload anchor off-site", async ({ page }) => {
@@ -53,7 +52,7 @@ test("does not preload anchor off-site", async ({ page }) => {
   const link = await page.locator("a[href*=https]")
   const href = await link.evaluate((link) => link.href)
 
-  assert.notOk(await urlInSnapshotCache(page, href))
+  expect(await urlInSnapshotCache(page, href)).toEqual(false)
 })
 
 test("does not preload anchor that will drive an ancestor frame", async ({ page }) => {
@@ -62,7 +61,7 @@ test("does not preload anchor that will drive an ancestor frame", async ({ page 
   const preloadLink = await page.locator("#hello a[data-turbo-preload]")
   const href = await preloadLink.evaluate((link) => link.href)
 
-  assert.notOk(await urlInSnapshotCache(page, href))
+  expect(await urlInSnapshotCache(page, href)).toEqual(false)
 })
 
 test("does not preload anchor that will drive a target frame", async ({ page }) => {
@@ -71,7 +70,7 @@ test("does not preload anchor that will drive a target frame", async ({ page }) 
   const link = await page.locator("a[data-turbo-frame=hello]")
   const href = await link.evaluate((link) => link.href)
 
-  assert.notOk(await urlInSnapshotCache(page, href))
+  expect(await urlInSnapshotCache(page, href)).toEqual(false)
 })
 
 test("does not preload a link with [data-turbo=false]", async ({ page }) => {
@@ -80,7 +79,7 @@ test("does not preload a link with [data-turbo=false]", async ({ page }) => {
   const link = await page.locator("[data-turbo=false] a")
   const href = await link.evaluate((link) => link.href)
 
-  assert.notOk(await urlInSnapshotCache(page, href))
+  expect(await urlInSnapshotCache(page, href)).toEqual(false)
 })
 
 test("does not preload a link with [data-turbo-method]", async ({ page }) => {
@@ -89,7 +88,7 @@ test("does not preload a link with [data-turbo-method]", async ({ page }) => {
   const preloadLink = await page.locator("a[data-turbo-method]")
   const href = await preloadLink.evaluate((link) => link.href)
 
-  assert.notOk(await urlInSnapshotCache(page, href))
+  expect(await urlInSnapshotCache(page, href)).toEqual(false)
 })
 
 function urlInSnapshotCache(page, href) {


### PR DESCRIPTION
Replace calls to `assert`-prefixed assertions with Playwright's `expect`-based assertions in the following files:

* `src/tests/functional/async_script_tests.js`
* `src/tests/functional/cache_observer_tests.js`
* `src/tests/functional/drive_disabled_tests.js`
* `src/tests/functional/drive_tests.js`
* `src/tests/functional/drive_view_transition_legacy_tests.js`
* `src/tests/functional/import_tests.js`
* `src/tests/functional/link_prefetch_observer_tests.js`
* `src/tests/functional/pausable_rendering_tests.js`
* `src/tests/functional/preloader_tests.js`

Some `nextBody` calls are made unnecessary by invoking Playwright's wait-and-retry expectations, so this commit removes them when possible.