### PR TITLE
Record and cancel pending prefetch requests

### DIFF
--- a/src/tests/fixtures/hover_to_prefetch.html
+++ b/src/tests/fixtures/hover_to_prefetch.html
@@ -11,6 +11,7 @@
   <body>
     <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch">Hover to prefetch me</a>
     <a href="/src/tests/fixtures/bare.html" id="anchor_for_prefetch_other_href">Hover to prefetch me</a>
+    <a href="/__turbo/delayed_response" id="anchor_for_slow_prefetch">Hover to prefetch me (response, that takes long to render)</a>
     <a href="/src/tests/fixtures/prefetched.html" id="anchor_with_inner_elements">
       <span>Hover to prefetch me</span>
     </a>

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -268,6 +268,23 @@ test("it cancels pending prefetch requests if a new prefetch request is made", a
   await expect(page).toHaveURL("src/tests/fixtures/prefetched.html")
 })
 
+test("it cancels the pending prefetch request if the same link is hovered again", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+
+  let finishedRequestCount = 0
+  page.on("requestfinished", async () => (finishedRequestCount++))
+
+  await page.hover("#anchor_for_slow_prefetch")
+  await sleep(150)
+  await page.mouse.move(0, 0)
+
+  // Prefetching the same URL again while the last request is still not finished should abort the latter
+  await page.hover("#anchor_for_slow_prefetch")
+
+  await sleep(1200)
+  expect(finishedRequestCount).toEqual(1)
+})
+
 test("it resets the cache when a link is hovered", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
 

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -285,6 +285,21 @@ test("it cancels the pending prefetch request if the same link is hovered again"
   expect(finishedRequestCount).toEqual(1)
 })
 
+test("it keeps the running prefetch request when clicking a link", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+
+  let requestCount = 0
+  page.on("request", async () => (requestCount++))
+
+  await hoverSelector({ page, selector: "#anchor_for_slow_prefetch" })
+  await sleep(150)
+  await page.click("#anchor_for_slow_prefetch")
+
+  // The prefetch request should be used for the visit
+  await expect(page).toHaveTitle("One")
+  expect(requestCount).toEqual(1)
+})
+
 test("it resets the cache when a link is hovered", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
 

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -232,6 +232,42 @@ test("it cancels the prefetch request if the link is no longer hovered", async (
   })
 })
 
+test("it cancels pending prefetch requests if a new request is made", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+
+  // Prefetch a request, that takes a long time to load
+  await hoverSelector({ page, selector: "#anchor_for_slow_prefetch" })
+  await page.click("#anchor_for_slow_prefetch", {noWaitAfter: true})
+
+  // Issue a new request to a secondary resource, that loads fast
+  await page.click("#anchor_for_prefetch")
+
+  // Allow for the slow request to be processed if it wasn't canceled
+  await sleep(1100)
+
+  // The page should show the secondary resource
+  await expect(page).toHaveTitle("Prefetched Page")
+  await expect(page).toHaveURL("src/tests/fixtures/prefetched.html")
+})
+
+test("it cancels pending prefetch requests if a new prefetch request is made", async ({ page }) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+
+  // Prefetch a request, that takes a long time to load
+  await hoverSelector({ page, selector: "#anchor_for_slow_prefetch" })
+  await page.click("#anchor_for_slow_prefetch", {noWaitAfter: true})
+
+  // Issue a new request including prefetch to a secondary resource, that loads fast
+  await hoverSelector({ page, selector: "#anchor_for_prefetch" })
+  await page.click("#anchor_for_prefetch")
+
+  await sleep(1100)
+
+  // The page should show the secondary resource
+  await expect(page).toHaveTitle("Prefetched Page")
+  await expect(page).toHaveURL("src/tests/fixtures/prefetched.html")
+})
+
 test("it resets the cache when a link is hovered", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
 


### PR DESCRIPTION
Fixes #1244, #1372, #1479

Inspired by https://github.com/hotwired/turbo/issues/1244#issuecomment-3756194305 by @SHPmax

### What's this?

Turbo can speed up page loads by prefetching requests. If the connection is slow or the server takes some time to respond, this currently has two side-effects, though:

1) Requesting a resource (that takes longer to load than the prefetch delay) multiple times - e.g. by quickly hovering back and forth over a link - will result in multiple requests to this same resource, that are running in parallel.
    
    https://github.com/user-attachments/assets/591b5667-db79-4479-b7b0-05107163fd50

2) If you request a resource that loads slow, then one that loads fast, the promise of the fast one will fulfill first (displaying a page for instance), then the slow one - that is still running - kicks in and overwrites the result.
   
    https://github.com/user-attachments/assets/526199763-b907fb74-52d4-4f52-bdc6-98c460bda694

    (_taken from #1479_)

### Solution

This PR makes the `link_prefetch_observer` record the last fetch request and cancel the previous one to the same URL. On top of that, during `turbo:visit`, all currently recorded requests but the one for the current URL are cancelled as well. This way, there now can only be one active prefetch request per URL and never a pending one of a different URL a visit happens.

I added test cases to outline the issue. You can see this PR in effect by commenting out the two added `fetchRequest.cancel()` statements in the `link_prefetch_observer`.

/cc @fritzmg, @ilyadh