### PR TITLE
Skip cache notifications for promoted frame visits

### DIFF
--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -40,9 +40,9 @@ export class PageView extends View {
     this.snapshotCache.clear()
   }
 
-  async cacheSnapshot(snapshot = this.snapshot) {
+  async cacheSnapshot(snapshot = this.snapshot, shouldNotifyApplication = true) {
     if (snapshot.isCacheable) {
-      this.delegate.viewWillCacheSnapshot()
+      if (shouldNotifyApplication) this.delegate.viewWillCacheSnapshot()
       const { lastRenderedLocation: location } = this
       await nextEventLoopTick()
       const cachedSnapshot = snapshot.clone()

--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -1,7 +1,7 @@
 import { FetchMethod, FetchRequest } from "../../http/fetch_request"
 import { getAnchor } from "../url"
 import { PageSnapshot } from "./page_snapshot"
-import { getHistoryMethodForAction, uuid } from "../../util"
+import { getHistoryMethodForAction, removeTemporaryElementsFrom, uuid } from "../../util"
 import { StreamMessage } from "../streams/stream_message"
 import { ViewTransitioner } from "./view_transitioner"
 
@@ -384,7 +384,18 @@ export class Visit {
 
   cacheSnapshot() {
     if (!this.snapshotCached) {
-      this.view.cacheSnapshot(this.snapshot).then((snapshot) => snapshot && this.visitCachedSnapshot(snapshot))
+      // Cache notifications prepare the live document. They cannot affect a supplied
+      // snapshot and would instead mutate the page that remains visible.
+      const shouldNotifyApplication = !this.snapshot
+      this.view.cacheSnapshot(this.snapshot, shouldNotifyApplication).then((snapshot) => {
+        if (snapshot) {
+          this.visitCachedSnapshot(snapshot)
+
+          // The callback can restore temporary elements with the previous frame contents,
+          // so remove them only after the cached snapshot has been prepared.
+          removeTemporaryElementsFrom(snapshot.element)
+        }
+      })
       this.snapshotCached = true
     }
   }

--- a/src/observers/cache_observer.js
+++ b/src/observers/cache_observer.js
@@ -1,6 +1,6 @@
-export class CacheObserver {
-  selector = "[data-turbo-temporary]"
+import { removeTemporaryElementsFrom } from "../util"
 
+export class CacheObserver {
   started = false
 
   start() {
@@ -18,12 +18,6 @@ export class CacheObserver {
   }
 
   removeTemporaryElements = (_event) => {
-    for (const element of this.temporaryElements) {
-      element.remove()
-    }
-  }
-
-  get temporaryElements() {
-    return [...document.querySelectorAll(this.selector)]
+    removeTemporaryElementsFrom(document)
   }
 }

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -14,6 +14,7 @@ import {
   readEventLogs,
   scrollPosition,
   scrollToSelector,
+  visitAction,
   withPathname,
   withSearchParam
 } from "../helpers/page"
@@ -724,11 +725,72 @@ test("navigating pushing URL state from a frame navigation fires events", async 
   expect(await nextAttributeMutationNamed(page, "html", "aria-busy"), "sets aria-busy on the <html>").toEqual("true")
   await nextEventOnTarget(page, "html", "turbo:before-visit")
   await nextEventOnTarget(page, "html", "turbo:visit")
-  await nextEventOnTarget(page, "html", "turbo:before-cache")
   await nextEventOnTarget(page, "html", "turbo:before-render")
   await nextEventOnTarget(page, "html", "turbo:render")
   await nextEventOnTarget(page, "html", "turbo:load")
   expect(await nextAttributeMutationNamed(page, "html", "aria-busy"), "removes aria-busy from the <html>").not.toBeTruthy()
+})
+
+test("navigating a frame with an action does not fire turbo:before-cache", async ({ page }) => {
+  await page.evaluate(() => {
+    window.beforeCacheCount = 0
+    addEventListener("turbo:before-cache", () => window.beforeCacheCount++)
+  })
+  await page.click("#link-outside-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+
+  expect(await page.evaluate(() => window.beforeCacheCount), "does not fire turbo:before-cache").toEqual(0)
+})
+
+test("navigating a frame with an action preserves unrelated temporary elements", async ({ page }) => {
+  await page.locator("body").evaluate((body) => {
+    body.insertAdjacentHTML("beforeend", '<div id="temporary" data-turbo-temporary>Temporary element</div>')
+  })
+  await page.click("#link-outside-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+
+  expect(await visitAction(page)).toEqual("advance")
+  await expect(page.locator("#temporary")).toHaveText("Temporary element")
+})
+
+test("restoring history after a promoted frame navigation does not restore temporary elements", async ({ page }) => {
+  await page.locator("body").evaluate((body) => {
+    body.insertAdjacentHTML("beforeend", '<div id="marker">Client-only marker</div>')
+    body.insertAdjacentHTML("beforeend", '<div id="temporary" data-turbo-temporary>Temporary element</div>')
+  })
+  await page.locator("#frame").evaluate((frame) => {
+    frame.insertAdjacentHTML("beforeend", '<div id="frame-temporary" data-turbo-temporary>Temporary frame element</div>')
+  })
+  await page.click("#link-outside-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+  await nextBeat()
+  await nextBeat()
+
+  await page.goBack()
+  await nextEventNamed(page, "turbo:load")
+  await expect(page.locator("#marker"), "restores Back from the snapshot cache").toHaveCount(1)
+  await expect(page.locator("#temporary")).toHaveCount(0)
+  await expect(page.locator("#frame-temporary")).toHaveCount(0)
+
+  await page.goForward()
+  await nextEventNamed(page, "turbo:load")
+  await expect(page.locator("#marker"), "restores Forward from the snapshot cache").toHaveCount(1)
+  await expect(page.locator("#temporary")).toHaveCount(0)
+  await expect(page.locator("#frame-temporary")).toHaveCount(0)
+})
+
+test("replacing URL state from a frame navigation preserves unrelated temporary elements", async ({ page }) => {
+  await page.locator("body").evaluate((body) => {
+    body.insertAdjacentHTML("beforeend", '<div id="temporary" data-turbo-temporary>Temporary element</div>')
+  })
+  await page.locator("#link-outside-frame-action-advance").evaluate((link) => {
+    link.setAttribute("data-turbo-action", "replace")
+  })
+  await page.click("#link-outside-frame-action-advance")
+  await nextEventNamed(page, "turbo:load")
+
+  expect(await visitAction(page)).toEqual("replace")
+  await expect(page.locator("#temporary")).toHaveText("Temporary element")
 })
 
 test("navigating a frame with a form[method=get] that does not redirect still updates the [src]", async ({

--- a/src/util.js
+++ b/src/util.js
@@ -68,6 +68,12 @@ export function nextMicrotask() {
   return Promise.resolve()
 }
 
+export function removeTemporaryElementsFrom(root) {
+  for (const element of root.querySelectorAll("[data-turbo-temporary]")) {
+    element.remove()
+  }
+}
+
 export function parseHTMLDocument(html = "") {
   return new DOMParser().parseFromString(html, "text/html")
 }


### PR DESCRIPTION
## Summary

- Skip application cache notifications when a Visit caches a supplied, detached snapshot
- Preserve unrelated temporary elements in the live page during promoted frame navigation
- Remove temporary elements from the cached snapshot after its frame contents are prepared
- Keep normal Drive cache preparation unchanged

Fixes #919
Fixes #1075
Fixes #1259
Fixes #1387
Fixes #1553

## Problem

A frame navigation with `data-turbo-action="advance"` or `replace` renders the target frame and then starts a synthetic page Visit with `willRender: false`.

The Visit caches a detached snapshot captured before the frame navigation, but it also dispatches `turbo:before-cache` against the current document after the frame has rendered.

Application cache handlers cannot affect the detached snapshot being cached. They instead mutate the live page that the synthetic Visit will not replace. Turbo's `CacheObserver` therefore removes unrelated `[data-turbo-temporary]` elements permanently from the current page.

Simply skipping the event leaves the detached snapshot unchanged. Temporary elements then remain in that cached snapshot and can reappear when the user navigates Back.

## Change

When a Visit caches a supplied snapshot, `Visit#cacheSnapshot` tells `PageView#cacheSnapshot` not to notify the application.

The decision is derived from the existing internal `snapshot` value, so this does not add a new Visit option or expand the public `Turbo.visit` API.

Snapshot cloning and `visitCachedSnapshot` remain active. After `visitCachedSnapshot` restores the promoted frame's previous contents, the Visit removes `[data-turbo-temporary]` elements from the cached snapshot.

Performing the removal after that callback covers temporary elements both inside and outside the restored frame without touching the live document. `CacheObserver` and `Visit` use the same `removeTemporaryElementsFrom(root)` helper, keeping the definition of a temporary element in one place.

For normal Drive visits, the post-preparation cleanup is effectively a no-op. `turbo:before-cache` still runs against the live document, `CacheObserver` removes temporary elements there, and the resulting clone no longer contains them.

The observable behavior change is therefore limited to Visits that cache a supplied snapshot, including promoted frame Visits.

## Related work

#1549 addresses a separate promoted-frame problem for frame-only or mismatched-head responses by ensuring the synthetic Visit receives full-page HTML and advances `lastRenderedLocation`.

The changes are complementary: #1549 does not change cache notifications or temporary-element cleanup, and this PR does not fix head merging or frame-only cache keys.

This PR intentionally does not close #1008, #1237, #1241, #1300, or hotwired/turbo-rails#580.

## Test plan

- [x] Verify promoted frame Visits do not dispatch `turbo:before-cache`
- [x] Verify `advance` preserves unrelated `[data-turbo-temporary]` elements and uses the `advance` action
- [x] Verify `replace` preserves unrelated `[data-turbo-temporary]` elements and uses the `replace` action
- [x] Verify Back/Forward restores from the snapshot cache and does not restore temporary elements inside or outside the promoted frame
- [x] Verify normal Drive Visits still dispatch `turbo:before-cache`
- [x] Verify normal Drive caching still omits temporary elements
- [x] Run the complete frame and CacheObserver suites in Chrome and Firefox (`164/164` passing)
- [x] Run Chromium unit tests (`38/38` passing)
- [x] Run `yarn build`
- [x] Run `yarn lint`
