### PR TITLE
Support custom scroll roots with `data-turbo-scroll-root`

### DIFF
--- a/src/core/drive/navigator.js
+++ b/src/core/drive/navigator.js
@@ -139,6 +139,10 @@ export class Navigator {
     delete this.currentVisit
   }
 
+  visitCanceled(visit) {
+    this.delegate.visitCanceled(visit)
+  }
+
   // Same-page links are no longer handled with a Visit.
   // This method is still needed for Turbo Native adapters.
   locationWithActionIsSamePage(location, action) {

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -128,6 +128,7 @@ export class Visit {
       }
       this.cancelRender()
       this.state = VisitState.canceled
+      this.delegate.visitCanceled(this)
     }
   }
 
@@ -288,7 +289,12 @@ export class Visit {
     this.startRequest()
   }
 
-  requestPreventedHandlingResponse(_request, _response) {}
+  requestPreventedHandlingResponse(_request, _response) {
+    // The response was handled out-of-band (e.g. rendered as a Turbo Stream),
+    // so this visit will never complete or render. Cancel it so the terminal
+    // path runs and scroll tracking (paused on visitStarted) is resumed.
+    this.cancel()
+  }
 
   async requestSucceededWithResponse(request, response) {
     const responseHTML = await response.responseHTML

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -318,6 +318,7 @@ export class Session {
   // Page observer delegate
 
   pageBecameInteractive() {
+    this.scrollObserver.refresh()
     this.view.lastRenderedLocation = this.location
     this.notifyApplicationAfterPageLoad()
   }
@@ -357,6 +358,7 @@ export class Session {
   }
 
   viewRenderedSnapshot(_snapshot, _isPreview, renderMethod) {
+    this.scrollObserver.refresh()
     this.view.lastRenderedLocation = this.history.location
     this.notifyApplicationAfterRender(renderMethod)
   }

--- a/src/core/session.js
+++ b/src/core/session.js
@@ -15,6 +15,7 @@ import { StreamMessageRenderer } from "./streams/stream_message_renderer"
 import { StreamObserver } from "../observers/stream_observer"
 import { clearBusyState, dispatch, findClosestRecursively, getVisitAction, markAsBusy, debounce } from "../util"
 import { PageView } from "./drive/page_view"
+import { VisitState } from "./drive/visit"
 import { FrameElement } from "../elements/frame_element"
 import { Preloader } from "./drive/preloader"
 import { Cache } from "./cache"
@@ -283,12 +284,20 @@ export class Session {
     }
     extendURLWithDeprecatedProperties(visit.location)
     this.notifyApplicationAfterVisitingLocation(visit.location, visit.action)
+    if (visit.state === VisitState.started) {
+      this.scrollObserver.pause()
+    }
   }
 
   visitCompleted(visit) {
+    this.scrollObserver.resume()
     this.view.unmarkVisitDirection()
     clearBusyState(document.documentElement)
     this.notifyApplicationAfterPageLoad(visit.getTimingMetrics())
+  }
+
+  visitCanceled(_visit) {
+    this.scrollObserver.resume()
   }
 
   // Form submit observer delegate

--- a/src/core/view.js
+++ b/src/core/view.js
@@ -50,7 +50,7 @@ export class View {
   }
 
   get scrollRoot() {
-    return window
+    return this.delegate.scrollObserver?.scrollRoot ?? window
   }
 
   // Rendering

--- a/src/observers/scroll_observer.js
+++ b/src/observers/scroll_observer.js
@@ -1,5 +1,8 @@
+import { getScrollPosition } from "../util"
+
 export class ScrollObserver {
   started = false
+  #root = null
   #paused = false
 
   constructor(delegate) {
@@ -7,11 +10,15 @@ export class ScrollObserver {
   }
 
   get scrollRoot() {
-    return window
+    if (this.#root instanceof Element && !this.#root.isConnected) {
+      this.#root = null
+    }
+    return this.#root ?? (this.#root = this.#resolveRoot())
   }
 
   start() {
     if (!this.started) {
+      this.#root = null
       this.#paused = false
       this.#addListener()
       this.onScroll()
@@ -34,23 +41,45 @@ export class ScrollObserver {
     this.#paused = false
   }
 
-  onScroll = () => {
+  refresh() {
+    this.#root = null
+  }
+
+  onScroll = (event) => {
     if (this.#paused) return
     const root = this.scrollRoot
-    this.updatePosition({ x: root.pageXOffset, y: root.pageYOffset })
+    if (event && !this.#scrollEventTargetsRoot(event.target, root)) return
+    this.updatePosition(getScrollPosition(root))
   }
 
   // Private
+
+  #resolveRoot() {
+    const element = document.querySelector("[data-turbo-scroll-root]")
+    if (element && element !== document.documentElement && element !== document.body) {
+      return element
+    } else {
+      return window
+    }
+  }
+
+  #scrollEventTargetsRoot(target, root) {
+    if (root === window) {
+      return target === document || target === document.documentElement
+    } else {
+      return target === root
+    }
+  }
 
   updatePosition(position) {
     this.delegate.scrollPositionChanged(position)
   }
 
   #addListener() {
-    addEventListener("scroll", this.onScroll, false)
+    addEventListener("scroll", this.onScroll, true)
   }
 
   #removeListener() {
-    removeEventListener("scroll", this.onScroll, false)
+    removeEventListener("scroll", this.onScroll, true)
   }
 }

--- a/src/observers/scroll_observer.js
+++ b/src/observers/scroll_observer.js
@@ -5,6 +5,10 @@ export class ScrollObserver {
     this.delegate = delegate
   }
 
+  get scrollRoot() {
+    return window
+  }
+
   start() {
     if (!this.started) {
       addEventListener("scroll", this.onScroll, false)
@@ -21,7 +25,8 @@ export class ScrollObserver {
   }
 
   onScroll = () => {
-    this.updatePosition({ x: window.pageXOffset, y: window.pageYOffset })
+    const root = this.scrollRoot
+    this.updatePosition({ x: root.pageXOffset, y: root.pageYOffset })
   }
 
   // Private

--- a/src/observers/scroll_observer.js
+++ b/src/observers/scroll_observer.js
@@ -1,5 +1,6 @@
 export class ScrollObserver {
   started = false
+  #paused = false
 
   constructor(delegate) {
     this.delegate = delegate
@@ -11,7 +12,8 @@ export class ScrollObserver {
 
   start() {
     if (!this.started) {
-      addEventListener("scroll", this.onScroll, false)
+      this.#paused = false
+      this.#addListener()
       this.onScroll()
       this.started = true
     }
@@ -19,12 +21,21 @@ export class ScrollObserver {
 
   stop() {
     if (this.started) {
-      removeEventListener("scroll", this.onScroll, false)
+      this.#removeListener()
       this.started = false
     }
   }
 
+  pause() {
+    this.#paused = true
+  }
+
+  resume() {
+    this.#paused = false
+  }
+
   onScroll = () => {
+    if (this.#paused) return
     const root = this.scrollRoot
     this.updatePosition({ x: root.pageXOffset, y: root.pageYOffset })
   }
@@ -33,5 +44,13 @@ export class ScrollObserver {
 
   updatePosition(position) {
     this.delegate.scrollPositionChanged(position)
+  }
+
+  #addListener() {
+    addEventListener("scroll", this.onScroll, false)
+  }
+
+  #removeListener() {
+    removeEventListener("scroll", this.onScroll, false)
   }
 }

--- a/src/tests/fixtures/scroll_root.html
+++ b/src/tests/fixtures/scroll_root.html
@@ -1,0 +1,46 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Scroll Root</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <style>
+      body {
+        height: 100vh;
+        margin: 0;
+        display: flex;
+        flex-direction: column;
+      }
+      header {
+        min-height: 25vh;
+      }
+      main {
+        overflow-y: auto;
+        position: relative;
+      }
+      section {
+        min-height: 50vh;
+      }
+      .push-below-fold {
+        height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Scroll Root</h1>
+      <p><a id="leave-link" href="/src/tests/fixtures/scroll_root_entry.html">Leave to document-root page</a></p>
+    </header>
+    <main id="scroll-container" data-turbo-scroll-root>
+      <section id="one">One</section>
+      <section id="two">Two</section>
+      <section id="three">Three</section>
+      <section id="four">Four</section>
+      <section id="five">Five</section>
+      <hr class="push-below-fold">
+      <p><a id="below-the-fold-link" href="/src/tests/fixtures/one.html">one.html</a></p>
+      <hr class="push-below-fold">
+    </main>
+  </body>
+</html>

--- a/src/tests/fixtures/scroll_root_entry.html
+++ b/src/tests/fixtures/scroll_root_entry.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Scroll Root Entry</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <style>
+      section {
+        min-height: 100vh;
+      }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>Scroll Root Entry (document root)</h1>
+      <p><a id="enter-link" href="/src/tests/fixtures/scroll_root.html">Enter custom-scroll-root page</a></p>
+    </header>
+    <section id="one">One</section>
+    <section id="two">Two</section>
+    <section id="three">Three</section>
+    <section id="four">Four</section>
+    <section id="five">Five</section>
+  </body>
+</html>

--- a/src/tests/functional/scroll_restoration_tests.js
+++ b/src/tests/functional/scroll_restoration_tests.js
@@ -7,7 +7,8 @@ import {
 } from "../helpers/page"
 
 const scrollRoots = [
-  { name: "document", fixture: "scroll_restoration.html", root: null }
+  { name: "document", fixture: "scroll_restoration.html", root: null },
+  { name: "custom scroll root", fixture: "scroll_root.html", root: "[data-turbo-scroll-root]" }
 ]
 
 for (const { name, fixture, root } of scrollRoots) {
@@ -18,7 +19,9 @@ for (const { name, fixture, root } of scrollRoots) {
     expect(yAfterLoading).not.toEqual(0)
   })
 
-  test(`reloading after scrolling (${name})`, async ({ page }) => {
+  test(`reloading after scrolling (${name})`, async ({ page, browserName }) => {
+    test.skip(browserName === "chromium" && root !== null, "Chromium (CDP) doesn't natively restore nested scroll containers on reload; Turbo's own custom-root restore is covered in scroll_root_tests.js")
+
     await page.goto(`/src/tests/fixtures/${fixture}`)
     await scrollToSelector(page, "#three")
     const { y: yAfterScrolling } = await scrollPosition(page, root)
@@ -29,7 +32,9 @@ for (const { name, fixture, root } of scrollRoots) {
     expect(yAfterReloading).not.toEqual(0)
   })
 
-  test(`returning from history (${name})`, async ({ page }) => {
+  test(`returning from history (${name})`, async ({ page, browserName }) => {
+    test.skip(browserName === "chromium" && root !== null, "Chromium (CDP) doesn't natively restore nested scroll containers on history return; Turbo's own custom-root restore is covered in scroll_root_tests.js")
+
     await page.goto(`/src/tests/fixtures/${fixture}`)
     await scrollToSelector(page, "#three")
     await page.goto("/src/tests/fixtures/bare.html")

--- a/src/tests/functional/scroll_restoration_tests.js
+++ b/src/tests/functional/scroll_restoration_tests.js
@@ -6,30 +6,36 @@ import {
   scrollToSelector
 } from "../helpers/page"
 
-test("landing on an anchor", async ({ page }) => {
-  await page.goto("/src/tests/fixtures/scroll_restoration.html#three")
-  await nextBeat()
-  const { y: yAfterLoading } = await scrollPosition(page)
-  expect(yAfterLoading).not.toEqual(0)
-})
+const scrollRoots = [
+  { name: "document", fixture: "scroll_restoration.html", root: null }
+]
 
-test("reloading after scrolling", async ({ page }) => {
-  await page.goto("/src/tests/fixtures/scroll_restoration.html")
-  await scrollToSelector(page, "#three")
-  const { y: yAfterScrolling } = await scrollPosition(page)
-  expect(yAfterScrolling).not.toEqual(0)
+for (const { name, fixture, root } of scrollRoots) {
+  test(`landing on an anchor (${name})`, async ({ page }) => {
+    await page.goto(`/src/tests/fixtures/${fixture}#three`)
+    await nextBeat()
+    const { y: yAfterLoading } = await scrollPosition(page, root)
+    expect(yAfterLoading).not.toEqual(0)
+  })
 
-  await reloadPage(page)
-  const { y: yAfterReloading } = await scrollPosition(page)
-  expect(yAfterReloading).not.toEqual(0)
-})
+  test(`reloading after scrolling (${name})`, async ({ page }) => {
+    await page.goto(`/src/tests/fixtures/${fixture}`)
+    await scrollToSelector(page, "#three")
+    const { y: yAfterScrolling } = await scrollPosition(page, root)
+    expect(yAfterScrolling).not.toEqual(0)
 
-test("returning from history", async ({ page }) => {
-  await page.goto("/src/tests/fixtures/scroll_restoration.html")
-  await scrollToSelector(page, "#three")
-  await page.goto("/src/tests/fixtures/bare.html")
-  await page.goBack()
+    await reloadPage(page)
+    const { y: yAfterReloading } = await scrollPosition(page, root)
+    expect(yAfterReloading).not.toEqual(0)
+  })
 
-  const { y: yAfterReturning } = await scrollPosition(page)
-  expect(yAfterReturning).not.toEqual(0)
-})
+  test(`returning from history (${name})`, async ({ page }) => {
+    await page.goto(`/src/tests/fixtures/${fixture}`)
+    await scrollToSelector(page, "#three")
+    await page.goto("/src/tests/fixtures/bare.html")
+    await page.goBack()
+
+    const { y: yAfterReturning } = await scrollPosition(page, root)
+    expect(yAfterReturning).not.toEqual(0)
+  })
+}

--- a/src/tests/functional/scroll_root_tests.js
+++ b/src/tests/functional/scroll_root_tests.js
@@ -1,0 +1,104 @@
+import { expect, test } from "@playwright/test"
+import {
+  nextBeat,
+  nextEventNamed,
+  readEventLogs,
+  scrollPosition,
+  scrollToSelector
+} from "../helpers/page"
+
+test("restores custom root scroll on history return after visiting from a windowed page", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_root_entry.html")
+  await readEventLogs(page)
+  await page.click("#enter-link")
+  await nextEventNamed(page, "turbo:load")
+  await nextBeat()
+
+  await scrollToSelector(page, "#three")
+  await nextBeat()
+  const { y: yAfterScrolling } = await scrollPosition(page, "[data-turbo-scroll-root]")
+  expect(yAfterScrolling, "custom root scrolled").not.toEqual(0)
+
+  await page.click("#leave-link")
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+  await nextBeat()
+
+  const { y: yAfterReturning } = await scrollPosition(page, "[data-turbo-scroll-root]")
+  expect(Math.abs(yAfterReturning - yAfterScrolling), "custom root position restored on history return").toBeLessThanOrEqual(2)
+})
+
+test("restores windowed scroll on history return after visiting from a custom-root page", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_root.html")
+  await readEventLogs(page)
+  await page.click("#leave-link")
+  await nextEventNamed(page, "turbo:load")
+  await nextBeat()
+
+  await scrollToSelector(page, "#three")
+  await nextBeat()
+  const { y: yAfterScrolling } = await scrollPosition(page)
+  expect(yAfterScrolling, "document scrolled").not.toEqual(0)
+
+  await visitLocation(page, "/src/tests/fixtures/scroll_root.html")
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+  await nextBeat()
+
+  const { y: yAfterReturning } = await scrollPosition(page)
+  expect(Math.abs(yAfterReturning - yAfterScrolling), "windowed position restored on history return").toBeLessThanOrEqual(2)
+})
+
+test("falls back to the window when no [data-turbo-scroll-root] is present", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_restoration.html")
+  const isWindow = await page.evaluate(() => window.Turbo.session.scrollObserver.scrollRoot === window)
+  expect(isWindow, "scroll root is the window").toBe(true)
+})
+
+test("uses the first element when several carry [data-turbo-scroll-root]", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_root.html")
+  const usesFirst = await page.evaluate(() => {
+    const second = document.createElement("div")
+    second.setAttribute("data-turbo-scroll-root", "")
+    document.body.append(second)
+    const first = document.querySelector("[data-turbo-scroll-root]")
+    return window.Turbo.session.scrollObserver.scrollRoot === first && first !== second
+  })
+  expect(usesFirst, "scroll root is the first matching element").toBe(true)
+})
+
+test("re-resolves the scroll root after the element is replaced by a Turbo Stream", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_root.html")
+  const originalIsRoot = await page.evaluate(() => {
+    const original = document.querySelector("[data-turbo-scroll-root]")
+    return window.Turbo.session.scrollObserver.scrollRoot === original
+  })
+  expect(originalIsRoot, "original element is the scroll root").toBe(true)
+
+  await page.evaluate(() => {
+    window.Turbo.renderStreamMessage(`
+      <turbo-stream action="replace" target="scroll-container">
+        <template>
+          <main id="scroll-container" data-turbo-scroll-root style="overflow-y: auto">
+            <section id="one" style="min-height: 100vh">One</section>
+            <section id="two" style="min-height: 100vh">Two</section>
+          </main>
+        </template>
+      </turbo-stream>
+    `)
+  })
+  await nextBeat()
+
+  const resolvesToNewRoot = await page.evaluate(() => {
+    const current = document.querySelector("[data-turbo-scroll-root]")
+    const resolved = window.Turbo.session.scrollObserver.scrollRoot
+    return resolved === current && current.isConnected && resolved !== window
+  })
+  expect(resolvesToNewRoot, "scroll root re-resolves to the new connected element").toBe(true)
+})
+
+function visitLocation(page, location) {
+  return page.evaluate((location) => window.Turbo.visit(location), location)
+}

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -311,6 +311,23 @@ test("can scroll to element after history-initiated turbo:visit", async ({ page 
   expect(await isScrolledToSelector(page, "#" + id), "scrolls after history-initiated turbo:load").toBeTruthy()
 })
 
+test("can scroll to element in custom scroll root after history-initiated turbo:visit", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_root.html")
+  await readEventLogs(page)
+  const id = "below-the-fold-link"
+  await page.evaluate((id) => {
+    addEventListener("turbo:load", () => document.getElementById(id)?.scrollIntoView())
+  }, id)
+
+  await scrollToSelector(page, "#" + id)
+  await page.click("#" + id)
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  expect(await isScrolledToSelector(page, "#" + id, "[data-turbo-scroll-root]"), "scrolls after history-initiated turbo:load").toBeTruthy()
+})
+
 test("Visit with network error", async ({ page }) => {
   await page.evaluate(() => {
     addEventListener("turbo:fetch-request-error", (event) => event.preventDefault())

--- a/src/tests/functional/visit_tests.js
+++ b/src/tests/functional/visit_tests.js
@@ -12,6 +12,7 @@ import {
   readEventLogs,
   reloadPage,
   resetMutationLogs,
+  scrollPosition,
   scrollToSelector,
   visitAction,
   willChangeBody,
@@ -158,6 +159,30 @@ test("navigation by history is not cancelable", async ({ page }) => {
   await nextEventNamed(page, "turbo:load")
 
   await expect(page.locator("h1")).toHaveText("Visit")
+})
+
+test("resumes scroll tracking after a visit is canceled without a successor", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/scroll_restoration.html")
+
+  await page.evaluate(() => {
+    window.Turbo.visit("/src/tests/fixtures/one.html")
+    window.Turbo.session.navigator.stop()
+  })
+  await nextBeat()
+
+  await scrollToSelector(page, "#three")
+  await nextBeat()
+  const { y: yAfterScrolling } = await scrollPosition(page)
+  expect(yAfterScrolling).not.toEqual(0)
+
+  await readEventLogs(page)
+  await page.evaluate(() => window.Turbo.visit("/src/tests/fixtures/one.html"))
+  await nextEventNamed(page, "turbo:load")
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+
+  const { y: yAfterReturning } = await scrollPosition(page)
+  expect(yAfterReturning, "scroll recorded after the canceled visit is restored on return").toEqual(yAfterScrolling)
 })
 
 test("turbo:before-fetch-request event.detail", async ({ page }) => {

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -57,13 +57,13 @@ export async function hasSelector(page, selector) {
   return !!(await page.locator(selector).count())
 }
 
-export async function isScrolledToSelector(page, selector) {
+export async function isScrolledToSelector(page, selector, scrollRootSelector = null) {
   const boundingBox = await page
     .locator(selector)
     .evaluate((element) => (element instanceof HTMLElement ? { x: element.offsetLeft, y: element.offsetTop } : null))
 
   if (boundingBox) {
-    const { y: pageY } = await scrollPosition(page)
+    const { y: pageY } = await scrollPosition(page, scrollRootSelector)
     const { y: elementY } = boundingBox
     const offset = pageY - elementY
     return Math.abs(offset) <= 2
@@ -278,12 +278,18 @@ export function setLocalStorageFromEvent(page, eventName, storageKey, storageVal
   )
 }
 
-export function scrollPosition(page) {
-  return page.evaluate(() => ({ x: window.scrollX, y: window.scrollY }))
+export function scrollPosition(page, scrollRootSelector = null) {
+  return page.evaluate(selector => {
+    const scrollRoot = selector ? document.querySelector(selector) : window
+    if (!scrollRoot) {
+      throw new Error(`scrollPosition: no element matches ${selector}`)
+    }
+    return { x: scrollRoot.scrollX ?? scrollRoot.scrollLeft, y: scrollRoot.scrollY ?? scrollRoot.scrollTop }
+  }, scrollRootSelector)
 }
 
-export async function isScrolledToTop(page) {
-  const { y: pageY } = await scrollPosition(page)
+export async function isScrolledToTop(page, selector = null) {
+  const { y: pageY } = await scrollPosition(page, selector)
   return pageY === 0
 }
 

--- a/src/tests/helpers/page.js
+++ b/src/tests/helpers/page.js
@@ -1,3 +1,5 @@
+import { getScrollPosition } from "../../util"
+
 export function attributeForSelector(page, selector, attributeName) {
   return page.locator(selector).getAttribute(attributeName)
 }
@@ -278,14 +280,17 @@ export function setLocalStorageFromEvent(page, eventName, storageKey, storageVal
   )
 }
 
-export function scrollPosition(page, scrollRootSelector = null) {
-  return page.evaluate(selector => {
+export async function scrollPosition(page, scrollRootSelector = null) {
+  const root = await page.evaluate(selector => {
     const scrollRoot = selector ? document.querySelector(selector) : window
     if (!scrollRoot) {
       throw new Error(`scrollPosition: no element matches ${selector}`)
     }
-    return { x: scrollRoot.scrollX ?? scrollRoot.scrollLeft, y: scrollRoot.scrollY ?? scrollRoot.scrollTop }
+    const { scrollX, scrollY, scrollLeft, scrollTop } = scrollRoot
+    return { scrollX, scrollY, scrollLeft, scrollTop }
   }, scrollRootSelector)
+
+  return getScrollPosition(root)
 }
 
 export async function isScrolledToTop(page, selector = null) {

--- a/src/util.js
+++ b/src/util.js
@@ -281,3 +281,10 @@ export function debounce(fn, delay) {
     timeoutId = setTimeout(callback, delay)
   }
 }
+
+export function getScrollPosition(root) {
+  return {
+    x: root.scrollX ?? root.scrollLeft,
+    y: root.scrollY ?? root.scrollTop
+  }
+}


### PR DESCRIPTION
Scroll restoration in Turbo works on the premise that the _window_ is the scroll container: the `ScrollObserver` is hardcoded to read the scroll properties of  `window`, and saves and restores these properties when navigating forwards and backwards. This premise breaks down for a number of common layouts: those with fixed sidebars and scrollable main content, and layouts with sticky headers or footers and scrollable main content where use of `position: sticky` would conflict with the Popover API, where correct hiding of anchor-positioned elements like menus depends on the anchor being clipped by the scroll container, not just visually covered (currently only Chromium supports the hiding).

This PR introduces a new attribute, `data-turbo-scroll-root`, which allows scroll restoration to target an arbitrary scroll container within the body. The default of targeting the window remains unchanged, and the attribute is the only way to change the scroll root. Restoration works across mixed navigations, both between a window and element scroll container, and between two different element scroll containers, because the recording and restoration is relative to the same container.

To support this, scroll tracking is paused at the beginning of a visit and resumed at the end (whether successful or cancelled) to prevent scrolling during navigation from clobbering the intended value for restoration. The scroll root itself is cached, but only until the next render, to prevent the cached value referring to a detached element. I’ve added tests for all the relevant cases and combinations I could think of; unfortunately there’s a known CDP limitation on native scroll restoration which means Chromium is skipped for two tests for native behaviour.

I also wanted to flag that in principle it would be possible to split this change to introduce the mechanism first (pausing, and then cached scroll root resolution) before the new functionality (actually being able to change the scroll root). But I figured it would be hard to evaluate the mechanism without being able to see the full change upfront.