### PR TITLE
Fix prefetch for links with data-turbo-frame=_self

### DIFF
--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -113,7 +113,11 @@ export class LinkPrefetchObserver {
     request.headers["X-Sec-Purpose"] = "prefetch"
 
     const turboFrame = link.closest("turbo-frame")
-    const turboFrameTarget = link.getAttribute("data-turbo-frame") || turboFrame?.getAttribute("target") || turboFrame?.id
+    let turboFrameTarget = link.getAttribute("data-turbo-frame") || turboFrame?.getAttribute("target") || turboFrame?.id
+
+    if (turboFrameTarget === "_self") {
+      turboFrameTarget = turboFrame?.id
+    }
 
     if (turboFrameTarget && turboFrameTarget !== "_top") {
       request.headers["Turbo-Frame"] = turboFrameTarget

--- a/src/tests/fixtures/hover_to_prefetch.html
+++ b/src/tests/fixtures/hover_to_prefetch.html
@@ -56,5 +56,10 @@
     <turbo-frame id="frame_for_prefetch_top" target="_top">
       <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_in_frame_target_top">Hover to prefetch me</a>
     </turbo-frame>
+
+    <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_out_of_frame_target_self" data-turbo-frame="_self">Hover to prefetch me</a>
+    <turbo-frame id="frame_for_prefetch_self">
+      <a href="/src/tests/fixtures/prefetched.html" id="anchor_for_prefetch_in_frame_target_self" data-turbo-frame="_self">Hover to prefetch me</a>
+    </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/link_prefetch_observer_tests.js
+++ b/src/tests/functional/link_prefetch_observer_tests.js
@@ -205,6 +205,24 @@ test("doesn't include a turbo-frame header when the link is inside a turbo frame
   }})
 })
 
+test("includes turbo-frame header when the link with a data-turbo-frame=_self is inside a turbo frame", async ({ page}) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+
+  await assertPrefetchedOnHover({ page, selector: "#anchor_for_prefetch_in_frame_target_self", callback: (request) => {
+    const turboFrameHeader = request.headers()["turbo-frame"]
+    expect(turboFrameHeader).toEqual("frame_for_prefetch_self")
+  }})
+})
+
+test("doesn't include turbo-frame header when the link with a data-turbo-frame=_self is outside of a turbo frame", async ({ page}) => {
+  await goTo({ page, path: "/hover_to_prefetch.html" })
+
+  await assertPrefetchedOnHover({ page, selector: "#anchor_for_prefetch_out_of_frame_target_self", callback: (request) => {
+    const turboFrameHeader = request.headers()["turbo-frame"]
+    expect(turboFrameHeader).toEqual(undefined)
+  }})
+})
+
 test("it prefetches links with a delay", async ({ page }) => {
   await goTo({ page, path: "/hover_to_prefetch.html" })
 


### PR DESCRIPTION
Links with `data-turbo-frame="_self"` cause incorrect header to be set for prefetch requests: `Turbo-Frame: _self`. Unlike normal navigation, `_self` is not resolved to the current turbo-frame id.

When a link is outside of a turbo-frame, a `Turbo-Frame: _self` header is still sent, which can lead to incorrect server responses. In rails, server is rendering `turbo_rails/frame` layout which causes a page reload upon navigation.

Example:

```html
<turbo-frame id="frame" target="_top">
  <!-- header is incorrect -->
  <a data-turbo-frame="_self" href="/test">_self in frame</a> 
</turbo-frame>

<!-- header is incorrect, page reload in rails -->
<a data-turbo-frame="_self" href="/test">_self out of frame</a>
```

This change resolves `_self` to the closest turbo-frame before setting the header and avoids sending the header when no frame is present. Tests cover both cases.

Fixes #1349.