### PR TITLE
Remove deprecated `Turbo.clearCache()` function

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -78,19 +78,6 @@ export function renderStreamMessage(message) {
 }
 
 /**
- * Removes all entries from the Turbo Drive page cache.
- * Call this when state has changed on the server that may affect cached pages.
- *
- * @deprecated since version 7.2.0 in favor of `Turbo.cache.clear()`
- */
-export function clearCache() {
-  console.warn(
-    "Please replace `Turbo.clearCache()` with `Turbo.cache.clear()`. The top-level function is deprecated and will be removed in a future version of Turbo.`"
-  )
-  session.clearCache()
-}
-
-/**
  * Sets the delay after which the progress bar will appear during navigation.
  *
  * The progress bar appears after 500ms by default.

--- a/src/tests/functional/import_tests.js
+++ b/src/tests/functional/import_tests.js
@@ -20,7 +20,6 @@ async function assertTurboInterface(page) {
   await assertTypeOf(page, "Turbo.connectStreamSource", "function")
   await assertTypeOf(page, "Turbo.disconnectStreamSource", "function")
   await assertTypeOf(page, "Turbo.renderStreamMessage", "function")
-  await assertTypeOf(page, "Turbo.clearCache", "function")
   await assertTypeOf(page, "Turbo.setProgressBarDelay", "function")
   await assertTypeOf(page, "Turbo.setConfirmMethod", "function")
   await assertTypeOf(page, "Turbo.setFormMode", "function")

--- a/src/tests/unit/export_tests.js
+++ b/src/tests/unit/export_tests.js
@@ -10,7 +10,6 @@ test("Turbo interface", () => {
   assert.equal(typeof Turbo.connectStreamSource, "function")
   assert.equal(typeof Turbo.disconnectStreamSource, "function")
   assert.equal(typeof Turbo.renderStreamMessage, "function")
-  assert.equal(typeof Turbo.clearCache, "function")
   assert.equal(typeof Turbo.setProgressBarDelay, "function")
   assert.equal(typeof Turbo.setConfirmMethod, "function")
   assert.equal(typeof Turbo.setFormMode, "function")


### PR DESCRIPTION
The deprecation was introduced in [87b0efb][], which was part of the [v7.2.0][] release.

[87b0efb]: https://github.com/hotwired/turbo/commit/87b0efbc1079c0c065d512a55fb001295feb003e
[v7.2.0]: https://github.com/hotwired/turbo/releases/tag/v7.2.0