### PR TITLE
Tests: Flaky `[autofocus]` assertions

### DIFF
--- a/src/tests/functional/autofocus_tests.js
+++ b/src/tests/functional/autofocus_tests.js
@@ -48,7 +48,7 @@ test("receiving a Turbo Stream message with an [autofocus] element when the acti
       </turbo-stream>
     `)
   })
-  await expect(page.locator("#autofocus-from-stream")).toBeFocused({ timeout: 200 })
+  await expect(page.locator("#autofocus-from-stream")).toBeFocused()
 })
 
 test("autofocus from a Turbo Stream message does not leak a placeholder [id]", async ({ page }) => {
@@ -61,7 +61,7 @@ test("autofocus from a Turbo Stream message does not leak a placeholder [id]", a
     `)
   })
 
-  await expect(page.locator("#container-from-stream input")).toBeFocused({ timeout: 200 })
+  await expect(page.locator("#container-from-stream input")).toBeFocused()
 
 })
 
@@ -87,9 +87,7 @@ test("don't focus on [autofocus] elements on page refreshes with morphing", asyn
   await expect(button).toBeFocused()
   await expect(input).not.toBeFocused()
 
-  await page.evaluate(() => {
-    document.querySelector("#form").requestSubmit()
-  })
+  await page.locator("#form").evaluate((form) => form.requestSubmit())
 
   await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
   await nextPageRefresh(page)


### PR DESCRIPTION
Playwright will retry the [toBeFocused][] assertions for 5,000ms by
[default][].

[toBeFocused]: https://playwright.dev/docs/test-assertions#auto-retrying-assertions
[default]: https://playwright.dev/docs/test-timeouts

