### PR TITLE
Fix flaky SVG link navigation tests

### DIFF
--- a/src/tests/fixtures/navigation.html
+++ b/src/tests/fixtures/navigation.html
@@ -46,9 +46,9 @@
       <p><a id="empty-target-link" href="/src/tests/fixtures/one.html" target="">Empty target attribute link</a></p>
       <p><a id="bare-target-link" href="/src/tests/fixtures/one.html" target>Bare target attribute link</a></p>
       <p><a id="same-origin-download-link" href="/intentionally_missing_fake_download.html" download="x.html">Same-origin download link</a></p>
-      <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html">Same-origin link inside SVG element</a></text></svg>
-      <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="cross-origin-link-inside-svg-element" href="about:blank">Cross-origin link inside SVG element</a></text></svg>
-      <svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="same-origin-anchored-svg-link" href="#main">SVG link with hash-only href</a></text></svg>
+      <svg width="600" height="100" style="display: block"><a id="same-origin-link-inside-svg-element" href="/src/tests/fixtures/one.html"><rect width="600" height="100" fill="#e0e0e0"/><text x="10" y="55" fill="black">Same-origin link inside SVG element</text></a></svg>
+      <svg width="600" height="100" style="display: block"><a id="cross-origin-link-inside-svg-element" href="about:blank"><rect width="600" height="100" fill="#e0e0e0"/><text x="10" y="55" fill="black">Cross-origin link inside SVG element</text></a></svg>
+      <svg width="600" height="100" style="display: block"><a id="same-origin-anchored-svg-link" href="#main"><rect width="600" height="100" fill="#e0e0e0"/><text x="10" y="55" fill="black">SVG link with hash-only href</text></a></svg>
       <p><a id="same-origin-get-link-form" href="/src/tests/fixtures/navigation.html?a=one&b=two" data-turbo-method="get">Same-origin data-turbo-method=get link</a></p>
       <p><a id="same-origin-replace-post-link" href="/__turbo/redirect" data-turbo-method="post" data-turbo-action="replace">Same-origin data-turbo-action=replace link with post method</a></p>
       <p><a id="link-to-disabled-frame" href="/src/tests/fixtures/frames/hello.html" data-turbo-frame="hello">Disabled turbo-frame</a></p>

--- a/src/tests/functional/navigation_tests.js
+++ b/src/tests/functional/navigation_tests.js
@@ -298,7 +298,8 @@ test("following a same-origin link inside an SVG element", async ({ page }) => {
   await page.keyboard.press("Enter")
 
   await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
-  expect(await visitAction(page)).toEqual("load")
+  // A same-origin SVG link is visitable, so Turbo drives it like any other link.
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("following a cross-origin link inside an SVG element", async ({ page }) => {
@@ -314,7 +315,8 @@ test("following a same-origin SVG link", async ({ page }) => {
   await page.click("#same-origin-link-inside-svg-element")
 
   await expect(page).toHaveURL(withPathname("/src/tests/fixtures/one.html"))
-  expect(await visitAction(page)).toEqual("load")
+  // A same-origin SVG link is visitable, so Turbo drives it like any other link.
+  expect(await visitAction(page)).toEqual("advance")
 })
 
 test("following a same-origin SVG anchored link", async ({ page }) => {


### PR DESCRIPTION
## The flake

The three SVG link tests in `navigation_tests.js` — `following a same-origin link inside an SVG element`, `following a same-origin SVG link`, and `following a same-origin SVG anchored link` — fail intermittently (~50% on CI, including on `main`). There are two independent causes.

### 1. Unreliable click target (the actionability flake)

Each link was rendered as a bare `<text>` inside an `<svg>` with a negative-origin `viewBox="-300 -50 600 100"`:

```html
<svg width="600" height="100" viewbox="-300 -50 600 100"><text><a id="…" href="…">…</a></text></svg>
```

The only pointer-events hit area was the thin painted glyph geometry. Playwright clicks the **center** of the element's box; whether that point landed on a glyph varied with font rendering across runs/platforms, producing the `element is outside of the viewport` and `<svg> … intercepts pointer events` failures.

**Fix:** give each link a solid, deterministic hit area — a `<rect>` filling the `<svg>` with the label as a sibling `<text>`, both inside the `<a>`. This is the pattern already used in `hover_to_prefetch.html`. Clicks now land on the link every time.

### 2. Stale assertion (why "load" only passed by accident)

A same-origin SVG link is a visitable link, so Turbo drives it as an **`advance`** visit, exactly like any other same-origin link — `findLinkFromClickTarget` matches `a[href], a[xlink:href]` and returns it. These tests asserted `"advance"` from their introduction (`fe41ac3`, 2016) until **`ffc3ea3`** flipped them to `"load"` to green a suite that had been broken by the `SVGAElement.href` regression (`getLinkHrefString` calling `String#startsWith` on an `SVGAnimatedString`, which threw). That regression was later fixed in #1510 by using `getAttribute`. With the crash gone, Turbo drives the link again, so `"advance"` is correct once more.

`"load"` only ever passed when an off-glyph click **missed** the link and fell through to a native navigation — i.e. the same actionability nondeterminism above. Once the click reliably lands on the link, the result is deterministically `advance`.

The hash SVG link (`#main`) and the cross-origin SVG link (`about:blank`) are correctly **not** driven by Turbo and keep their `"load"` expectations.

## Evidence

- **Before:** the three tests failed **30/30** locally (`--repeat-each=30`). The `same-origin link inside an SVG element` case (focus + Enter, no click actionability involved) failed deterministically with `Expected "load", Received "advance"`, confirming cause #2 independently of the click flake.
- **After:** the three tests pass **30/30 on chromium and 30/30 on firefox**; the full `navigation_tests.js` suite is green.

## Diff

Test-only: `src/tests/fixtures/navigation.html` (deterministic hit area) and `src/tests/functional/navigation_tests.js` (restore the `advance` expectation for the two same-origin cases). No `src/` behavior change.
