### PR TITLE
Fix activateScriptElement to set the CSP nonce correctly

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -4,12 +4,12 @@ export function activateScriptElement(element) {
   } else {
     const createdScriptElement = document.createElement("script")
     const cspNonce = getCspNonce()
-    if (cspNonce) {
-      createdScriptElement.nonce = cspNonce
-    }
     createdScriptElement.textContent = element.textContent
     createdScriptElement.async = false
     copyElementAttributes(createdScriptElement, element)
+    if (cspNonce && !createdScriptElement.nonce) {
+      createdScriptElement.nonce = cspNonce
+    }
     return createdScriptElement
   }
 }


### PR DESCRIPTION
The `activateScriptElement` function did not correctly set the CSP nonce on occasions. When the element to duplicate has been stripped from its CSP nonce in `elementWithoutNonce`, the nonce attribute is set to an empty string and would overwrite the correct nonce.

Fix #1502