### PR TITLE
Fix TypeError when FrameElement delegate is undefined (fixes #1364)

### DIFF
--- a/src/elements/frame_element.js
+++ b/src/elements/frame_element.js
@@ -34,18 +34,24 @@ export class FrameElement extends HTMLElement {
   }
 
   connectedCallback() {
-    this.delegate.connect()
+    if (this.delegate) {
+      this.delegate.connect()
+    }
   }
 
   disconnectedCallback() {
-    this.delegate.disconnect()
+    if (this.delegate) {
+      this.delegate.disconnect()
+    }
   }
 
   reload() {
-    return this.delegate.sourceURLReloaded()
+    return this.delegate?.sourceURLReloaded()
   }
 
   attributeChangedCallback(name) {
+    if (!this.delegate) return
+
     if (name == "loading") {
       this.delegate.loadingStyleChanged()
     } else if (name == "src") {
@@ -161,7 +167,7 @@ export class FrameElement extends HTMLElement {
    * Determines if the element has finished loading
    */
   get complete() {
-    return !this.delegate.isLoading
+    return this.delegate ? !this.delegate.isLoading : true
   }
 
   /**

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -1090,3 +1090,21 @@ async function withoutChangingEventListenersCount(page, callback) {
 function frameScriptEvaluationCount(page) {
   return page.evaluate(() => window.frameScriptEvaluationCount)
 }
+
+test("FrameElement does not throw when delegate is undefined in connectedCallback (fixes #1364)", async ({ page }) => {
+  const errorThrown = await page.evaluate(() => {
+    const frame = document.createElement("turbo-frame")
+    frame.id = "test-frame-1364"
+    frame.delegate = undefined
+
+    try {
+      document.body.appendChild(frame)
+      document.body.removeChild(frame)
+      return false
+    } catch (e) {
+      return true
+    }
+  })
+
+  expect(errorThrown, "FrameElement should not throw when delegate is undefined").toBe(false)
+})


### PR DESCRIPTION
Add defensive checks in connectedCallback, disconnectedCallback, attributeChangedCallback, reload(), and complete getter to handle edge case where delegate is undefined (observed on Safari/WebKit).