### PR TITLE
Remove stale arm64 tag comment from devcontainer.json

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -9,8 +9,6 @@
     // IMPORTANT: The playwright image version must match @playwright/test version from package.json.
     // Otherwise it will not work, the test version will look for the browser versions which it won't
     // find on the image.
-    //
-    // pick '...-arm64' version if running on Apple Silicon.
     "args": {
       "PLAYWRIGHT_TAG": "v1.51.1-jammy"
     }


### PR DESCRIPTION
## The stale comment

`.devcontainer/devcontainer.json` tells Apple Silicon users to swap the tag:

> `// pick '...-arm64' version if running on Apple Silicon.`

The pinned tag is a multi-arch manifest list that already carries `linux/arm64`, so Docker selects the right image on its own and the edit is unnecessary.

## Evidence

`docker manifest inspect mcr.microsoft.com/playwright:v1.51.1-jammy` lists both `linux/amd64` and `linux/arm64`. Building the devcontainer unmodified on an M1 Mac gives a container reporting `aarch64`, with the Playwright suite running in it normally. The tags either side of the pinned one — `v1.30.0-jammy` and `v1.55.0-noble` — are multi-arch too, so this isn't specific to the version in use today, and the line can go rather than be reworded.

The `IMPORTANT` note above it is untouched: the image version does still have to match `@playwright/test`.
