### PR TITLE
Fix historyPoppedWithEmptyState on data-turbo=false pages (fixes #1496)

### DIFF
--- a/src/core/session.js
+++ b/src/core/session.js
@@ -217,9 +217,19 @@ export class Session {
   }
 
   historyPoppedWithEmptyState(location) {
+    // Don't inject Turbo state on pages with data-turbo="false" — it would cause
+    // restore visits on subsequent back/forward, replacing the DOM despite Turbo being disabled
+    if (this.pageHasTurboDisabled()) return
+
     this.history.replace(location)
     this.view.lastRenderedLocation = location
     this.view.cacheSnapshot()
+  }
+
+  pageHasTurboDisabled() {
+    const body = document.body?.getAttribute("data-turbo")
+    const html = document.documentElement?.getAttribute("data-turbo")
+    return body === "false" || html === "false"
   }
 
   // Scroll observer delegate

--- a/src/tests/fixtures/data_turbo_false_hash_routing.html
+++ b/src/tests/fixtures/data_turbo_false_hash_routing.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>data-turbo=false hash routing</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body data-turbo="false">
+    <h1>Hash routing with data-turbo="false"</h1>
+    <p>Current hash: <strong id="current-hash"></strong></p>
+    <nav>
+      <a href="#step1" id="link-step1">Step 1</a>
+      <a href="#step2" id="link-step2">Step 2</a>
+      <a href="#step3" id="link-step3">Step 3</a>
+    </nav>
+    <div id="content"></div>
+    <script>
+      function updateHash() {
+        const el = document.getElementById("current-hash")
+        if (el) el.textContent = location.hash || "(none)"
+      }
+      window.addEventListener("hashchange", updateHash)
+      updateHash()
+    </script>
+  </body>
+</html>

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -425,6 +425,25 @@ test("same-page anchor visits do not trigger visit events", async ({ page }) => 
   }
 })
 
+test("history.back on data-turbo=false page with hash routing does not trigger restore visit", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/data_turbo_false_hash_routing.html")
+  await readEventLogs(page)
+
+  await page.click("#link-step1")
+  await page.click("#link-step2")
+  await page.click("#link-step3")
+
+  await page.goBack()
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/data_turbo_false_hash_routing.html"))
+  await expect(page).toHaveURL(withHash("#step2"))
+  expect(await noNextEventNamed(page, "turbo:visit")).toEqual(true)
+
+  await page.goBack()
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/data_turbo_false_hash_routing.html"))
+  await expect(page).toHaveURL(withHash("#step1"))
+  expect(await noNextEventNamed(page, "turbo:visit")).toEqual(true)
+})
+
 test("correct referrer header", async ({ page }) => {
   page.click("#headers-link")
   await nextEventNamed(page, "turbo:load")


### PR DESCRIPTION
Don't inject Turbo state into history entries when the page has data-turbo="false" on body or html. This prevents restore visits on subsequent back/forward navigation for hash-based routing.