### PR TITLE
Clone snapshots when reading from cache

### DIFF
--- a/src/core/drive/page_view.js
+++ b/src/core/drive/page_view.js
@@ -52,7 +52,7 @@ export class PageView extends View {
   }
 
   getCachedSnapshotForLocation(location) {
-    return this.snapshotCache.get(location)
+    return this.snapshotCache.get(location)?.clone()
   }
 
   isPageRefresh(visit) {

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -408,6 +408,28 @@ test("navigating back to anchored URL", async ({ page }) => {
   expect(await isScrolledToSelector(page, "#main"), "scrolled to #main").toEqual(true)
 })
 
+test("reusing a cached snapshot keeps document.body connected during rendering", async ({ page }) => {
+  const bodyWasDisconnected = await page.evaluate(async () => {
+    // Cached snapshots must stay detached so subsequent transitions never reuse the same body element.
+    let bodyWasDisconnected = false
+    const adoptNode = document.adoptNode
+    document.adoptNode = function (node) {
+      const adoptedNode = adoptNode.call(this, node)
+      if (!document.body) bodyWasDisconnected = true
+      return adoptedNode
+    }
+
+    const view = window.Turbo.session.view
+    await view.cacheSnapshot()
+    await view.renderPage(view.getCachedSnapshotForLocation(location))
+    await view.renderPage(view.getCachedSnapshotForLocation(location))
+
+    return bodyWasDisconnected
+  })
+
+  expect(bodyWasDisconnected, "keeps document.body connected").toEqual(false)
+})
+
 test("following a redirection", async ({ page }) => {
   await page.click("#redirection-link")
 


### PR DESCRIPTION
## Problem

Rendering the same cached snapshot more than once can temporarily remove `document.body`. Synchronous teardown callbacks can then observe or snapshot a bodyless document, surfacing errors such as `Cannot read properties of null (reading 'querySelectorAll')` or `Cannot read properties of null (reading 'cloneNode')`.

## Cause

The snapshot cache returns the stored `PageSnapshot` object directly. After its body is rendered once, that cached body becomes the live `document.body`. A later render reuses the same element and calls `document.adoptNode(this.newElement)`.

`adoptNode` changes a node's document ownership and detaches it from its current parent; it does not attach the node to the destination document. When the adopted element is already the live body, `document.body` is therefore `null` until the renderer appends it again. Detachment can synchronously invoke custom-element `disconnectedCallback` hooks, allowing reentrant rendering or snapshotting to encounter the missing body.

## Solution

Clone snapshots when reading them from the cache. The cached body remains detached, and each transition receives its own body element. The regression test renders the same cache entry twice and verifies that later transitions never reuse the cached body or disconnect `document.body`.

## Test plan

- `yarn build`
- `yarn lint`
- `yarn test:unit` — 38 tests passed in Chromium, Firefox, and WebKit
- Focused regression repeated 10 times in both Chrome and Firefox — 20 tests passed
