### PR TITLE
Remove deprecated support for `[data-turbo-cache="false"]`

### DIFF
--- a/src/observers/cache_observer.js
+++ b/src/observers/cache_observer.js
@@ -1,6 +1,5 @@
 export class CacheObserver {
   selector = "[data-turbo-temporary]"
-  deprecatedSelector = "[data-turbo-cache=false]"
 
   started = false
 
@@ -25,18 +24,6 @@ export class CacheObserver {
   }
 
   get temporaryElements() {
-    return [...document.querySelectorAll(this.selector), ...this.temporaryElementsWithDeprecation]
-  }
-
-  get temporaryElementsWithDeprecation() {
-    const elements = document.querySelectorAll(this.deprecatedSelector)
-
-    if (elements.length) {
-      console.warn(
-        `The ${this.deprecatedSelector} selector is deprecated and will be removed in a future version. Use ${this.selector} instead.`
-      )
-    }
-
-    return [...elements]
+    return [...document.querySelectorAll(this.selector)]
   }
 }

--- a/src/tests/fixtures/cache_observer.html
+++ b/src/tests/fixtures/cache_observer.html
@@ -10,7 +10,6 @@
      <section>
        <h1>Cache Observer</h1>
        <div id="temporary" data-turbo-temporary>data-turbo-temporary</div>
-       <div id="temporary-with-deprecated-selector" data-turbo-cache="false">data-turbo-cache=false</div>
        <p><a id="link" href="/src/tests/fixtures/rendering.html">rendering</a></p>
        <p><a id="redirect-here-link" href="/__turbo/redirect?path=/src/tests/fixtures/cache_observer.html">Redirection link back to here</a></p>
      </section>

--- a/src/tests/functional/cache_observer_tests.js
+++ b/src/tests/functional/cache_observer_tests.js
@@ -15,19 +15,6 @@ test("removes temporary elements", async ({ page }) => {
   assert.notOk(await hasSelector(page, "#temporary"))
 })
 
-test("removes temporary elements with deprecated turbo-cache=false selector", async ({ page }) => {
-  await page.goto("/src/tests/fixtures/cache_observer.html")
-
-  assert.equal(await page.textContent("#temporary-with-deprecated-selector"), "data-turbo-cache=false")
-
-  await page.click("#link")
-  await nextBody(page)
-  await page.goBack()
-  await nextBody(page)
-
-  assert.notOk(await hasSelector(page, "#temporary-with-deprecated-selector"))
-})
-
 test("following a redirect renders [data-turbo-temporary] elements before the cache removes", async ({ page }) => {
   await page.goto("/src/tests/fixtures/navigation.html")
   await page.click("#redirect-to-cache-observer")


### PR DESCRIPTION
This deprecation was originally introduced in [e013072][], which was part of the [v7.3.0][] release.

[e013072]: https://github.com/hotwired/turbo/commit/e0130727e6986f971131b1e905eea7a5d3200f87
[v7.3.0]: https://github.com/hotwired/turbo/releases/tag/v7.3.0