### PR TITLE
Make PREFETCH_DELAY configurable via Turbo.config.drive.prefetchDelay

### DIFF
--- a/src/core/config/drive.js
+++ b/src/core/config/drive.js
@@ -1,6 +1,7 @@
 export const drive = {
   enabled: true,
   progressBarDelay: 500,
+  prefetchDelay: 100,
   unvisitableExtensions: new Set(
     [
       ".7z", ".aac", ".apk", ".avi", ".bmp", ".bz2", ".css", ".csv", ".deb", ".dmg", ".doc",

--- a/src/core/drive/prefetch_cache.js
+++ b/src/core/drive/prefetch_cache.js
@@ -1,15 +1,17 @@
 import { LRUCache } from "../lru_cache"
 import { toCacheKey } from "../url"
-
-const PREFETCH_DELAY = 100
+import { config } from "../config"
 
 class PrefetchCache extends LRUCache {
   #prefetchTimeout = null
   #maxAges = {}
 
-  constructor(size = 1, prefetchDelay = PREFETCH_DELAY) {
+  constructor(size = 1) {
     super(size, toCacheKey)
-    this.prefetchDelay = prefetchDelay
+  }
+
+  get prefetchDelay() {
+    return config.drive.prefetchDelay
   }
 
   putLater(url, request, ttl) {

--- a/src/tests/unit/export_tests.js
+++ b/src/tests/unit/export_tests.js
@@ -44,6 +44,19 @@ test("Session interface", () => {
   assert.equal("off", config.forms.mode)
 })
 
+test("config.drive.prefetchDelay is configurable", () => {
+  const { config } = Turbo
+
+  assert.equal(100, config.drive.prefetchDelay)
+
+  config.drive.prefetchDelay = 200
+
+  assert.equal(200, config.drive.prefetchDelay)
+
+  // Reset to default
+  config.drive.prefetchDelay = 100
+})
+
 test("StreamActions interface", () => {
   assert.equal(typeof StreamActions, "object")
 })


### PR DESCRIPTION
## Summary

Makes `PREFETCH_DELAY` configurable via `Turbo.config.drive.prefetchDelay`, addressing #1481.

The current hardcoded 100ms delay can cause excessive prefetch requests on pages with many links (e.g., image galleries where cursor movement frequently hovers over multiple links).

## Changes

- Added `prefetchDelay` to `Turbo.config.drive` (default: 100ms)
- Modified `PrefetchCache` to read the delay dynamically via a getter, so changes take effect immediately
- Added unit test for the new configuration option

## Usage

```javascript
// Increase delay for pages with dense link areas
Turbo.config.drive.prefetchDelay = 300
```
This follows the existing pattern used by Turbo.config.drive.progressBarDelay.