### PR TITLE
Fix flaky autofocus stream test by waiting for the initial autofocus to settle

### DIFF
--- a/src/tests/functional/autofocus_tests.js
+++ b/src/tests/functional/autofocus_tests.js
@@ -40,6 +40,9 @@ test("navigating a frame with a turbo-frame targeting the frame autofocuses [aut
 })
 
 test("receiving a Turbo Stream message with an [autofocus] element when the activeElement is the document", async ({ page }) => {
+  // Ensure the [autofocus] element has been processed before blurring
+  await expect(page.locator("#first-autofocus-element")).toBeFocused()
+
   await page.evaluate(() => {
     document.activeElement.blur()
     window.Turbo.renderStreamMessage(`
@@ -48,6 +51,7 @@ test("receiving a Turbo Stream message with an [autofocus] element when the acti
       </turbo-stream>
     `)
   })
+
   await expect(page.locator("#autofocus-from-stream")).toBeFocused()
 })
 
@@ -62,7 +66,6 @@ test("autofocus from a Turbo Stream message does not leak a placeholder [id]", a
   })
 
   await expect(page.locator("#container-from-stream input")).toBeFocused()
-
 })
 
 test("receiving a Turbo Stream message with an [autofocus] element when an element within the document has focus", async ({ page }) => {


### PR DESCRIPTION
Chrome's native autofocus processing for the page's `[autofocus]` button can run after `page.goto` resolves. If the test's stream rendering happens in between, the pending autofocus steals focus from the stream-appended input. Wait for the initial autofocus to complete before proceeding.