### PR TITLE
Fix id not escaped for selector

### DIFF
--- a/src/core/snapshot.js
+++ b/src/core/snapshot.js
@@ -18,7 +18,10 @@ export class Snapshot {
   }
 
   getElementForAnchor(anchor) {
-    return anchor ? this.element.querySelector(`[id='${anchor}'], a[name='${anchor}']`) : null
+    if (!anchor) return null
+
+    const id = CSS.escape(anchor)
+    return this.element.querySelector(`[id=${id}], a[name=${id}]`)
   }
 
   get isConnected() {


### PR DESCRIPTION
Given this page:

```
<!DOCTYPE html>
<html lang="en">
    <head>
        <meta charset="utf-8">
        <meta http-equiv="X-UA-Compatible" content="IE=edge">
        <meta name="viewport" content="width=device-width, initial-scale=1">
        <title>Test</title>

        <style>
            .space { height: 100vh; }
        </style>
        <script src="https://esm.run/@hotwired/turbo" type="module"></script>
    </head>

    <body>
        <p id="top"><a href="#'">Jump</a></p>

        <div class="space"></div>

        <p id="'">
            Hello
            <p><a href="#top">Back to top</a></p>
        </p>
    </body>
</html>
```

Turbo will error out when clicking `Jump` due to the id not being escaped.

I suppose there should be a test but I have no idea how the test here works.