### PR TITLE
Fix back-button stale frame on advance navigation

### DIFF
--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -378,7 +378,7 @@ export class FrameController {
       frame.delegate.fetchResponseLoaded = async (fetchResponse) => {
         if (frame.src) {
           const { statusCode, redirected } = fetchResponse
-          const responseHTML = await fetchResponse.responseHTML
+          const responseHTML = frame.ownerDocument.documentElement.outerHTML
           const response = { statusCode, redirected, responseHTML }
           const options = {
             response,

--- a/src/tests/fixtures/frame_navigation.html
+++ b/src/tests/fixtures/frame_navigation.html
@@ -28,6 +28,7 @@
         <p>The following link has a <code>data-turbo-action="advance"</code> attribute and exists within a Turbo Frame. Tapping
           it should replace the frame's contents, keeping the Index heading.</p>
         <a id="link-to-frame-with-empty-head" href="/src/tests/fixtures/frames/empty_head.html" data-turbo-action="advance">About (a link with data-turbo-action="advance")</a>
+        <a id="link-to-frame-fragment" href="/__turbo/frame-navigation/empty-head-fragment" data-turbo-action="advance">About (frame fragment response)</a>
       </turbo-frame>
 
       <div style="height: calc(100vh*2);"></div>

--- a/src/tests/functional/frame_navigation_tests.js
+++ b/src/tests/functional/frame_navigation_tests.js
@@ -43,6 +43,53 @@ test("frame navigation with data-turbo-action", async ({ page }) => {
   await expect(titleText).toHaveText("Frame navigation tests")
 })
 
+test("navigating back after promoting frame navigation with mismatched head restores previous frame contents", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
+  await page.click("#link-to-frame-with-empty-head")
+  await nextEventOnTarget(page, "empty-head", "turbo:frame-load")
+  await nextEventNamed(page, "turbo:load")
+
+  await expect(page.locator("#empty-head h2")).toHaveText("Frame updated")
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/frames/empty_head.html"))
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/frame_navigation.html"))
+  await expect(page.locator("#empty-head h2")).not.toBeVisible()
+  await expect(page.locator("#empty-head #link-to-frame-with-empty-head")).toBeVisible()
+})
+
+test("navigating back after promoting frame navigation with frame-fragment response restores previous frame contents", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_navigation.html")
+  await page.click("#link-to-frame-fragment")
+  await nextEventOnTarget(page, "empty-head", "turbo:frame-load")
+  await nextEventNamed(page, "turbo:load")
+
+  await expect(page.locator("#empty-head h2")).toHaveText("Frame updated")
+  await expect(page).toHaveURL(withPathname("/__turbo/frame-navigation/empty-head-fragment"))
+
+  // Navigate to an intermediate page so the snapshot cache for the advanced URL
+  // is exercised on the way back through history. Without the fix, the cache key
+  // for lastRenderedLocation stays at the *source* URL (frame_navigation.html)
+  // instead of the *advanced* URL, which overwrites the source's snapshot with
+  // the new frame content. The second back navigation then renders stale content.
+  await page.evaluate(() => window.Turbo.visit("/src/tests/fixtures/one.html"))
+  await nextEventNamed(page, "turbo:load")
+
+  // First back — returns to the advanced URL
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  // Second back — returns to frame_navigation.html
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  await expect(page).toHaveURL(withPathname("/src/tests/fixtures/frame_navigation.html"))
+  await expect(page.locator("#empty-head h2")).not.toBeVisible()
+  await expect(page.locator("#empty-head #link-to-frame-fragment")).toBeVisible()
+})
+
 test("frame navigation emits fetch-request-error event when offline", async ({ page }) => {
   await page.goto("/src/tests/fixtures/tabs.html")
   await page.context().setOffline(true)

--- a/src/tests/server.mjs
+++ b/src/tests/server.mjs
@@ -175,6 +175,10 @@ router.get("/messages", (request, response) => {
   streamResponses.add(response)
 })
 
+router.get("/frame-navigation/empty-head-fragment", (request, response) => {
+  response.type("html").status(200).send('<turbo-frame id="empty-head"><h2>Frame updated</h2></turbo-frame>')
+})
+
 router.get("/file.unknown_svg", (request, response) => {
   response.set({
     "Content-Type": "image/svg+xml"


### PR DESCRIPTION
Fixes #1300.

## Problem

A `<turbo-frame data-turbo-action="advance">` correctly advances the URL on frame navigation, but pressing the browser back button restores the URL while leaving the frame's **previously-rendered (new) content** in place instead of the original content.

The bug manifests when the promoted frame response cannot be rendered as a page snapshot because its head does not contain the same tracked elements as the current page. Turbo Rails frame requests use a minimal `turbo_rails/frame` layout; when that layout has an empty or otherwise mismatched head, the simulated page visit sees the same tracked-head mismatch. Bare `<turbo-frame>...</turbo-frame>` fragment responses hit the same path.

### Root cause

`proposeVisitIfNavigatedWithAction` sets up a `fetchResponseLoaded` callback that fires a *simulated* full-page visit to manage history and snapshot caching. That visit used `fetchResponse.responseHTML` as its page content.

For a frame response with no matching tracked head elements, `PageRenderer.shouldRender` is `false` and `viewRenderedSnapshot` is never called. Consequently `lastRenderedLocation` stays at the **source URL** instead of the **advanced URL**.

When the user then navigates to a third page, the pre-navigation `cacheSnapshot` call uses `lastRenderedLocation` as its key and writes the current page (with the *new* frame content) into the **source URL's cache slot**, overwriting the pre-navigation snapshot. Navigating back through the advanced URL triggers a full page reload (nothing cached there), and the second back step renders stale frame content.

## Fix

Use `frame.ownerDocument.documentElement.outerHTML` instead of `await fetchResponse.responseHTML` in the `fetchResponseLoaded` callback.

This gives the simulated visit the live full-page HTML after the frame render, including the current page head, so `shouldRender` is `true`, `viewRenderedSnapshot` fires, and `lastRenderedLocation` is correctly set to the advanced URL. The source URL's snapshot is preserved untouched through subsequent navigations.

## Tests

- Added a server endpoint (`/__turbo/frame-navigation/empty-head-fragment`) that returns a bare `<turbo-frame>` fragment, covering fragment-only responses in addition to the existing empty-head full-page fixture.
- Added two regression tests in `frame_navigation_tests.js`:
  - Single back navigation with a mismatched-head full-page response.
  - Multi-step back navigation with a fragment response (the case that was failing).
- Verified with `yarn lint` and the focused frame navigation browser tests.

## Prior art

OpenProject ships a monkeypatch for this bug: [`frontend/src/turbo/turbo-navigation-patch.ts`](https://github.com/opf/openproject/commit/38f7443bec9655359dbcb3f42dac33295876c521). This PR applies the same fix upstream so downstream consumers can drop their workarounds.
