### PR TITLE
Reduce flakiness in several tests

### DIFF
--- a/src/tests/functional/form_submission_tests.js
+++ b/src/tests/functional/form_submission_tests.js
@@ -1018,7 +1018,9 @@ test("link method form submission inside frame submits a single request", async 
 
 test("link method form submission targeting frame submits a single request", async ({ page }) => {
   let requestCounter = 0
-  page.on("request", () => requestCounter++)
+  page.on("request", (request) => {
+    if (request.url().includes("/__turbo/redirect")) requestCounter++
+  })
 
   await page.click("#turbo-method-post-to-targeted-frame")
 
@@ -1026,7 +1028,8 @@ test("link method form submission targeting frame submits a single request", asy
 
   await noNextEventNamed(page, "turbo:before-fetch-request")
   expect(fetchOptions.method, "[data-turbo-method] overrides the GET method").toEqual("POST")
-  expect(requestCounter, "submits a single HTTP request then follows a redirect").toEqual(2)
+  await expect(page.locator("#hello h2")).toHaveText("Hello from a frame")
+  expect(requestCounter, "submits a single HTTP request").toEqual(1)
 })
 
 test("link method form submission inside frame", async ({ page }) => {

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -152,10 +152,10 @@ test("successfully following a link to a page without a matching frame dispatche
 test("successfully following a link to a page without a matching frame shows an error and throws an exception", async ({
   page
 }) => {
-  let error = undefined
-  page.once("pageerror", (e) => (error = e))
-
-  await page.click("#missing-frame-link")
+  const [error] = await Promise.all([
+    page.waitForEvent("pageerror"),
+    page.click("#missing-frame-link")
+  ])
 
   await expect(page.locator("#missing")).toHaveText("Content missing")
 
@@ -184,10 +184,10 @@ test("failing to follow a link to a page without a matching frame dispatches a t
 test("failing to follow a link to a page without a matching frame shows an error and throws an exception", async ({
   page
 }) => {
-  let error = undefined
-  page.once("pageerror", (e) => (error = e))
-
-  await page.click("#missing-page-link")
+  const [error] = await Promise.all([
+    page.waitForEvent("pageerror"),
+    page.click("#missing-page-link")
+  ])
 
   await expect(page.locator("#missing")).toHaveText("Content missing")
 

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -449,15 +449,21 @@ test("double-clicking on a link", async ({ page }) => {
 })
 
 test("does not fire turbo:load twice after following a redirect", async ({ page }) => {
+  await page.evaluate(() => {
+    window.turboLoadCount = 0
+    addEventListener("turbo:load", () => window.turboLoadCount++)
+  })
+
   page.click("#redirection-link")
 
   await nextBeat() // 301 redirect response
 
-  expect(await noNextEventNamed(page, "turbo:load")).toEqual(true)
-
   await nextBeat() // 200 response
   await nextBody(page)
   await nextEventNamed(page, "turbo:load")
+  await nextBeat()
+
+  expect(await page.evaluate(() => window.turboLoadCount)).toEqual(1)
 })
 
 test("navigating back whilst a visit is in-flight", async ({ page }) => {


### PR DESCRIPTION
I decided to look at some of the tests that are flaking. The selection of tests which I improved are a bit random because I basically ran the test suite a few times on my machine and observed which ones happened to flake and then looked into which ones I can fix. 

The commit message has all of them listed together with the explanation of the problem and the fix but for easier PR review, I'll copy paste the problem and fix as a comment under each test.

These are not all of the flaky tests, it's just the ones I managed to fix in this coding session. When I'll have more time I'll look at a few more and open a new PR.
