### PR TITLE
Reset forceReloaded after a successful page render

### DIFF
--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -24,6 +24,10 @@ export class PageView extends View {
     if (!renderer.shouldRender) {
       this.forceReloaded = true
     } else {
+      // Reset on every real render so a forced reload recorded by an earlier render
+      // (e.g. a no-render frame promotion via data-turbo-action) cannot persist and
+      // suppress the scroll reset of subsequent Visits.
+      this.forceReloaded = false
       visit?.changeHistory()
     }
 

--- a/src/tests/fixtures/frames/frame_only_body.html
+++ b/src/tests/fixtures/frames/frame_only_body.html
@@ -1,0 +1,3 @@
+<turbo-frame id="frame">
+  <h2>Frame: Loaded</h2>
+</turbo-frame>

--- a/src/tests/fixtures/scroll_reset_after_frame_navigation.html
+++ b/src/tests/fixtures/scroll_reset_after_frame_navigation.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Scroll reset after a frame navigation</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <style>
+      body { min-height: 300vh; }
+    </style>
+  </head>
+  <body>
+    <turbo-frame id="frame">
+      <a id="frame-link" href="/src/tests/fixtures/frames/frame_only_body.html">Navigate the frame</a>
+    </turbo-frame>
+
+    <a id="full-visit" href="/src/tests/fixtures/scroll_restoration.html">Full Drive visit</a>
+  </body>
+</html>

--- a/src/tests/functional/scroll_restoration_tests.js
+++ b/src/tests/functional/scroll_restoration_tests.js
@@ -1,6 +1,8 @@
 import { expect, test } from "@playwright/test"
 import {
+  clickWithoutScrolling,
   nextBeat,
+  nextEventNamed,
   reloadPage,
   scrollPosition,
   scrollToSelector
@@ -32,4 +34,35 @@ test("returning from history", async ({ page }) => {
 
   const { y: yAfterReturning } = await scrollPosition(page)
   expect(yAfterReturning).not.toEqual(0)
+})
+
+// A <turbo-frame> navigation with a data-turbo-action promotes to a page Visit. When
+// the frame responds with a frame-only body (no full document), that Visit's page
+// render is skipped, which sets PageView#forceReloaded. It must be cleared on the
+// next real render, otherwise it suppresses the scroll reset of later Visits.
+async function assertScrollsToTopAfterFrameNavigation(page, action) {
+  await page.goto("/src/tests/fixtures/scroll_reset_after_frame_navigation.html")
+  await nextEventNamed(page, "turbo:load") // consume the initial load before tracking later ones
+
+  await page.locator("#frame").evaluate((frame, action) => frame.setAttribute("data-turbo-action", action), action)
+  await page.click("#frame-link")
+  await nextEventNamed(page, "turbo:load")
+  await expect(page).toHaveURL(/frame_only_body\.html/)
+
+  await page.evaluate(() => window.scrollTo(0, 500))
+  expect((await scrollPosition(page)).y).toEqual(500)
+
+  await clickWithoutScrolling(page, "#full-visit")
+  await nextEventNamed(page, "turbo:load")
+  await expect(page).toHaveURL(/scroll_restoration\.html/)
+
+  expect((await scrollPosition(page)).y).toEqual(0)
+}
+
+test('scrolls to the top on a Drive visit made after a frame navigation with data-turbo-action="advance"', async ({ page }) => {
+  await assertScrollsToTopAfterFrameNavigation(page, "advance")
+})
+
+test('scrolls to the top on a Drive visit made after a frame navigation with data-turbo-action="replace"', async ({ page }) => {
+  await assertScrollsToTopAfterFrameNavigation(page, "replace")
 })


### PR DESCRIPTION
## Summary

A `<turbo-frame>` navigation with a `data-turbo-action` (`advance` or `replace`) promotes to a page-level `Visit`. When the frame's response is a **frame-only body** (no full `<html>` document, a common server optimization for frame requests), the promoted Visit's page render is skipped: `PageRenderer#shouldRender` is `false` (the response's head has no matching `data-turbo-track="reload"` element), and `PageView#forceReloaded` is set to `true`.

`forceReloaded` is only ever **set, never reset**. `Visit#performScroll()` bails when `view.forceReloaded` is truthy, so once it is stuck **every subsequent Drive Visit silently stops resetting scroll to the top** for the lifetime of the page (until a full reload).

## Fix

Reset `forceReloaded` on every real (rendered) page render, so the flag reflects only the current render. It is read in exactly one place (`Visit#performScroll`), so clearing it after a successful render has no other effect.

## Test

Two functional tests in `scroll_restoration_tests.js`, one for `advance` and one for `replace`: navigate a frame that responds with a frame-only body, scroll down, perform a normal Drive Visit, and assert `scrollY === 0`. Passes on Chrome and Firefox; fails without the fix.

Feel free to require changes, I can also inline the test helper function, or write this as a loop for both `advance` and `replace`, wasn't sure on the preferred style. Same with the comments.

## AI Disclaimer
This PR was generated with the help of Claude Code.

---

Fixes #1344, fixes #1526.