### PR TITLE
Coalesce morph refreshes so an in-flight frame fetch isn't starved

### DIFF
--- a/src/core/drive/morphing_page_renderer.js
+++ b/src/core/drive/morphing_page_renderer.js
@@ -11,7 +11,7 @@ export class MorphingPageRenderer extends PageRenderer {
             shouldRefreshFrameWithMorphing(node, newNode) &&
               !closestFrameReloadableWithMorphing(node)
           ) {
-            node.reload()
+            node.delegate.refreshForMorph()
             return false
           }
           return true

--- a/src/core/frames/frame_controller.js
+++ b/src/core/frames/frame_controller.js
@@ -34,6 +34,9 @@ export class FrameController {
   #hasBeenLoaded = false
   #ignoredAttributes = new Set()
   #shouldMorphFrame = false
+  #currentRequestIsMorphRefresh = false
+  #pendingMorphRefresh = false
+  #performingMorphRefresh = false
   action = null
 
   constructor(element) {
@@ -70,15 +73,18 @@ export class FrameController {
       this.linkInterceptor.stop()
       this.formSubmitObserver.stop()
 
+      this.#pendingMorphRefresh = false
+
       if (!this.element.hasAttribute("recurse")) {
-        this.#currentFetchRequest?.cancel()
+        this.#cancelFetchRequest()
       }
     }
   }
 
   disabledChanged() {
     if (this.disabled) {
-      this.#currentFetchRequest?.cancel()
+      this.#pendingMorphRefresh = false
+      this.#cancelFetchRequest()
     } else if (this.loadingStyle == FrameLoadingStyle.eager) {
       this.#loadSourceURL()
     }
@@ -87,8 +93,12 @@ export class FrameController {
   sourceURLChanged() {
     if (this.#isIgnoringChangesTo("src")) return
 
+    // An explicit src change (external navigation, or an explicit reload()'s
+    // null-then-set toggle) supersedes any queued morph refresh.
+    this.#pendingMorphRefresh = false
+
     if (!this.sourceURL) {
-      this.#currentFetchRequest?.cancel()
+      this.#cancelFetchRequest()
     }
 
     if (this.element.isConnected) {
@@ -109,6 +119,35 @@ export class FrameController {
     this.element.src = null
     this.element.src = src
     return this.element.loaded
+  }
+
+  // Refresh the frame's contents as part of a page or ancestor-frame morph.
+  //
+  // Unlike reload(), this does not unconditionally abort and re-issue the
+  // frame's fetch. If a morph-driven refresh is already in flight, the new
+  // morph is coalesced into a single queued follow-up that runs once the
+  // in-flight request settles. Without this, a burst of morphs (e.g. repeated
+  // refresh broadcasts) would each abort the request the previous morph
+  // started, starving the fetch so its content never lands.
+  refreshForMorph() {
+    if (this.#currentRequestIsMorphRefresh) {
+      this.#pendingMorphRefresh = true
+    } else {
+      this.#performMorphRefresh()
+    }
+  }
+
+  // Reuse reload()'s exact refresh semantics (complete/src handling, lazy and
+  // disabled gating, morph-render selection), tagging the resulting request as
+  // a morph refresh so the scheduler can coalesce subsequent morphs against it.
+  #performMorphRefresh() {
+    this.#pendingMorphRefresh = false
+    this.#performingMorphRefresh = true
+    try {
+      this.sourceURLReloaded()
+    } finally {
+      this.#performingMorphRefresh = false
+    }
   }
 
   loadingStyleChanged() {
@@ -214,23 +253,29 @@ export class FrameController {
     markAsBusy(this.element)
   }
 
-  requestPreventedHandlingResponse(_request, _response) {
-    this.#resolveVisitPromise()
+  requestPreventedHandlingResponse(request, _response) {
+    this.#finishRequest(request)
   }
 
   async requestSucceededWithResponse(request, response) {
-    await this.loadResponse(response)
-    this.#resolveVisitPromise()
+    try {
+      await this.loadResponse(response)
+    } finally {
+      this.#finishRequest(request)
+    }
   }
 
   async requestFailedWithResponse(request, response) {
-    await this.loadResponse(response)
-    this.#resolveVisitPromise()
+    try {
+      await this.loadResponse(response)
+    } finally {
+      this.#finishRequest(request)
+    }
   }
 
   requestErrored(request, error) {
     console.error(error)
-    this.#resolveVisitPromise()
+    this.#finishRequest(request)
   }
 
   requestFinished(_request) {
@@ -348,14 +393,50 @@ export class FrameController {
     this.#currentFetchRequest?.cancel()
     this.#currentFetchRequest = request
 
+    // Consume the morph-refresh tag exactly once, before perform() dispatches
+    // turbo:before-fetch-request — a listener that synchronously starts another
+    // visit must not inherit this request's morph-refresh classification.
+    this.#currentRequestIsMorphRefresh = this.#performingMorphRefresh
+    this.#performingMorphRefresh = false
+
     return new Promise((resolve) => {
       this.#resolveVisitPromise = () => {
         this.#resolveVisitPromise = () => {}
         this.#currentFetchRequest = null
+        this.#currentRequestIsMorphRefresh = false
         resolve()
       }
       request.perform()
     })
+  }
+
+  // Settle the request that just completed. A stale settlement — from a request
+  // that was already superseded (e.g. an ordinary fetch whose render finished
+  // after a morph started its replacement) — is ignored so it can't resolve or
+  // clear the newer in-flight request's state. When the current morph refresh
+  // settles and a morph arrived while it was in flight, start a single coalesced
+  // follow-up. #performMorphRefresh reuses reload()'s gating, so a disconnected
+  // or disabled frame never issues a deferred fetch.
+  #finishRequest(request) {
+    if (request !== this.#currentFetchRequest) return
+
+    const wasMorphRefresh = this.#currentRequestIsMorphRefresh
+    this.#resolveVisitPromise()
+
+    if (wasMorphRefresh && this.#pendingMorphRefresh) {
+      this.#performMorphRefresh()
+    }
+  }
+
+  // Cancel the in-flight request without installing a replacement. An aborted
+  // request never reaches #finishRequest (perform() swallows the AbortError), so
+  // its identity and morph-refresh marker must be retired here — otherwise the
+  // marker would keep pointing at a dead request and every later morph would
+  // coalesce behind it forever.
+  #cancelFetchRequest() {
+    this.#currentFetchRequest?.cancel()
+    this.#currentFetchRequest = null
+    this.#currentRequestIsMorphRefresh = false
   }
 
   #navigateFrame(element, url, submitter) {

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -16,7 +16,7 @@ export class MorphingFrameRenderer extends FrameRenderer {
             shouldRefreshFrameWithMorphing(node, newNode) &&
               closestFrameReloadableWithMorphing(node) === currentElement
           ) {
-            node.reload()
+            node.delegate.refreshForMorph()
             return false
           }
           return true

--- a/src/tests/fixtures/frame_morph_in_flight.html
+++ b/src/tests/fixtures/frame_morph_in_flight.html
@@ -1,0 +1,3 @@
+<turbo-frame id="morph-frame">
+  <h2>Loaded in-flight frame</h2>
+</turbo-frame>

--- a/src/tests/fixtures/page_refresh_morph_in_flight_frame.html
+++ b/src/tests/fixtures/page_refresh_morph_in_flight_frame.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <meta name="turbo-refresh-method" content="morph">
+
+    <title>Turbo</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1 id="title">Page with an in-flight morph frame</h1>
+
+    <turbo-frame id="morph-frame" src="/src/tests/fixtures/frame_morph_in_flight.html" refresh="morph">
+      <h2>Frame awaiting its in-flight fetch</h2>
+    </turbo-frame>
+
+    <form id="form" action="/__turbo/refresh" method="post" class="redirect">
+      <input type="hidden" name="path" value="/src/tests/fixtures/page_refresh_morph_in_flight_frame.html">
+      <input type="hidden" name="sleep" value="20">
+      <input id="form-submit" type="submit" value="form[method=post]">
+    </form>
+  </body>
+</html>

--- a/src/tests/functional/page_refresh_tests.js
+++ b/src/tests/functional/page_refresh_tests.js
@@ -264,6 +264,90 @@ test("frames with refresh='morph' are preserved when missing from new content", 
   await expect(page.locator("#missing-frame"), "the frame is preserved").toBeAttached()
 })
 
+// Holds every fetch for the frame's src so it stays in flight while the page is
+// morphed, and counts how many requests Turbo issues. Each response is tagged
+// with the ordinal of the request that produced it, so the rendered text proves
+// exactly which request settled. Returns a `release` that serves the held
+// requests (and any later ones) so the frame can settle.
+async function holdFrameRequests(page, { url }) {
+  const state = { requestCount: 0 }
+  const held = []
+  let holding = true
+  const bodyFor = (n) => `<turbo-frame id="morph-frame"><h2>Loaded frame ${n}</h2></turbo-frame>`
+
+  await page.route(url, async (route) => {
+    const n = ++state.requestCount
+    if (holding) {
+      held.push({ route, n })
+    } else {
+      await route.fulfill({ contentType: "text/html", body: bodyFor(n) }).catch(() => {})
+    }
+  })
+
+  state.release = async () => {
+    holding = false
+    for (const { route, n } of held) {
+      await route.fulfill({ contentType: "text/html", body: bodyFor(n) }).catch(() => {})
+    }
+  }
+
+  return state
+}
+
+test("a refresh='morph' frame with a single in-flight morph refreshes its content", async ({ page }) => {
+  const frame = await holdFrameRequests(page, { url: "**/frame_morph_in_flight.html" })
+
+  await page.goto("/src/tests/fixtures/page_refresh_morph_in_flight_frame.html")
+  await expect.poll(() => frame.requestCount, "issues the initial frame fetch").toBe(1)
+
+  // A single morph while the initial fetch is in flight cancels and restarts it
+  // as a morph refresh — the existing reload contract for one morph is preserved.
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+  await expect.poll(() => frame.requestCount, "restarts the fetch as a morph refresh").toBe(2)
+
+  // With no further morphs, releasing the in-flight request settles the frame
+  // and no follow-up is scheduled: the count stays at 2.
+  await frame.release()
+  await expect(page.locator("#morph-frame")).toHaveText("Loaded frame 2")
+  await expect.poll(() => frame.requestCount).toBe(2)
+})
+
+test("a refresh='morph' frame with an in-flight fetch is not aborted and refetched by subsequent morphs", async ({ page }) => {
+  const frame = await holdFrameRequests(page, { url: "**/frame_morph_in_flight.html" })
+
+  await page.goto("/src/tests/fixtures/page_refresh_morph_in_flight_frame.html")
+  await expect.poll(() => frame.requestCount).toBe(1)
+
+  // First morph cancels the in-flight ordinary request and restarts it as a
+  // morph refresh (request #2).
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+  await expect.poll(() => frame.requestCount).toBe(2)
+
+  // Further morphs arriving while that morph refresh is still in flight must
+  // coalesce into a single queued follow-up instead of aborting and refetching.
+  // Before the fix each morph issued node.reload(), aborting the in-flight
+  // request and starting a new one, so the count would climb to 4.
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  expect(frame.requestCount, "subsequent morphs coalesce rather than abort-and-refetch").toBe(2)
+
+  // Releasing the in-flight request (#2) settles it, then exactly one coalesced
+  // follow-up (#3) runs and renders. The rendered "frame 3" text proves the
+  // queued request — not merely the original in-flight one (#2) — landed.
+  await frame.release()
+  await expect(page.locator("#morph-frame")).toHaveText("Loaded frame 3")
+  await expect.poll(() => frame.requestCount, "exactly one coalesced follow-up runs").toBe(3)
+
+  // The two coalesced morphs produce a single follow-up, not one request each.
+  await page.waitForTimeout(200)
+  expect(frame.requestCount, "no extra requests beyond the single follow-up").toBe(3)
+})
+
 test("it preserves the scroll position when the turbo-refresh-scroll meta tag is 'preserve'", async ({ page }) => {
   await page.goto("/src/tests/fixtures/page_refresh.html")
 


### PR DESCRIPTION
## The bug

On a page refresh with morphing, `MorphingPageRenderer.renderElement` (and its nested twin `MorphingFrameRenderer.renderElement`) calls `reload()` on every top-level `refresh="morph"` frame. `FrameController#sourceURLReloaded` reloads by toggling the attribute — `src = null; src = src` — which aborts the frame's in-flight fetch (`sourceURLChanged` → `#currentFetchRequest.cancel()` → `AbortController.abort`) and immediately re-issues it.

That's fine for a single morph. But under repeated refresh broadcasts — each broadcast drives another morph — every morph aborts the request the *previous* morph just started. A frame whose content is still loading is refetched faster than it can settle, so its content never lands. The `AbortError` is swallowed in `FetchRequest#perform`, so there's no error surfaced; the frame just sits empty while requests churn.

This is easy to hit with `broadcasts_refreshes` driving a page that contains a `refresh="morph"` frame backed by a slow endpoint (in our case a client-appended HEY Calendar frame).

## The fix

Replace the unconditional `reload()` at the two morph decision points with a new `FrameController#refreshForMorph()` that schedules against request identity instead of aborting unconditionally:

- **First morph while an ordinary fetch is in flight** still cancels and restarts once, preserving first-morph freshness and the existing single-morph behavior. `refreshForMorph` reuses `sourceURLReloaded()`, so `complete`/`src` handling, lazy and disabled gating, `#hasBeenLoaded`, and morph-render selection are byte-for-byte the same as before for the single-morph case.
- **A morph arriving while a morph refresh is already in flight** is coalesced into a single queued follow-up that runs *after* the in-flight request's render completes, rather than aborting it. A burst of N morphs produces one restart and at most one catch-up, not N aborts.

Supporting changes, all in `FrameController`:

- Settlement is **request-identity aware**: a stale settlement from a superseded request (an ordinary fetch whose async `loadResponse` finishes after a morph started its replacement) can no longer resolve or clear the newer in-flight request's state, or fire a spurious follow-up.
- A render throw (e.g. a missing frame) still **finalizes** the request in a `finally`, rather than wedging the queue with a marker that never clears.
- Cancellation without a replacement (disconnect, disable, external `src` clear) **retires** the morph-refresh marker, so later morphs don't coalesce behind a dead request.

## What's unchanged

The public `reload()` contract (there's a test that it re-fetches), `frame[refresh="morph"]` explicit-reload morphing, nested descendant `refresh="morph"` reloads via `MorphingFrameRenderer`, missing-frame preservation (the `!newFrame` clause), compatibility checks, and `data-turbo-permanent`. No public API is added.

## Tests

`page_refresh_tests.js` adds functional tests that hold the frame's fetch in flight (via `page.route`) and count the requests Turbo issues across a morph storm:

- A single morph during an in-flight fetch still cancels and restarts it (count 1 → 2).
- Three morphs during an in-flight fetch coalesce: the count stays at 2 during the storm, then exactly one follow-up runs after release (count → 3), and the frame content lands. The responses are version-tagged so the final DOM proves the *queued* follow-up rendered, not merely the first in-flight request.

On `main` (unconditional `reload()`) the storm test observes 4 requests (one abort-and-refetch per morph) and fails; with the fix it observes 2.

## Downstream impact

Application-level workarounds that mark in-flight frames `data-turbo-permanent` for the duration of a morph become unnecessary once this lands. (We run one in HEY, `preserveInFlightFramesDuringMorph`, precisely to stop this loop; it's removable with this fix.)

---

Opened as a draft for maintainer review. Companion RFC — a declarative opt-out for application-owned frames (`data-turbo-refresh-policy="manual"` + `turbo:before-frame-refresh`) — is in a separate PR; the two are independent and touch the same renderer lines.
