### PR TITLE
Fix it so same-page anchor visits do not trigger visit events

### DIFF
--- a/src/core/session.js
+++ b/src/core/session.js
@@ -219,7 +219,6 @@ export class Session {
   historyPoppedWithEmptyState(location) {
     this.history.replace(location)
     this.view.lastRenderedLocation = location
-    this.view.cacheSnapshot()
   }
 
   // Scroll observer delegate

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -418,8 +418,9 @@ test("same-page anchor visits do not trigger visit events", async ({ page }) => 
     "turbo:load"
   ]
 
-  for (const eventName in events) {
+  for (const eventName of events) {
     await page.goto("/src/tests/fixtures/navigation.html")
+    await readEventLogs(page)
     await page.click('a[href="#main"]')
     expect(await noNextEventNamed(page, eventName), `same-page links do not trigger ${eventName} events`).toEqual(true)
   }

--- a/src/util.js
+++ b/src/util.js
@@ -253,7 +253,8 @@ export function findLinkFromClickTarget(target) {
   const link = findClosestRecursively(target, "a[href], a[xlink\\:href]")
 
   if (!link) return null
-  if (link.href.startsWith("#")) return null
+  if (link.getAttribute("href")?.startsWith("#")) return null
+  if (!(link instanceof HTMLAnchorElement)) return null
   if (link.hasAttribute("download")) return null
 
   const linkTarget = link.getAttribute("target")


### PR DESCRIPTION
There was a test for this, but it was broken.
