### PR TITLE
Add a declarative opt-out from morph refreshes for application-owned frames

### DIFF
--- a/src/core/drive/morphing_page_renderer.js
+++ b/src/core/drive/morphing_page_renderer.js
@@ -1,12 +1,20 @@
 import { PageRenderer } from "./page_renderer"
 import { dispatch } from "../../util"
-import { morphElements, shouldRefreshFrameWithMorphing, closestFrameReloadableWithMorphing } from "../morphing"
+import {
+  morphElements,
+  shouldRefreshFrameWithMorphing,
+  shouldPreserveFrameDuringMorphRefresh,
+  closestFrameReloadableWithMorphing
+} from "../morphing"
 
 export class MorphingPageRenderer extends PageRenderer {
   static renderElement(currentElement, newElement) {
     morphElements(currentElement, newElement, {
       callbacks: {
         beforeNodeMorphed: (node, newNode) => {
+          if (shouldPreserveFrameDuringMorphRefresh(node, newNode, "page-morph")) {
+            return false
+          }
           if (
             shouldRefreshFrameWithMorphing(node, newNode) &&
               !closestFrameReloadableWithMorphing(node)

--- a/src/core/frames/morphing_frame_renderer.js
+++ b/src/core/frames/morphing_frame_renderer.js
@@ -1,5 +1,10 @@
 import { FrameRenderer } from "./frame_renderer"
-import { morphChildren, shouldRefreshFrameWithMorphing, closestFrameReloadableWithMorphing } from "../morphing"
+import {
+  morphChildren,
+  shouldRefreshFrameWithMorphing,
+  shouldPreserveFrameDuringMorphRefresh,
+  closestFrameReloadableWithMorphing
+} from "../morphing"
 import { dispatch } from "../../util"
 
 export class MorphingFrameRenderer extends FrameRenderer {
@@ -12,6 +17,9 @@ export class MorphingFrameRenderer extends FrameRenderer {
     morphChildren(currentElement, newElement, {
       callbacks: {
         beforeNodeMorphed: (node, newNode) => {
+          if (shouldPreserveFrameDuringMorphRefresh(node, newNode, "frame-morph")) {
+            return false
+          }
           if (
             shouldRefreshFrameWithMorphing(node, newNode) &&
               closestFrameReloadableWithMorphing(node) === currentElement

--- a/src/core/index.js
+++ b/src/core/index.js
@@ -114,8 +114,8 @@ export function setFormMode(mode) {
 /**
  * Morph the state of the currentBody based on the attributes and contents of
  * the newBody. Morphing body elements may dispatch turbo:morph,
- * turbo:before-morph-element, turbo:before-morph-attribute, and
- * turbo:morph-element events.
+ * turbo:before-morph-element, turbo:before-morph-attribute, turbo:morph-element,
+ * and turbo:before-frame-refresh events.
  *
  * @param currentBody HTMLBodyElement destination of morphing changes
  * @param newBody HTMLBodyElement source of morphing changes
@@ -127,8 +127,8 @@ export function morphBodyElements(currentBody, newBody) {
 /**
  * Morph the child elements of the currentFrame based on the child elements of
  * the newFrame. Morphing turbo-frame elements may dispatch turbo:before-frame-morph,
- * turbo:before-morph-element, turbo:before-morph-attribute, and
- * turbo:morph-element events.
+ * turbo:before-morph-element, turbo:before-morph-attribute, turbo:morph-element,
+ * and turbo:before-frame-refresh events.
  *
  * @param currentFrame FrameElement destination of morphing children changes
  * @param newFrame FrameElement source of morphing children changes

--- a/src/core/morphing.js
+++ b/src/core/morphing.js
@@ -39,6 +39,30 @@ export function shouldRefreshFrameWithMorphing(currentFrame, newFrame) {
     !currentFrame.closest("[data-turbo-permanent]")
 }
 
+// Whether an application has opted a refresh="morph" frame out of being
+// refreshed by a page or ancestor-frame morph. Evaluated at the morph decision
+// point, before compatibility is checked, so it covers every path a morph would
+// otherwise take for the frame — matched-compatible (reload), matched-incompatible
+// (morph in place), and missing-from-response (preserve). A frame opts out
+// either declaratively with data-turbo-refresh-policy="manual" or imperatively
+// by canceling the turbo:before-frame-refresh event. The application then owns
+// the frame's refresh and teardown, exactly as with data-turbo-permanent, but
+// scoped to morph refreshes rather than all navigation. `source` is "page-morph"
+// or "frame-morph"; `newFrame` is the incoming counterpart, or undefined when the
+// frame is absent from the new content.
+export function shouldPreserveFrameDuringMorphRefresh(currentFrame, newFrame, source) {
+  if (!(currentFrame instanceof FrameElement) || !currentFrame.shouldReloadWithMorph) return false
+  if (currentFrame.refreshPolicy === "manual") return true
+
+  const event = dispatch("turbo:before-frame-refresh", {
+    target: currentFrame,
+    cancelable: true,
+    detail: { newFrame, source }
+  })
+
+  return event.defaultPrevented
+}
+
 function areFramesCompatibleForRefreshing(currentFrame, newFrame) {
   // newFrame cannot yet be an instance of FrameElement because custom
   // elements don't get initialized until they're attached to the DOM, so

--- a/src/elements/frame_element.js
+++ b/src/elements/frame_element.js
@@ -96,6 +96,16 @@ export class FrameElement extends HTMLElement {
   }
 
   /**
+   * Gets the frame's morph-refresh policy.
+   *
+   * When "manual", the frame is not refreshed by a page or ancestor-frame morph;
+   * the application owns its refresh and teardown.
+   */
+  get refreshPolicy() {
+    return this.getAttribute("data-turbo-refresh-policy")
+  }
+
+  /**
    * Determines if the element is loading
    */
   get loading() {

--- a/src/tests/fixtures/frame_auto.html
+++ b/src/tests/fixtures/frame_auto.html
@@ -1,0 +1,3 @@
+<turbo-frame id="auto-frame">
+  <h2>Fetched auto frame</h2>
+</turbo-frame>

--- a/src/tests/fixtures/frame_inner_auto.html
+++ b/src/tests/fixtures/frame_inner_auto.html
@@ -1,0 +1,3 @@
+<turbo-frame id="inner-auto">
+  <h2>Inner auto frame loaded</h2>
+</turbo-frame>

--- a/src/tests/fixtures/frame_inner_manual.html
+++ b/src/tests/fixtures/frame_inner_manual.html
@@ -1,0 +1,3 @@
+<turbo-frame id="inner-manual">
+  <h2>Inner manual frame loaded</h2>
+</turbo-frame>

--- a/src/tests/fixtures/frame_manual.html
+++ b/src/tests/fixtures/frame_manual.html
@@ -1,0 +1,3 @@
+<turbo-frame id="manual-frame">
+  <h2>Fetched manual frame</h2>
+</turbo-frame>

--- a/src/tests/fixtures/frame_manual_changed.html
+++ b/src/tests/fixtures/frame_manual_changed.html
@@ -1,0 +1,3 @@
+<turbo-frame id="manual-frame">
+  <h2>Fetched changed manual frame</h2>
+</turbo-frame>

--- a/src/tests/fixtures/frame_morph_manual_inner.html
+++ b/src/tests/fixtures/frame_morph_manual_inner.html
@@ -1,0 +1,17 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <title>Turbo</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1 id="title">Frame morph with a manual inner frame</h1>
+
+    <turbo-frame id="outer-morph" src="/src/tests/fixtures/frame_outer_morph.html" refresh="morph">
+      <h2>Outer frame</h2>
+    </turbo-frame>
+  </body>
+</html>

--- a/src/tests/fixtures/frame_outer_morph.html
+++ b/src/tests/fixtures/frame_outer_morph.html
@@ -1,0 +1,9 @@
+<turbo-frame id="outer-morph">
+  <h2>Outer frame loaded</h2>
+  <turbo-frame id="inner-manual" src="/src/tests/fixtures/frame_inner_manual.html" refresh="morph" data-turbo-refresh-policy="manual">
+    <h2>Inner manual frame</h2>
+  </turbo-frame>
+  <turbo-frame id="inner-auto" src="/src/tests/fixtures/frame_inner_auto.html" refresh="morph">
+    <h2>Inner auto frame</h2>
+  </turbo-frame>
+</turbo-frame>

--- a/src/tests/fixtures/page_refresh_manual_frame.html
+++ b/src/tests/fixtures/page_refresh_manual_frame.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html id="html">
+  <head>
+    <meta charset="utf-8">
+    <meta name="turbo-refresh-method" content="morph">
+
+    <title>Turbo</title>
+    <link rel="icon" href="data:;base64,iVBORw0KGgo=">
+    <script src="/dist/turbo.es2017-umd.js" data-turbo-track="reload"></script>
+    <script src="/src/tests/fixtures/test.js"></script>
+  </head>
+  <body>
+    <h1 id="title">Page with manual and automatic morph frames</h1>
+
+    <turbo-frame id="manual-frame" src="/src/tests/fixtures/frame_manual.html" refresh="morph" data-turbo-refresh-policy="manual">
+      <h2>Manual frame</h2>
+    </turbo-frame>
+
+    <turbo-frame id="auto-frame" src="/src/tests/fixtures/frame_auto.html" refresh="morph">
+      <h2>Automatic frame</h2>
+    </turbo-frame>
+
+    <form id="form" action="/__turbo/refresh" method="post" class="redirect">
+      <input type="hidden" name="path" value="/src/tests/fixtures/page_refresh_manual_frame.html">
+      <input type="hidden" name="sleep" value="20">
+      <input id="form-submit" type="submit" value="form[method=post]">
+    </form>
+  </body>
+</html>

--- a/src/tests/fixtures/test.js
+++ b/src/tests/fixtures/test.js
@@ -85,6 +85,7 @@
   "turbo:frame-render",
   "turbo:frame-missing",
   "turbo:before-frame-morph",
+  "turbo:before-frame-refresh",
   "turbo:morph",
   "turbo:before-morph-element",
   "turbo:morph-element",

--- a/src/tests/functional/frame_refresh_policy_tests.js
+++ b/src/tests/functional/frame_refresh_policy_tests.js
@@ -1,0 +1,148 @@
+import { test, expect } from "@playwright/test"
+import { nextEventNamed, nextEventOnTarget } from "../helpers/page"
+
+// Records every turbo:before-frame-refresh into a page-global array, so assertions
+// about which frames did (and did not) dispatch it don't depend on the shared
+// event-log cursor that nextEvent* helpers consume.
+function collectFrameRefreshEvents(page) {
+  return page.evaluate(() => {
+    window.frameRefreshEvents = []
+    addEventListener("turbo:before-frame-refresh", ({ target, detail }) => {
+      window.frameRefreshEvents.push({ id: target.id, source: detail.source })
+    })
+  })
+}
+
+function frameRefreshEvents(page) {
+  return page.evaluate(() => window.frameRefreshEvents)
+}
+
+test("a refresh='morph' frame is refreshed by a page morph by default", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_manual_frame.html")
+  await expect(page.locator("#auto-frame")).toHaveText("Fetched auto frame")
+
+  await page.locator("#auto-frame").evaluate((frame) => (frame.textContent = "Automatic sentinel"))
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  // The default (no policy) frame is re-fetched, replacing the sentinel.
+  await expect(page.locator("#auto-frame")).toHaveText("Fetched auto frame")
+})
+
+test("a data-turbo-refresh-policy='manual' frame is not refreshed by a page morph", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_manual_frame.html")
+  await expect(page.locator("#manual-frame")).toHaveText("Fetched manual frame")
+
+  await collectFrameRefreshEvents(page)
+  await page.locator("#manual-frame").evaluate((frame) => (frame.textContent = "Manual sentinel"))
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  // The manual frame is preserved: no refetch, no in-place morph, sentinel kept.
+  await expect(page.locator("#manual-frame")).toHaveText("Manual sentinel")
+
+  // A declaratively opted-out frame is preserved without even dispatching the
+  // cancelable event, while the default frame is refreshed as usual.
+  const events = await frameRefreshEvents(page)
+  expect(events.some((event) => event.id === "manual-frame")).toBe(false)
+  expect(events.some((event) => event.id === "auto-frame" && event.source === "page-morph")).toBe(true)
+})
+
+test("turbo:before-frame-refresh fires for a refreshed frame with the morph source", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_manual_frame.html")
+  await expect(page.locator("#auto-frame")).toHaveText("Fetched auto frame")
+
+  await page.click("#form-submit")
+
+  const detail = await nextEventOnTarget(page, "auto-frame", "turbo:before-frame-refresh")
+  expect(detail.source).toEqual("page-morph")
+})
+
+test("canceling turbo:before-frame-refresh opts a frame out of the morph refresh", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_manual_frame.html")
+  await expect(page.locator("#auto-frame")).toHaveText("Fetched auto frame")
+
+  await page.locator("#auto-frame").evaluate((frame) => {
+    frame.addEventListener("turbo:before-frame-refresh", (event) => event.preventDefault())
+    frame.textContent = "Prevented sentinel"
+  })
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  await expect(page.locator("#auto-frame")).toHaveText("Prevented sentinel")
+})
+
+test("a data-turbo-refresh-policy='manual' frame missing from new content is preserved without refetching", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_manual_frame.html")
+  await expect(page.locator("#manual-frame")).toHaveText("Fetched manual frame")
+
+  await page.evaluate(() => {
+    const frame = document.getElementById("manual-frame")
+    frame.textContent = "Manual sentinel"
+    frame.id = "manual-missing" // absent from the server's new content
+  })
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  await expect(page.locator("#manual-missing"), "the frame is preserved").toBeAttached()
+  await expect(page.locator("#manual-missing")).toHaveText("Manual sentinel")
+})
+
+test("a data-turbo-refresh-policy='manual' frame is preserved even when its src is incompatible with the new content", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_manual_frame.html")
+  await expect(page.locator("#manual-frame")).toHaveText("Fetched manual frame")
+
+  // Change the live frame's src so it no longer matches the src in the server's
+  // new content: an incompatible frame, which shouldRefreshFrameWithMorphing
+  // rejects and would otherwise be morphed in place from the page response. The
+  // opt-out is evaluated before that compatibility check, so the frame is still
+  // preserved.
+  await page.locator("#manual-frame").evaluate((frame) => frame.setAttribute("src", "/src/tests/fixtures/frame_manual_changed.html"))
+  await expect(page.locator("#manual-frame")).toHaveText("Fetched changed manual frame")
+  await page.locator("#manual-frame").evaluate((frame) => (frame.textContent = "Manual sentinel"))
+
+  await page.click("#form-submit")
+  await nextEventNamed(page, "turbo:render", { renderMethod: "morph" })
+
+  await expect(page.locator("#manual-frame")).toHaveText("Manual sentinel")
+})
+
+test("data-turbo-refresh-policy='manual' does not affect an explicit reload()", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/page_refresh_manual_frame.html")
+  await expect(page.locator("#manual-frame")).toHaveText("Fetched manual frame")
+
+  await collectFrameRefreshEvents(page)
+  await page.locator("#manual-frame").evaluate((frame) => (frame.textContent = "Manual sentinel"))
+  await page.evaluate(() => document.getElementById("manual-frame").reload())
+
+  // The policy scopes only morph refreshes; explicit reload() still re-fetches
+  // and never dispatches the morph-refresh event.
+  expect(await nextEventOnTarget(page, "manual-frame", "turbo:before-frame-morph")).toBeTruthy()
+  await expect(page.locator("#manual-frame")).toHaveText("Fetched manual frame")
+  expect(await frameRefreshEvents(page)).toEqual([])
+})
+
+test("during an ancestor frame morph, a manual inner frame is preserved and an automatic one is refreshed", async ({ page }) => {
+  await page.goto("/src/tests/fixtures/frame_morph_manual_inner.html")
+  await expect(page.locator("#inner-manual")).toHaveText("Inner manual frame loaded")
+  await expect(page.locator("#inner-auto")).toHaveText("Inner auto frame loaded")
+
+  await collectFrameRefreshEvents(page)
+  await page.locator("#inner-manual").evaluate((frame) => (frame.textContent = "Inner manual sentinel"))
+  await page.locator("#inner-auto").evaluate((frame) => (frame.textContent = "Inner auto sentinel"))
+
+  // Reloading the outer refresh='morph' frame morphs its response, which reloads
+  // the inner refresh='morph' frames via MorphingFrameRenderer.
+  await page.evaluate(() => document.getElementById("outer-morph").reload())
+  await nextEventOnTarget(page, "outer-morph", "turbo:before-frame-morph")
+
+  // The manual inner frame is preserved; the automatic one is refreshed.
+  await expect(page.locator("#inner-manual"), "manual inner frame preserved").toHaveText("Inner manual sentinel")
+  await expect(page.locator("#inner-auto")).toHaveText("Inner auto frame loaded")
+
+  const events = await frameRefreshEvents(page)
+  expect(events.some((event) => event.id === "inner-manual")).toBe(false)
+  expect(events.some((event) => event.id === "inner-auto" && event.source === "frame-morph")).toBe(true)
+})


### PR DESCRIPTION
## Motivation

A page or ancestor-frame morph refreshes every top-level `refresh="morph"` frame by reloading it from the server. But some frames are owned by the *application*, not the server — client-appended regions, pagination sentinels, media sessions, in-page editors — and must not be auto-refreshed no matter what the new content contains.

Today the only tool for that is `data-turbo-permanent`, which is broader than needed: it opts an element out of *all* navigation, not just morph refreshes, and overloads "permanent" for what is really "the app owns this frame's refresh lifecycle."

## What this adds

A morph-refresh-scoped opt-out, available two ways:

- **Declaratively:** `data-turbo-refresh-policy="manual"` on the frame, exposed as the read-only `FrameElement#refreshPolicy`.
- **Imperatively:** cancel a new cancelable `turbo:before-frame-refresh` event. Its `detail` is `{ newFrame, source }`, where `source` is `"page-morph"` or `"frame-morph"` and `newFrame` is the incoming counterpart (or `undefined` when the frame is absent from the new content).

An opted-out frame is preserved: its subtree is skipped and it is not removed. The application then owns the frame's refresh and teardown — the same contract as `data-turbo-permanent`, but scoped to morph refreshes rather than all navigation.

## Why the check runs before the compatibility test

`shouldPreserveFrameDuringMorphRefresh` is evaluated at the morph decision point in both morph renderers, *before* `shouldRefreshFrameWithMorphing`. That placement is deliberate: it covers every path a morph would otherwise take for the frame —

- **matched-compatible** — would reload,
- **matched-incompatible / changed `src`** — `shouldRefreshFrameWithMorphing` returns false here, so without the opt-out the frame is morphed in place from the page response,
- **missing from the response** — would reload-to-preserve via the `!newFrame` clause.

If the check lived inside `shouldRefreshFrameWithMorphing` it would miss the incompatible path entirely.

## Backward compatibility

Additive. With no opt-out, DOM and network behavior are unchanged; the only difference is a new cancelable event dispatched for `refresh="morph"` frames during a morph. Explicit `reload()` neither consults the policy nor dispatches the event — the policy is morph-scoped only.

## Known limitation

Missing-frame preservation relies on the same idiomorph `beforeNodeRemoved` callback as the existing `refresh="morph"` missing-frame preservation, and shares its limitation: a frame idiomorph relocates because one of its descendant ids is reused elsewhere in the new content is not preserved (the removal callback never fires). This is pre-existing behavior of the missing-frame path, not new here; flagging it so the "application owns teardown" contract is understood precisely.

The same callback shape bounds the nested case. Idiomorph calls `beforeNodeRemoved` once, for the unmatched ancestor, and then removes that subtree wholesale, so an opted-out frame whose *container* is absent from the new content — and whose own id is absent too — is removed with it, and no `turbo:before-frame-refresh` is dispatched for it. (If the frame's id is present elsewhere in the new content, idiomorph relocates it by id and the opt-out is honored there; the relocation reconnects the frame, which reloads its `src` — pre-existing frame behavior.) On `main`, a `data-turbo-permanent` element and a `refresh="morph"` frame inside such a container are removed the same way, so the opt-out follows the contract every existing morph hook has rather than keeping a stale container alive to preserve one descendant.

## Tests

`frame_refresh_policy_tests.js` covers, for both `page-morph` and `frame-morph` sources: default frames still refresh; `manual` frames are preserved (matched-compatible, matched-incompatible/changed-src, and missing); `turbo:before-frame-refresh` fires with the right `source` and can be `preventDefault`'d to opt out; a manual frame does not dispatch the event at all; and explicit `reload()` is unaffected. Event assertions use a page-global collector rather than the shared event-log cursor so "this frame emitted no event" is reliable. Neutralizing the helper turns the opt-out/event tests red while the baseline refresh tests stay green.

---

Opened as a draft / RFC for maintainer review — it adds public surface (an attribute and an event), so naming and shape are open to direction. Companion bug-fix PR (morph-scoped queued invalidation, no public API) is separate; the two are independent and touch the same renderer lines. Together they let an application drop temporary `data-turbo-permanent` choreography around morph refreshes: the bug fix handles the universal in-flight-fetch loop with zero annotation, and this handles frames the app explicitly owns.

