### PR TITLE
Don't start a view transition for a visit that won't render

### DIFF
--- a/src/core/drive/visit.js
+++ b/src/core/drive/visit.js
@@ -400,7 +400,7 @@ export class Visit {
   }
 
   async renderPageSnapshot(snapshot, isPreview) {
-    await this.viewTransitioner.renderChange(this.view.shouldTransitionTo(snapshot), async () => {
+    await this.viewTransitioner.renderChange(this.willRender && this.view.shouldTransitionTo(snapshot), async () => {
       await this.view.renderPage(snapshot, isPreview, this.willRender, this)
       this.performScroll()
     })

--- a/src/tests/fixtures/transitions/frame.html
+++ b/src/tests/fixtures/transitions/frame.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8" />
+    <title>Frame</title>
+    <meta name="turbo-view-transition" content="true" />
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+  </head>
+  <body>
+    <turbo-frame id="frame">
+      <h2>Loaded</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/transitions/left.html
+++ b/src/tests/fixtures/transitions/left.html
@@ -27,5 +27,8 @@
     <p><a id="go-right" href="/src/tests/fixtures/transitions/right.html">go right</a></p>
     <div class="square"></div>
     <p><a id="go-other" href="/src/tests/fixtures/transitions/other.html">go other</a></p>
+    <turbo-frame id="frame">
+      <a id="go-frame" href="/src/tests/fixtures/transitions/frame.html" data-turbo-action="advance">go frame</a>
+    </turbo-frame>
   </body>
 </html>

--- a/src/tests/functional/drive_view_transition_tests.js
+++ b/src/tests/functional/drive_view_transition_tests.js
@@ -36,3 +36,12 @@ test("navigating does not trigger a view transition when meta tag not present", 
   const called = await page.evaluate(`window.startViewTransitionCalled`)
   expect(called).toEqual(undefined)
 })
+
+test("navigating a frame with data-turbo-action does not trigger a view transition", async ({ page }) => {
+  await page.locator("#go-frame").click()
+  await page.locator("#frame").getByText("Loaded").waitFor()
+  await nextBody(page)
+
+  const called = await page.evaluate(`window.startViewTransitionCalled`)
+  expect(called).toEqual(undefined)
+})


### PR DESCRIPTION
We noticed this in our app: we have `<meta name="view-transition" content="same-origin">` enabled sitewide, and a search results list that uses a turbo-frame with `data-turbo-action="advance"` to update the URL after the frame re-renders itself. Every time a user changed a filter or paged through results, the whole page would flash/freeze for the duration of a view transition even though nothing outside the frame actually changed.

The cause: a frame navigation with data-turbo-action proposes a follow-up visit with `willRender: false` (its only job is to advance the URL, the frame already rendered its own content). `Visit#renderPageSnapshot` started a view transition for that visit anyway, based solely on `view.shouldTransitionTo(snapshot)`, without checking whether the visit would actually render anything.

The fix guards the transition on `this.willRender` as well, so a transition only starts when a visit really renders the page.

Added a functional test (drive_view_transition_tests.js) with a frame + data-turbo-action fixture that reproduces the issue; it fails without the fix and passes with it.

Let me know if you want to take a different approach with this one.
