### PR TITLE
Preserve hash fragment during frame navigation

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -131,7 +131,7 @@ export class FrameController {
 
   async loadResponse(fetchResponse) {
     if (fetchResponse.redirected || (fetchResponse.succeeded && fetchResponse.isHTML)) {
-      this.sourceURL = fetchResponse.response.url
+      this.sourceURL = fetchResponse.response.url + this.#hashFromSourceURL
     }
 
     try {
@@ -528,6 +528,13 @@ export class FrameController {
     if (this.element.src) {
       return this.element.src
     }
+  }
+
+  get #hashFromSourceURL() {
+    if (this.sourceURL) {
+      return expandURL(this.sourceURL).hash
+    }
+    return ""
   }
 
   set sourceURL(sourceURL) {

--- a/src/tests/fixtures/frames.html
+++ b/src/tests/fixtures/frames.html
@@ -40,6 +40,7 @@
       <button id="add-refresh-morph-to-frame" type="button">Add [refresh="morph"] to #frame</button>
       <button id="add-src-to-frame" type="button">Add [src="/src/tests/fixtures/frames.html"] to #frame so it can be reloaded</button>
       <a id="link-frame" href="/src/tests/fixtures/frames/frame.html">Navigate #frame from within</a>
+      <a id="link-frame-with-hash" href="/src/tests/fixtures/frames/frame.html#frame-hash" data-turbo-action="advance">Navigate #frame with hash</a>
       <a id="link-frame-with-search-params" href="/src/tests/fixtures/frames/frame.html?key=value">Navigate #frame with ?key=value</a>
       <a id="link-nested-frame-action-advance" href="/src/tests/fixtures/frames/frame.html" data-turbo-action="advance">Navigate #frame from within with a[data-turbo-action="advance"]</a>
       <a id="link-top" href="/src/tests/fixtures/one.html" data-turbo-frame="_top">Visit one.html</a>

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -848,6 +848,17 @@ test("a turbo-frame that has been driven by a[data-turbo-action] can be navigate
   await expect(page).toHaveURL(withPathname("/src/tests/fixtures/frames/hello.html"))
 })
 
+test("navigating a frame with a link that has a path and hash preserves the hash", async ({ page }) => {
+  await page.click("#link-frame-with-hash")
+  await nextEventNamed(page, "turbo:load")
+
+  await expect(page.locator("#frame h2")).toHaveText("Frame: Loaded")
+  await expect(page).toHaveURL(/#frame-hash$/)
+
+  const src = (await attributeForSelector(page, "#frame", "src")) ?? ""
+  expect(src).toContain("#frame-hash")
+})
+
 test("navigating turbo-frame from within with a[data-turbo-action=advance] pushes URL state", async ({ page }) => {
   await page.click("#link-nested-frame-action-advance")
   await nextEventNamed(page, "turbo:load")


### PR DESCRIPTION
`fetchResponse.response.url` strips the hash fragment (browsers never send it over the wire), so when `FrameController.loadResponse` updated `sourceURL` the hash was lost from the frame's `[src]` and any promoted URL state.

Re-attach the original hash from `sourceURL` after the response is received.

Partially addresses #598
