### PR TITLE
Do not add post form body to query params if form data is only set via event

### DIFF
--- a/src/http/fetch_request.js
+++ b/src/http/fetch_request.js
@@ -213,8 +213,7 @@ export function isSafe(fetchMethod) {
 }
 
 function buildResourceAndBody(resource, method, requestBody, enctype) {
-  const searchParams =
-    Array.from(requestBody).length > 0 ? new URLSearchParams(entriesExcludingFiles(requestBody)) : resource.searchParams
+  const searchParams = new URLSearchParams(entriesExcludingFiles(requestBody))
 
   if (isSafe(method)) {
     return [mergeIntoURLSearchParams(resource, searchParams), null]
@@ -237,9 +236,8 @@ function entriesExcludingFiles(requestBody) {
 }
 
 function mergeIntoURLSearchParams(url, requestBody) {
-  const searchParams = new URLSearchParams(entriesExcludingFiles(requestBody))
-
-  url.search = searchParams.toString()
+  const searchParams = entriesExcludingFiles(requestBody)
+  searchParams.forEach(([name, value]) => url.searchParams.append(name, value))
 
   return url
 }


### PR DESCRIPTION
In a scenario where you have an empty form, so no inputs and no `name` attribute on the submitter, and you're setting the form data via the `turbo:submit-start` event (with `event.detail.formSubmission.fetchRequest.body.append`), you're actually adding the form data to the URL objects `searchParams`, as `resource.searchParams` is used for the body. 
This causes the URL to contain all of the form data, which is especially problematic for larger amounts of data, as the webserver then might just close the connection because the URL is too long. In my case this happened after the URL reached about 7.5KB.
This PR fixes the issue, while also simplifying the logic a bit. 

/cc @m-vo 