### PR TITLE
Fix race condition in View#render by removing shared mutable state

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -281,11 +281,7 @@ export class FrameController {
       detail: { render }
     } = event
 
-    if (this.view.renderer && render) {
-      this.view.renderer.renderElement = render
-    }
-
-    return !defaultPrevented
+    return { immediateRender: !defaultPrevented, render }
   }
 
   viewRenderedSnapshot(_snapshot, _isPreview, _renderMethod) {}

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -340,11 +340,7 @@ export class Session {
       detail: { render }
     } = event
 
-    if (this.view.renderer && render) {
-      this.view.renderer.renderElement = render
-    }
-
-    return !defaultPrevented
+    return { immediateRender: !defaultPrevented, render }
   }
 
   viewRenderedSnapshot(_snapshot, _isPreview, renderMethod) {

--- a/src/core/view.js
+++ b/src/core/view.js
@@ -65,20 +65,19 @@ export class View {
     if (shouldRender) {
       try {
         this.renderPromise = new Promise((resolve) => (this.#resolveRenderPromise = resolve))
-        this.renderer = renderer
         await this.prepareToRenderSnapshot(renderer)
 
         const renderInterception = new Promise((resolve) => (this.#resolveInterceptionPromise = resolve))
-        const options = { resume: this.#resolveInterceptionPromise, render: this.renderer.renderElement, renderMethod: this.renderer.renderMethod }
-        const immediateRender = this.delegate.allowsImmediateRender(snapshot, options)
+        const options = { resume: this.#resolveInterceptionPromise, render: renderer.renderElement, renderMethod: renderer.renderMethod }
+        const { immediateRender, render } = this.delegate.allowsImmediateRender(snapshot, options)
+        if (render) renderer.renderElement = render
         if (!immediateRender) await renderInterception
 
         await this.renderSnapshot(renderer)
-        this.delegate.viewRenderedSnapshot(snapshot, isPreview, this.renderer.renderMethod)
+        this.delegate.viewRenderedSnapshot(snapshot, isPreview, options.renderMethod)
         this.delegate.preloadOnLoadLinksForView(this.element)
         this.finishRenderingSnapshot(renderer)
       } finally {
-        delete this.renderer
         this.#resolveRenderPromise(undefined)
         delete this.renderPromise
       }


### PR DESCRIPTION
Hi folks! I'm back with a small concurrency fix.

### Problem

The `render` method in `View` stores `this.renderer` so delegates can mutate it, then accesses `this.renderer.renderMethod` after async operations. A concurrent render can delete `this.renderer`, raising: `TypeError: can't access property "renderMethod", this.renderer is undefined`, resulting in the the first render failing entirely.

### Root Cause

1. Render A starts, sets `this.renderer = rendererA`
2. Render A awaits `renderSnapshot()`
3. While A is paused, Render B starts and overwrites `this.renderer = rendererB`
4. Render B completes and its `finally` block runs `delete this.renderer`
5. Render A resumes and tries to access `this.renderer.renderMethod`, and boom, `undefined`

### Prognosis

This isn't a critical bug, because it just means a different render wins the race condition than would otherwise. Perhaps its even weirdly desirable as an accidental "optimisation" due to less work being done. But it adds noise to my error reporting with semi-frequent exceptions (a few a day). Mostly, I think shared mutable state in parallel operations is better avoided, if it can be... it's hard to reason about, and could result in a more serious bug in the future that's difficult to track down.

### Solution

Remove the `this.renderer` shared mutable state entirely. Instead of having delegates mutate shared state, have `allowsImmediateRender` return the (possibly modified) render function. Any changes to the other properties of `this.renderer` were not used, so just returning the render function is sufficient to retain the existing behavior.