### PR TITLE
Add turbo:before-morph-element-added and turbo:before-morph-element-removed

### DIFF
--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -88,6 +88,10 @@
   "turbo:morph",
   "turbo:before-morph-element",
   "turbo:morph-element",
+  "turbo:before-morph-element-added",
+  "turbo:morph-element-added",
+  "turbo:before-morph-element-removed",
+  "turbo:morph-element-removed",
   "turbo:before-morph-attribute",
   "turbo:reload"
 ])


### PR DESCRIPTION
## Summary

Adds morph lifecycle events for element addition and removal, addressing #1477.

**New Events:**
| Event | Cancelable | Description |
|-------|------------|-------------|
| `turbo:before-morph-element-added` | Yes | Fired before a new element is added |
| `turbo:morph-element-added` | No | Fired after a new element has been added |
| `turbo:before-morph-element-removed` | Yes | Fired before an element is removed |
| `turbo:morph-element-removed` | No | Fired after an element has been removed |

### Why 4 events instead of 2?

This follows Turbo's existing event naming conventions:
- `turbo:before-morph-element` / `turbo:morph-element` (existing)
- `turbo:before-morph-element-added` / `turbo:morph-element-added` (new)
- `turbo:before-morph-element-removed` / `turbo:morph-element-removed` (new)

The "before" events are cancelable (via `event.preventDefault()`), while the "after" events are for post-processing like animations.

**Note about potential conflict with PR #1438:**
This PR modifies `src/core/morphing.js`, which may conflict with #1438 (Add `refresh` method to Turbo Drive). I've reviewed both changes and the overlap appears to be minimal - likely just a few lines in the callback class. If #1438 is merged first, I'm happy to resolve any conflicts on my branch.

### Demo

Interactive demo showing the events in action: https://github.com/yujiteshima/turbo-morph-events-demo