### PR TITLE
Allow prefetching on links with certain targets

### DIFF
--- a/src/observers/link_prefetch_observer.js
+++ b/src/observers/link_prefetch_observer.js
@@ -154,8 +154,16 @@ export class LinkPrefetchObserver {
 }
 
 const unfetchableLink = (link) => {
-  return link.origin !== document.location.origin || !["http:", "https:"].includes(link.protocol) || link.hasAttribute("target")
+  const target = link.getAttribute("target")
+  const hasMeaningfulTarget = target && target !== "_self" && target !== "_top" && target !== "_parent"
+
+  return (
+    link.origin !== document.location.origin ||
+    !["http:", "https:"].includes(link.protocol) ||
+    hasMeaningfulTarget
+  )
 }
+
 
 const linkToTheSamePage = (link) => {
   return (link.pathname + link.search === document.location.pathname + document.location.search) || link.href.startsWith("#")


### PR DESCRIPTION
Turbo checks if a link as a target and disables prefetching if so. There's a few targets that are essentially just the normal link behavior. _self is literally the default behavior, top navigates the full window, etc. This allows those specific targets to get prefetched.