### PR TITLE
Only retain previousFrameElement for promoted frame visits

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -299,7 +299,15 @@ export class FrameController {
   // Frame renderer delegate
 
   willRenderFrame(currentElement, _newElement) {
-    this.previousFrameElement = currentElement.cloneNode(true)
+    // Only clone the frame for promoted frame visits, where visitCachedSnapshot
+    // consumes the clone to restore the frame's contents into the cached page
+    // snapshot (and deletes it). For plain frame renders — src changes without
+    // a data-turbo-action, refresh="morph" reloads, broadcast-driven reloads —
+    // nothing ever consumes or clears the clone, so it would pin a complete
+    // copy of the frame's previous subtree on the controller indefinitely.
+    if (this.action) {
+      this.previousFrameElement = currentElement.cloneNode(true)
+    }
   }
 
   visitCachedSnapshot = ({ element }) => {

--- a/src/tests/functional/autofocus_tests.js
+++ b/src/tests/functional/autofocus_tests.js
@@ -56,6 +56,9 @@ test("receiving a Turbo Stream message with an [autofocus] element when the acti
 })
 
 test("autofocus from a Turbo Stream message does not leak a placeholder [id]", async ({ page }) => {
+  // Ensure the [autofocus] element has been processed before blurring
+  await expect(page.locator("#first-autofocus-element")).toBeFocused()
+
   await page.evaluate(() => {
     document.activeElement.blur()
     window.Turbo.renderStreamMessage(`


### PR DESCRIPTION
## The retention

`FrameController#willRenderFrame` deep-clones the frame's entire current subtree into `this.previousFrameElement` on **every** frame render. The only consumer is `visitCachedSnapshot`, which restores the clone into the cached page snapshot and then `delete`s it — and that callback is only wired up by `proposeVisitIfNavigatedWithAction`, i.e. for promoted frame visits (`data-turbo-action`).

For every other kind of frame render — `src` changes without an action, `refresh="morph"` reloads, broadcast/stream-driven `reload()`s — nothing ever consumes or clears the clone. Each frame controller then permanently retains a complete copy of its previous subtree, and refreshes it (re-clone) on every render.

Frames with large contents that reload frequently pay twice:

- the **pinned clone** itself (a full detached copy of the frame's previous children, held for the controller's lifetime), and
- the **per-render clone cost**: `cloneNode(true)` constructs nested custom elements in the clone, so every nested `<turbo-frame>` eagerly builds its `FrameController`, `AppearanceObserver`, and `IntersectionObserver` just to be thrown away.

Profiling a production-sized page (heap snapshots with forced GC, retainer-chain analysis) where a large frame containing ~150 nested lazy frames reloads via broadcast: the controller pinned the full subtree copy permanently and constructed ~190 IntersectionObservers per reload. Retainer chain:

```
live <turbo-frame> → FrameController.previousFrameElement → detached previous subtree
  → nested <turbo-frame> clones → FrameController → AppearanceObserver → IntersectionObserver
```

## The fix

Only take the clone when `this.action` is set — the promoted-visit case where `visitCachedSnapshot` will actually consume and release it. `proposeVisitIfNavigatedWithAction` assigns `this.action` before the fetch/render, so the clone is still captured for every promoted visit exactly as before.

## Tests

The existing functional tests that exercise the consumer still pass, notably "navigating back after pushing URL state from a turbo-frame[data-turbo-action=advance] restores the frames previous contents" and the back-then-forward variant, plus the full frame, frame navigation, rendering, page refresh, and stream suites on Chrome (3 pre-existing noscript rendering failures on `main` are unrelated and fail identically without this change).
