### PR TITLE
Handle `InvalidStateError` during transitions

### DIFF
--- a/src/core/drive/view_transitioner.js
+++ b/src/core/drive/view_transitioner.js
@@ -6,7 +6,9 @@ export class ViewTransitioner {
     if (useViewTransition && this.viewTransitionsAvailable && !this.#viewTransitionStarted) {
       this.#viewTransitionStarted = true
       this.#lastOperation = this.#lastOperation.then(async () => {
-        await document.startViewTransition(render).finished
+        const transition = document.startViewTransition(render)
+        transition.ready.catch(() => {})
+        await transition.finished
       })
     } else {
       this.#lastOperation = this.#lastOperation.then(render)

--- a/src/tests/functional/drive_view_transition_tests.js
+++ b/src/tests/functional/drive_view_transition_tests.js
@@ -36,3 +36,28 @@ test("navigating does not trigger a view transition when meta tag not present", 
   const called = await page.evaluate(`window.startViewTransitionCalled`)
   expect(called).toEqual(undefined)
 })
+
+test("navigating does not leak an unhandled rejection when the view transition is skipped", async ({ page }) => {
+  await page.evaluate(`
+    window.unhandledRejections = []
+    addEventListener("unhandledrejection", (event) => {
+      window.unhandledRejections.push(String(event.reason))
+    })
+
+    document.startViewTransition = (callback) => {
+      window.startViewTransitionCalled = true
+      const updateCallbackDone = Promise.resolve(callback())
+      return {
+        ready: Promise.reject(new DOMException("Transition was aborted because of invalid state", "InvalidStateError")),
+        finished: updateCallbackDone,
+        updateCallbackDone
+      }
+    }
+  `)
+
+  await page.locator("#go-right").click()
+  await nextBody(page)
+
+  expect(await page.evaluate(`window.startViewTransitionCalled`)).toEqual(true)
+  expect(await page.evaluate(`window.unhandledRejections`)).toEqual([])
+})


### PR DESCRIPTION
## Context

During turbo stream refreshes the `ViewTransition.ready` promise is never handled. Turbo only care about the page itself finishing, hence the `.finished` call that happens. I imagine this can happen with anything that calls transitions though.

In these cases a user can start the transition via refresh, click on another tab, and the transition won't happen as the `ready` promise fails. The page _does_ render correctly though as we call `.finished`. 

However when this occurs, the promise _should_ be handled some way otherwise an error is thrown (`InvalidStateError`). As a result of the unhandled promise, this error gets sent to `console` as one can imagine that users switch tabs.

## Similar issue
React had a similar issue here: https://github.com/react/react/issues/34098 and their fix was to match on the error message here: https://github.com/react/react/pull/34450.

Note: I used a blunt hammer and did a catch-all but open to trying something else too as I'm new to this codebase.