### PR TITLE
Add defensive Element check in HeadSnapshot.detailsByOuterHTML 

### DIFF
--- a/src/core/drive/head_snapshot.js
+++ b/src/core/drive/head_snapshot.js
@@ -4,6 +4,7 @@ import { Snapshot } from "../snapshot"
 export class HeadSnapshot extends Snapshot {
   detailsByOuterHTML = this.children
     .filter((element) => !elementIsNoscript(element))
+    .filter((element) => element instanceof Element)
     .map((element) => elementWithoutNonce(element))
     .reduce((result, element) => {
       const { outerHTML } = element


### PR DESCRIPTION

Filter out non-Element nodes before calling elementWithoutNonce. Text/comment nodes in head lack hasAttribute(), causing TypeError during prefetch when head contains HTML comments.

