### PR TITLE
Same-page anchor: Account for `<a>` nested in `<svg>`

### DIFF
--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -47,6 +47,8 @@
       <p><a id="bare-target-link" href="/src/tests/fixtures/one.html" target>Bare target attribute link</a></p>
       <p><a id="same-origin-download-link" href="/intentionally_missing_fake_download.html" download="x.html">Same-origin download link</a></p>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
+      <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-targeted-link-inside-svg-element" href="/src/tests/fixtures/one.html" target="_blank">Same-origin targeted link inside SVG element</a></text></svg>
+      <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-page-link-inside-svg-element" href="#main">Same-page link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
       <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-anchored-svg-link" href="#main">SVG link with hash-only href</a></text></svg>
       <p><a id="same-origin-get-link-form" href="/src/tests/fixtures/navigation.html?a=one&b=two" data-turbo-method="get">Same-origin data-turbo-method=get link</a></p>

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -258,6 +258,18 @@ test("following a same-origin [target] link", async ({ page }) => {
   expect(await visitAction(page)).toEqual("load")
 })
 
+test("following a same-origin [target] link inside an SVG", async ({ page }) => {
+  const errors = []
+  await page.on("pageerror", e => errors.push(e))
+  const link = page.locator("#same-origin-targeted-link-inside-svg-element")
+  await link.focus()
+  const [popup] = await Promise.all([page.waitForEvent("popup"), page.keyboard.press("Enter")])
+
+  expect(pathname(popup.url())).toEqual("/src/tests/fixtures/one.html")
+  expect(await visitAction(page)).toEqual("load")
+  expect(errors, "raised an error").toHaveLength(0)
+})
+
 test("following a _self [target] link", async ({ page }) => {
   await page.click("#self-targeted-link")
 
@@ -298,7 +310,19 @@ test("following a same-origin link inside an SVG element", async ({ page }) => {
   await page.keyboard.press("Enter")
 
   await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
-  expect(await visitAction(page)).toEqual("load")
+  expect(await visitAction(page)).toEqual("advance")
+})
+
+test("following a same-page link inside an SVG element", async ({ page }) => {
+  const errors = []
+  await page.on("pageerror", e => errors.push(e))
+  const link = page.locator("#same-page-link-inside-svg-element")
+  await link.focus()
+  await page.keyboard.press("Enter")
+
+  await expect(page).toHaveURL(withHash("#main"))
+  expect(await isScrolledToSelector(page, "#main"), "scrolled to #main").toEqual(true)
+  expect(errors, "raised an error").toHaveLength(0)
 })
 
 test("following a cross-origin link inside an SVG element", async ({ page }) => {
@@ -437,6 +461,26 @@ test("same-page anchor visits do not trigger visit events", async ({ page }) => 
   for (const eventName in events) {
     await page.goto("/src/tests/fixtures/navigation.html")
     await page.click('a[href="#main"]')
+    expect(await noNextEventNamed(page, eventName), `same-page links do not trigger ${eventName} events`).toEqual(true)
+  }
+})
+
+test("same-page anchor visits within SVG elements do not trigger visit events", async ({ page }) => {
+  const events = [
+    "turbo:before-visit",
+    "turbo:visit",
+    "turbo:before-cache",
+    "turbo:before-render",
+    "turbo:render",
+    "turbo:load"
+  ]
+
+  for (const eventName of events) {
+    await page.goto("/src/tests/fixtures/navigation.html")
+    const link = page.locator("#same-origin-link-inside-svg-element")
+    await link.focus()
+    await page.keyboard.press("Enter")
+    await readEventLogs(page)
     expect(await noNextEventNamed(page, eventName), `same-page links do not trigger ${eventName} events`).toEqual(true)
   }
 })

--- a/src/util.js
+++ b/src/util.js
@@ -263,11 +263,13 @@ export function findLinkFromClickTarget(target) {
   const link = findClosestRecursively(target, "a[href], a[xlink\\:href]")
 
   if (!link) return null
-  if (getLinkHrefString(link).startsWith("#")) return null
   if (link.hasAttribute("download")) return null
 
   const linkTarget = link.getAttribute("target")
   if (linkTarget && linkTarget !== "_self") return null
+
+  const linkHref = link.getAttribute("href")
+  if (linkHref && linkHref.startsWith("#")) return null
 
   return link
 }


### PR DESCRIPTION
Follow-up to [#1285][]

While an `<a>` element is typically represented by an [HTMLAnchorElement][], an `<a>` nested inside an `<svg>` element is instead an [SVGAElement][].

Similarly, while [HTMLAnchorElement.href][] returns a `String`, the [SVGAElement.href][] returns an instance of [SVGAnimatedString][], which cannot be supported by neither calls to [String.startsWith][] nor [RegExp.test][].

This commit adds explicit test coverage for a same-page navigation from an `<a>` nested within an `<svg>`. To ensure that the value is a `String`, replace `.href` with `getAttribute("href")`. This restores the implementation to be closer to what was defined in [e591ea9e][].

*Note*

It's worth mentioning that both of these new tests pass _without_ the `page.on("pageerror")` parts are omitted from the coverage. That signals to me that either:

1. the intended behavior still functions when JavaScript errors are raised, 
2. the test coverage does not genuinely reflect real-world use cases

I'm hopeful that it's 1., and that the test coverage _with_ the explicit JavaScript error tracking sufficiently guards against both 1. and 2. being true.

[#1285]: https://github.com/hotwired/turbo/pull/1285
[HTMLAnchorElement]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement
[SVGAElement]: https://developer.mozilla.org/en-US/docs/Web/API/SVGAElement
[HTMLAnchorElement.href]: https://developer.mozilla.org/en-US/docs/Web/API/HTMLAnchorElement/href
[SVGAElement.href]: https://developer.mozilla.org/en-US/docs/Web/API/SVGAElement/href
[SVGAnimatedString]: https://developer.mozilla.org/en-US/docs/Web/API/SVGAnimatedString
[String.startsWith]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/startsWith
[RegExp.test]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/RegExp/test
[e591ea9e]: https://github.com/hotwired/turbo/pull/1285/changes/e591ea9eb087a308f8d6997dc3ffe051058e3ec9#diff-9c0ec1b0a889e599f3ff81590864dd9dc65684a86b41f1da75acc53fafed12e3R251-R256