### PR TITLE
Preserve noscript elements, remove only stylesheet children (#1497)

### DIFF
--- a/src/core/drive/head_snapshot.js
+++ b/src/core/drive/head_snapshot.js
@@ -1,3 +1,4 @@
+import { elementIsStylesheet } from "../../util"
 import { Snapshot } from "../snapshot"
 
 export class HeadSnapshot extends Snapshot {
@@ -93,11 +94,6 @@ function elementIsScript(element) {
 function elementIsNoscript(element) {
   const tagName = element.localName
   return tagName == "noscript"
-}
-
-function elementIsStylesheet(element) {
-  const tagName = element.localName
-  return tagName == "style" || (tagName == "link" && element.getAttribute("rel") == "stylesheet")
 }
 
 function elementIsMetaElementWithName(element, name) {

--- a/src/core/drive/page_renderer.js
+++ b/src/core/drive/page_renderer.js
@@ -1,4 +1,4 @@
-import { activateScriptElement, waitForLoad } from "../../util"
+import { activateScriptElement, elementIsStylesheet, waitForLoad } from "../../util"
 import { Renderer } from "../renderer"
 
 export class PageRenderer extends Renderer {
@@ -180,7 +180,7 @@ export class PageRenderer extends Renderer {
   deactivateNoscriptStylesheetElements() {
     for (const noscriptElement of this.newElement.querySelectorAll("noscript")) {
       for (const child of [...noscriptElement.children]) {
-        if (child.localName === "style" || (child.localName === "link" && child.getAttribute("rel") === "stylesheet")) {
+        if (elementIsStylesheet(child)) {
           child.remove()
         }
       }

--- a/src/core/drive/page_renderer.js
+++ b/src/core/drive/page_renderer.js
@@ -173,13 +173,17 @@ export class PageRenderer extends Renderer {
 
   activateNewBody() {
     document.adoptNode(this.newElement)
-    this.removeNoscriptElements()
+    this.deactivateNoscriptStylesheetElements()
     this.activateNewBodyScriptElements()
   }
 
-  removeNoscriptElements() {
+  deactivateNoscriptStylesheetElements() {
     for (const noscriptElement of this.newElement.querySelectorAll("noscript")) {
-      noscriptElement.remove()
+      for (const child of [...noscriptElement.children]) {
+        if (child.localName === "style" || (child.localName === "link" && child.getAttribute("rel") === "stylesheet")) {
+          child.remove()
+        }
+      }
     }
   }
 

--- a/src/core/drive/page_snapshot.js
+++ b/src/core/drive/page_snapshot.js
@@ -39,7 +39,11 @@ export class PageSnapshot extends Snapshot {
     }
 
     for (const clonedNoscriptElement of clonedElement.querySelectorAll("noscript")) {
-      clonedNoscriptElement.remove()
+      for (const child of [...clonedNoscriptElement.children]) {
+        if (child.localName === "style" || (child.localName === "link" && child.getAttribute("rel") === "stylesheet")) {
+          child.remove()
+        }
+      }
     }
 
     return new PageSnapshot(this.documentElement, clonedElement, this.headSnapshot)

--- a/src/core/drive/page_snapshot.js
+++ b/src/core/drive/page_snapshot.js
@@ -1,4 +1,4 @@
-import { parseHTMLDocument } from "../../util"
+import { elementIsStylesheet, parseHTMLDocument } from "../../util"
 import { Snapshot } from "../snapshot"
 import { expandURL } from "../url"
 import { HeadSnapshot } from "./head_snapshot"
@@ -40,7 +40,7 @@ export class PageSnapshot extends Snapshot {
 
     for (const clonedNoscriptElement of clonedElement.querySelectorAll("noscript")) {
       for (const child of [...clonedNoscriptElement.children]) {
-        if (child.localName === "style" || (child.localName === "link" && child.getAttribute("rel") === "stylesheet")) {
+        if (elementIsStylesheet(child)) {
           child.remove()
         }
       }

--- a/src/tests/fixtures/body_noscript_with_content.html
+++ b/src/tests/fixtures/body_noscript_with_content.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Body noscript with content</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1>Body noscript with content</h1>
+    <p><a id="back-link" href="/src/tests/fixtures/rendering.html">Go back</a></p>
+    <noscript id="lazy-load-noscript">
+      <img src="/src/tests/fixtures/logo.png" alt="Lazy loaded image">
+    </noscript>
+    <noscript id="mixed-noscript">
+      <img src="/src/tests/fixtures/logo.png" alt="Another image">
+      <link rel="stylesheet" type="text/css" href="/src/tests/fixtures/noscript.css">
+    </noscript>
+  </body>
+</html>

--- a/src/tests/fixtures/body_noscript_with_content.html
+++ b/src/tests/fixtures/body_noscript_with_content.html
@@ -16,5 +16,9 @@
       <img src="/src/tests/fixtures/logo.png" alt="Another image">
       <link rel="stylesheet" type="text/css" href="/src/tests/fixtures/noscript.css">
     </noscript>
+    <noscript id="alternate-stylesheet-noscript">
+      <img src="/src/tests/fixtures/logo.png" alt="Alternate stylesheet image">
+      <link rel="alternate stylesheet" type="text/css" href="/src/tests/fixtures/noscript.css">
+    </noscript>
   </body>
 </html>

--- a/src/tests/fixtures/rendering.html
+++ b/src/tests/fixtures/rendering.html
@@ -38,6 +38,7 @@
       <p><a id="additional-assets-link" href="/src/tests/fixtures/additional_assets.html">Additional assets</a></p>
       <p><a id="additional-script-link" href="/src/tests/fixtures/additional_script.html">Additional script</a></p>
       <p><a id="body-noscript-link" href="/src/tests/fixtures/body_noscript.html">Body noscript</a></p>
+      <p><a id="body-noscript-content-link" href="/src/tests/fixtures/body_noscript_with_content.html">Body noscript with content</a></p>
       <p><a id="head-script-link" href="/src/tests/fixtures/head_script.html">Head script</a></p>
       <p><a id="body-script-link" href="/src/tests/fixtures/body_script.html">Body script</a></p>
       <p><a id="eval-false-script-link" href="/src/tests/fixtures/eval_false_script.html">data-turbo-eval=false script</a></p>

--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -283,6 +283,16 @@ test("removes only stylesheet elements from noscript with mixed content", async 
   expect(await isNoscriptStylesheetEvaluated(page)).toEqual(false)
 })
 
+test("removes alternate stylesheet elements from noscript", async ({ page }) => {
+  await page.click("#body-noscript-content-link")
+  await nextEventNamed(page, "turbo:render")
+
+  const noscriptExists = await page.locator("#alternate-stylesheet-noscript").count()
+  expect(noscriptExists).toEqual(1)
+
+  expect(await isNoscriptStylesheetEvaluated(page)).toEqual(false)
+})
+
 test("waits for CSS to be loaded before rendering", async ({ page }) => {
   let finishLoadingCSS = (_value) => {}
   const promise = new Promise((resolve) => {

--- a/src/tests/functional/rendering_tests.js
+++ b/src/tests/functional/rendering_tests.js
@@ -265,6 +265,24 @@ test("does not evaluate body stylesheet elements inside noscript elements", asyn
   expect(await isNoscriptStylesheetEvaluated(page)).toEqual(false)
 })
 
+test("preserves noscript elements with non-style content after navigation", async ({ page }) => {
+  await page.click("#body-noscript-content-link")
+  await nextEventNamed(page, "turbo:render")
+
+  const noscriptCount = await page.locator("#lazy-load-noscript").count()
+  expect(noscriptCount).toEqual(1)
+})
+
+test("removes only stylesheet elements from noscript with mixed content", async ({ page }) => {
+  await page.click("#body-noscript-content-link")
+  await nextEventNamed(page, "turbo:render")
+
+  const mixedNoscriptExists = await page.locator("#mixed-noscript").count()
+  expect(mixedNoscriptExists).toEqual(1)
+
+  expect(await isNoscriptStylesheetEvaluated(page)).toEqual(false)
+})
+
 test("waits for CSS to be loaded before rendering", async ({ page }) => {
   let finishLoadingCSS = (_value) => {}
   const promise = new Promise((resolve) => {

--- a/src/util.js
+++ b/src/util.js
@@ -208,6 +208,11 @@ export function findClosestRecursively(element, selector) {
   }
 }
 
+export function elementIsStylesheet(element) {
+  return element.localName === "style" ||
+    (element.localName === "link" && element.relList.contains("stylesheet"))
+}
+
 export function elementIsFocusable(element) {
   const inertDisabledOrHidden = "[inert], :disabled, [hidden], details:not([open]), dialog:not([open])"
 


### PR DESCRIPTION
## Summary

Fixes #1497

The previous fix for #1464 (PR #1475) removed all `<noscript>` elements entirely during Turbo navigation to prevent unintended style evaluation. While this solved the style issue, it also destroyed the elements and their DOM structure, breaking JavaScript use cases that rely on `<noscript>` content being present in the DOM.

A common example is lazy loading with `IntersectionObserver`: JavaScript watches elements with a `data-lazy-load` attribute, and when they enter the viewport, reads the `innerHTML` of a child `<noscript>` to extract and insert the actual content (e.g., `<img>` tags). This is a well-established pattern used by libraries such as lazySizes and WordPress plugins like WP Rocket. It works because `<noscript>` content is not rendered when JavaScript is enabled, but remains accessible via `innerHTML` — providing both a progressive enhancement fallback and a mechanism for deferred loading.

### Why full stringification doesn't work either

The initial approach in PR #1475 (before the review change in `86e8efb`) converted `<noscript>` content from DOM to text via `noscriptElement.textContent = noscriptElement.innerHTML`. While this preserves the `<noscript>` element itself, it flattens the entire DOM tree inside it into a plain text node. JavaScript that expects to traverse or query child elements — or that relies on the original HTML structure in `innerHTML` — would break as well.

### How this fix works

When Turbo fetches a page, the HTML is parsed via `new DOMParser().parseFromString()`, which creates a non-browsing context. In this context, `<noscript>` children are parsed as real DOM elements (not hidden text). After `document.adoptNode()` transfers the parsed body into the live document, those child elements become accessible — and problematic ones like `<style>` and `<link rel="stylesheet">` can get evaluated by the browser, which was the original bug in #1464.

This fix takes a targeted approach: instead of removing the entire `<noscript>` element or converting its content to text, it removes only `<style>` and `<link rel="stylesheet">` children from within `<noscript>` elements. Since these are the specific elements that browsers evaluate after adoption, removing them is sufficient to prevent the unintended style application. The `<noscript>` elements themselves and their remaining children (images, etc.) stay intact in the DOM, preserving access for any JavaScript that relies on their content.

### Changes

- **`page_renderer.js`**: Rename `removeNoscriptElements()` → `deactivateNoscriptStylesheetElements()`, only remove style-related children instead of the entire element
- **`page_snapshot.js`**: Apply the same targeted removal in `clone()` for cached snapshots
- **New test fixture and tests**: Verify that `<noscript>` elements with non-style content are preserved after navigation, and that mixed-content `<noscript>` elements have only stylesheets removed