### PR TITLE
Rename `session.navigator` during destructuring to avoid clobbering `window.navigator`

### DIFF
--- a/src/core/index.js
+++ b/src/core/index.js
@@ -8,10 +8,13 @@ import { MorphingPageRenderer } from "./drive/morphing_page_renderer"
 import { MorphingFrameRenderer } from "./frames/morphing_frame_renderer"
 
 export { morphChildren, morphElements } from "./morphing"
+export { PageRenderer, PageSnapshot, FrameRenderer, fetch, config }
 
 const session = new Session(recentRequests)
-const { cache, navigator } = session
-export { navigator, session, cache, PageRenderer, PageSnapshot, FrameRenderer, fetch, config }
+
+// Rename `navigator` to avoid shadowing `window.navigator`
+const { cache, navigator: sessionNavigator } = session
+export { session, cache, sessionNavigator as navigator }
 
 /**
  * Starts the main session.


### PR DESCRIPTION
When Rollup's output format changed to "esm" in https://github.com/hotwired/turbo/pull/1016, it stopped automatically renaming variables that shadow globals. This caused the bundled turbo.js to overwrite `window.navigator` with Turbo's internal `Navigator` instance, breaking libraries that depend on the browser's `window.navigator`.

Fix by renaming `navigator` to `sessionNavigator` during destructuring, then re-exporting it under the original name.

Fixes hotwired/turbo-rails#776