### PR TITLE
Fix some flaky tests that were failing in recent runs

### DIFF
--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -740,7 +740,7 @@ test("navigating a frame with a form[method=get] that does not redirect still up
   await nextEventOnTarget(page, "frame", "turbo:frame-render")
   await nextEventOnTarget(page, "frame", "turbo:frame-load")
 
-  expect(await noNextEventNamed(page, "turbo:before-fetch-request")).toBeTruthy()
+  expect(await noNextEventOnTarget(page, "frame", "turbo:before-fetch-request")).toBeTruthy()
 
   const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
 

--- a/src/tests/functional/pausable_requests_tests.js
+++ b/src/tests/functional/pausable_requests_tests.js
@@ -17,20 +17,22 @@ test("pauses and resumes request", async ({ page }) => {
 })
 
 test("aborts request", async ({ page }) => {
-  page.once("dialog", (dialog) => {
-    expect(dialog.message()).toEqual("Continue request?")
-    dialog.dismiss()
+  const dialogMessages = []
+
+  page.on("dialog", async (dialog) => {
+    dialogMessages.push(dialog.message())
+    if (dialog.message() === "Continue request?") {
+      await dialog.dismiss()
+    } else {
+      await dialog.accept()
+    }
   })
 
   await page.click("#link")
   await nextBeat()
-
-  page.once("dialog", (dialog) => {
-    expect(dialog.message()).toEqual("Request aborted")
-    dialog.accept()
-  })
-
   await nextBeat()
 
+  expect(dialogMessages).toContain("Continue request?")
+  expect(dialogMessages).toContain("Request aborted")
   await expect(page.locator("h1")).toHaveText("Pausable Requests")
 })

--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -57,11 +57,9 @@ test("reloads when tracked elements change", async ({ page }) => {
   )
 
   await page.click("#tracked-asset-change-link")
-  await nextEventNamed(page, "turbo:load")
+  await page.waitForURL("**/tracked_asset_change.html")
 
   const reason = await page.evaluate(() => localStorage.getItem("reloadReason"))
-
-  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/tracked_asset_change.html"))
   expect(await visitAction(page)).toEqual("load")
   expect(reason).toEqual("tracked_element_mismatch")
 })


### PR DESCRIPTION
- Fix flaky frame test by using targeted event check: change `noNextEventNamed` to `noNextEventOnTarget` for the frame form navigation test. The previous check would pick up unrelated `turbo:before-fetch-request` events from link prefetching on other elements, causing random test failures.

- Fix rendering test that was failing due to execution context being destroyed during full page reload. Use `waitForURL` instead of `nextEventNamed` since the tracked element mismatch causes a real browser reload.

- Fix `pausable_requests` test race condition by using a single dialog handler that collects all messages, rather than registering handlers sequentially which could miss dialogs on Firefox.

This was mostly Claude work with some direction from me 😅