### PR TITLE
Use behavior: "instant" for scroll restoration to ignore CSS scroll-behavior

### DIFF
--- a/src/core/view.js
+++ b/src/core/view.js
@@ -42,7 +42,7 @@ export class View {
   }
 
   scrollToPosition({ x, y }) {
-    this.scrollRoot.scrollTo(x, y)
+    this.scrollRoot.scrollTo({ left: x, top: y, behavior: "instant" })
   }
 
   scrollToTop() {

--- a/src/tests/fixtures/scroll_restoration_with_smooth_scroll.html
+++ b/src/tests/fixtures/scroll_restoration_with_smooth_scroll.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Scroll Restoration with Smooth Scroll</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <style>
+      html {
+        scroll-behavior: smooth;
+      }
+      li {
+        min-height: 50vh;
+      }
+    </style>
+  </head>
+  <body>
+    <ul>
+      <li id="one">One</li>
+      <li id="two">Two</li>
+      <li id="three">Three</li>
+      <li id="four">Four</li>
+      <li id="five">Five</li>
+    </ul>
+  </body>
+</html>

--- a/src/tests/functional/scroll_restoration_tests.js
+++ b/src/tests/functional/scroll_restoration_tests.js
@@ -33,3 +33,19 @@ test("returning from history", async ({ page }) => {
   const { y: yAfterReturning } = await scrollPosition(page)
   expect(yAfterReturning).not.toEqual(0)
 })
+
+test("returning from history with scroll-behavior: smooth restores scroll position instantly", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_restoration_with_smooth_scroll.html")
+  await scrollToSelector(page, "#three")
+  const { y: yAfterScrolling } = await scrollPosition(page)
+  expect(yAfterScrolling).not.toEqual(0)
+
+  await page.goto("/src/tests/fixtures/bare.html")
+  await page.goBack()
+
+  // Scroll position should be restored instantly, not animated
+  // If scroll-behavior: smooth was applied, the position would still be 0 or near 0
+  // immediately after goBack() because the animation would be in progress
+  const { y: yAfterReturning } = await scrollPosition(page)
+  expect(yAfterReturning).not.toEqual(0)
+})


### PR DESCRIPTION
## Summary

Ensure scroll restoration on restoration visits ignores CSS `scroll-behavior: smooth`.

When CSS `scroll-behavior: smooth` is set (common in Bootstrap and other frameworks), restoration visits animate scrolling to the previous position instead of jumping instantly. This creates a poor user experience when navigating back/forward.

**Root cause:** `scrollTo(x, y)` defaults to `behavior: "auto"`, which respects CSS `scroll-behavior`.

**Solution:** Explicitly use `behavior: "instant"` so restoration always jumps immediately.

### Why `"instant"` is appropriate

Scroll restoration is a **framework-controlled action**, not a user-initiated scroll. The user expects to return to their previous position immediately—matching native browser back/forward behavior. CSS `scroll-behavior: smooth` is intended for explicit user actions like clicking anchor links, not for programmatic state restoration.

### Browser Compatibility

- Chrome / Firefox: ✅ Full support
- Safari: ✅ Supported since 15.4 ([WebKit release notes](https://webkit.org/blog/12445/new-webkit-features-in-safari-15-4/))

This change is low-risk, as unsupported environments fall back to instant scrolling.

Reference: [Preventing smooth scrolling with JavaScript](https://kilianvalkhof.com/2022/css-html/preventing-smooth-scrolling-with-javascript/)

### Related

- PR #607 addressed frame autoscroll (different UX context where smooth may be desirable)

Fixes #1448