### PR TITLE
Fix hash navigation logic

### DIFF
--- a/src/core/drive/history.js
+++ b/src/core/drive/history.js
@@ -78,18 +78,38 @@ export class History {
   // Event handlers
 
   onPopState = (event) => {
+    const newLocation = new URL(window.location.href)
+
+    // Ignore popstate events triggered by hash-only changes not managed by Turbo
+    if (!event.state?.turbo && this.location && this.#onlyHashChanged(newLocation)) {
+      this.location = newLocation
+      return
+    }
+
     const { turbo } = event.state || {}
-    this.location = new URL(window.location.href)
+    this.location = newLocation
 
     if (turbo) {
       const { restorationIdentifier, restorationIndex } = turbo
       this.restorationIdentifier = restorationIdentifier
       const direction = restorationIndex > this.currentIndex ? "forward" : "back"
-      this.delegate.historyPoppedToLocationWithRestorationIdentifierAndDirection(this.location, restorationIdentifier, direction)
+      this.delegate.historyPoppedToLocationWithRestorationIdentifierAndDirection(
+        this.location,
+        restorationIdentifier,
+        direction
+      )
       this.currentIndex = restorationIndex
     } else {
       this.currentIndex++
       this.delegate.historyPoppedWithEmptyState(this.location)
     }
+  }
+
+  #onlyHashChanged(newLocation) {
+    return (
+      this.location.origin === newLocation.origin &&
+      this.location.pathname === newLocation.pathname &&
+      this.location.search === newLocation.search
+    )
   }
 }

--- a/src/util.js
+++ b/src/util.js
@@ -209,8 +209,7 @@ export function findClosestRecursively(element, selector) {
 }
 
 export function elementIsStylesheet(element) {
-  return element.localName === "style" ||
-    (element.localName === "link" && element.relList.contains("stylesheet"))
+  return element.localName === "style" || (element.localName === "link" && element.relList.contains("stylesheet"))
 }
 
 export function elementIsFocusable(element) {
@@ -253,7 +252,7 @@ export function findLinkFromClickTarget(target) {
   const link = findClosestRecursively(target, "a[href], a[xlink\\:href]")
 
   if (!link) return null
-  if (link.href.startsWith("#")) return null
+  if (link.getAttribute("href")?.startsWith("#")) return null
   if (link.hasAttribute("download")) return null
 
   const linkTarget = link.getAttribute("target")


### PR DESCRIPTION
Fix how turbo handle hash navigation.

## Issue

On my website I have links looking like this

```
<li><a href="#t0">00:00</a> Intro</li>
```

Here is how "href" behaves for such links

```js
link.href  // http://localhost/courses/temporibus-accusamus-ullam-sed-5#t0' so it will never start with #
link.getAttribute('href') // '#t0'
```

With the fix, the navigation is not tracked by turbo, but navigating back to a known hash triggers a `popstate` event. So turbo logic need to be fenced to not be triggered.

I needed this change since my page contains an autoplay and a hash change make the video played multiple time. Like this issues #1017 
