### PR TITLE
Preserve scroll position during frame replacement

### DIFF
--- a/src/core/frames/frame_renderer.js
+++ b/src/core/frames/frame_renderer.js
@@ -3,16 +3,7 @@ import { Renderer } from "../renderer"
 
 export class FrameRenderer extends Renderer {
   static renderElement(currentElement, newElement) {
-    const destinationRange = document.createRange()
-    destinationRange.selectNodeContents(currentElement)
-    destinationRange.deleteContents()
-
-    const frameElement = newElement
-    const sourceRange = frameElement.ownerDocument?.createRange()
-    if (sourceRange) {
-      sourceRange.selectNodeContents(frameElement)
-      currentElement.appendChild(sourceRange.extractContents())
-    }
+    currentElement.replaceChildren(...newElement.childNodes)
   }
 
   constructor(delegate, currentSnapshot, newSnapshot, renderElement, isPreview, willRender = true) {

--- a/src/tests/fixtures/frame_scroll.html
+++ b/src/tests/fixtures/frame_scroll.html
@@ -1,0 +1,53 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frame Scroll</title>
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+    <style>
+      body { margin: 0; font: 16px/1.5 system-ui, sans-serif; }
+      main { max-width: 72rem; margin: 0 auto; padding: 2rem; }
+      header { min-height: 32vh; display: grid; align-content: end; border-bottom: 1px solid #ddd; margin-bottom: 2rem; }
+      form { display: grid; grid-template-columns: minmax(16rem, 1fr) 12rem 12rem 8rem auto; gap: .75rem; padding: 1rem; border: 1px solid #ddd; border-radius: .75rem; margin-bottom: 2rem; }
+      input, select, button, a { font: inherit; }
+      input, select { min-height: 2.5rem; }
+      .grid { min-height: 16rem; display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 1rem; }
+      article { min-height: 8rem; border: 1px solid #ddd; border-radius: .75rem; padding: 1rem; }
+      nav { margin-top: 2rem; display: flex; justify-content: center; gap: .5rem; border-top: 1px solid #ddd; padding-top: 1.5rem; }
+    </style>
+  </head>
+  <body>
+    <main>
+      <header><h1>Task manager</h1></header>
+
+      <form action="/src/tests/fixtures/frame_scroll.html" method="get" data-turbo-frame="results">
+        <input name="search" placeholder="Search">
+        <select name="due"><option>Any due date</option><option>Today</option></select>
+        <select name="per_page"><option>12 / page</option><option>24 / page</option></select>
+        <button type="submit">Apply</button>
+      </form>
+
+      <turbo-frame id="results">
+        <strong id="page-marker">Page 1</strong>
+        <div class="grid">
+          <article>Task 1.1</article>
+          <article>Task 1.2</article>
+          <article>Task 1.3</article>
+          <article>Task 1.4</article>
+          <article>Task 1.5</article>
+          <article>Task 1.6</article>
+          <article>Task 1.7</article>
+          <article>Task 1.8</article>
+          <article>Task 1.9</article>
+          <article>Task 1.10</article>
+          <article>Task 1.11</article>
+          <article>Task 1.12</article>
+        </div>
+        <nav>
+          <a id="next-page" href="/src/tests/fixtures/frames/scroll.html">Next</a>
+        </nav>
+      </turbo-frame>
+    </main>
+  </body>
+</html>

--- a/src/tests/fixtures/frames/scroll.html
+++ b/src/tests/fixtures/frames/scroll.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <title>Frame Scroll: Next Page</title>
+  </head>
+  <body>
+    <turbo-frame id="results">
+      <strong id="page-marker">Page 2</strong>
+      <div class="grid">
+        <article>Task 2.1</article>
+        <article>Task 2.2</article>
+        <article>Task 2.3</article>
+        <article>Task 2.4</article>
+        <article>Task 2.5</article>
+        <article>Task 2.6</article>
+        <article>Task 2.7</article>
+        <article>Task 2.8</article>
+        <article>Task 2.9</article>
+        <article>Task 2.10</article>
+        <article>Task 2.11</article>
+        <article>Task 2.12</article>
+      </div>
+      <nav><a href="/src/tests/fixtures/frame_scroll.html">Previous</a></nav>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/functional/frame_tests.js
+++ b/src/tests/functional/frame_tests.js
@@ -550,6 +550,62 @@ test("'turbo:frame-render' is triggered after frame has finished rendering", asy
   expect(fetchResponse.response.url).toContain("/src/tests/fixtures/frames/part.html")
 })
 
+// This only fails on Chrome 149 and 151, where emptying the frame clamps the window scroll;
+// the native selects just supply the page height it needs. On the pinned CI browser it passes
+// with or without the fix; the mutation test below is the actual guard.
+test("replacing a frame below native selects preserves scroll when its focused link is removed", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_scroll.html")
+  await page.locator("#results").evaluate((frame) => {
+    frame.addEventListener(
+      "turbo:before-frame-render",
+      () => {
+        window.scrollYBeforeFrameRender = window.scrollY
+        window.activeElementBeforeFrameRender = document.activeElement?.id
+      },
+      { once: true }
+    )
+    frame.addEventListener("turbo:frame-render", () => (window.scrollYAfterFrameRender = window.scrollY), { once: true })
+  })
+  await page.locator("#next-page").scrollIntoViewIfNeeded()
+  await page.waitForFunction(() => window.scrollY > 0)
+  const frameRendered = nextEventOnTarget(page, "results", "turbo:frame-render")
+  await page.click("#next-page")
+  await frameRendered
+  await expect(page.locator("#page-marker")).toHaveText("Page 2")
+
+  const { activeElementBeforeRender, beforeRender, afterRender } = await page.evaluate(() => ({
+    activeElementBeforeRender: window.activeElementBeforeFrameRender,
+    beforeRender: window.scrollYBeforeFrameRender,
+    afterRender: window.scrollYAfterFrameRender
+  }))
+
+  expect(activeElementBeforeRender, "removes the focused link during rendering").toEqual("next-page")
+  expect(beforeRender, "starts with the frame scrolled into view").toBeGreaterThan(0)
+  expect(afterRender, "preserves Y scroll position").toEqual(beforeRender)
+})
+
+test("replacing frame contents replaces children in a single mutation", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_scroll.html")
+  await page.locator("#results").evaluate((frame) => {
+    window.frameMutations = []
+    new MutationObserver((records) => {
+      for (const { removedNodes, addedNodes } of records) {
+        window.frameMutations.push({ removed: removedNodes.length, added: addedNodes.length })
+      }
+    }).observe(frame, { childList: true })
+  })
+
+  const frameRendered = nextEventOnTarget(page, "results", "turbo:frame-render")
+  await page.click("#next-page")
+  await frameRendered
+  await page.waitForFunction(() => window.frameMutations.length > 0)
+
+  const [mutation, ...remainingMutations] = await page.evaluate(() => window.frameMutations)
+  expect(remainingMutations, "never empties the frame before inserting").toHaveLength(0)
+  expect(mutation.removed, "removes the previous children").toBeGreaterThan(0)
+  expect(mutation.added, "inserts the new children in the same mutation").toBeGreaterThan(0)
+})
+
 test("navigating a frame from an outer link with a turbo-frame child fires events", async ({ page }) => {
   await page.click("#outside-frame-link-with-frame-child")
 


### PR DESCRIPTION
## Summary

In Chrome 149 and 151, `Range.deleteContents()` can reset the document scroll position when it removes the focused link from a Turbo Frame and native `<select>` controls precede the frame.

`FrameRenderer.renderElement` currently empties the destination frame and appends the response contents as two separate operations. This change replaces the destination children in one operation:

```js
currentElement.replaceChildren(...newElement.childNodes)
```

In the reproduction, this avoids the scroll reset while preserving the parsed response nodes used by script activation and permanent-element handling.

Turbo already calls `replaceChildren` without a feature guard in `FrameController.visitCachedSnapshot`. Turbo 8 also ships untranspiled private fields and methods, which require Safari 15 or newer, while `replaceChildren` is available from Safari 14. This change therefore does not raise Turbo 8's effective browser requirements. The Safari 13 compatibility concern previously discussed in #795 and #808 no longer applies to a browser capable of parsing the Turbo 8 bundle.

## Compatibility and scope

`FrameRenderer` is exported from `src/core/index.js`, and applications can replace its render function through `turbo:before-frame-render`. This change does not alter the public `renderElement(currentElement, newElement)` signature or the event customization contract.

`MorphingFrameRenderer` defines its own `renderElement` implementation and does not call `super`, so `refresh="morph"` frame rendering is not affected.

## Reproduction

The new functional fixture contains:

- native `<select>` controls before the frame;
- enough same-height frame content to place the pagination link below the initial viewport;
- a focused pagination link that is removed during frame rendering;
- event-time assertions that compare `window.scrollY` before and after rendering.

The scroll assertion documents the browser symptom. A second, browser-independent regression test guards the replacement semantics by observing child-list mutations. With the existing renderer, Chromium 134 observes seven removals followed by one insertion:

```text
[{ removed: 1, added: 0 } × 7, { removed: 0, added: 7 }]
```

With this change it observes one replacement mutation:

```text
[{ removed: 7, added: 7 }]
```

This makes the regression test fail on the Chromium 134 version currently used by CI even though that browser does not exhibit the visible scroll jump.

With the existing renderer in Chrome 151:

```text
turbo:before-frame-render  scrollY=520
turbo:frame-render         scrollY=0
```

With this change:

```text
turbo:before-frame-render  scrollY=520
turbo:frame-render         scrollY=520
```

## Scroll symptom by browser

| Browser | Before | After |
| --- | --- | --- |
| Chromium 134 | Pass | Pass |
| Chrome for Testing 149.0.7827.55 | Fail (`520 -> 0`) | Pass |
| Chrome 151.0.7922.169 | Fail (`520 -> 0`) | Pass |
| Firefox 135 | Pass | Pass |

The repository currently pins Playwright 1.51, whose bundled Chromium 134 does not reproduce the browser regression. The same functional test was therefore also run with the Chrome channel (`channel: "chrome"`) against Chrome 151.0.7922.169 to verify that it fails before the renderer change and passes afterward.

## Tests

- `yarn build`
- `yarn lint`
- `yarn playwright test src/tests/functional/frame_tests.js --project=chrome`
- `yarn playwright test src/tests/functional/frame_tests.js --project=firefox`
- focused custom-render and permanent-element frame tests in Chromium and Firefox
- focused regression against Chrome 151
- `git diff --check`

The full frame suite passed with 78 tests per configured browser.
